### PR TITLE
refactor(backend): store/websocket/server efficiency pass

### DIFF
--- a/internal/server/handler_common.go
+++ b/internal/server/handler_common.go
@@ -11,10 +11,7 @@ import (
 
 var tracer = otel.Tracer("otelop.server")
 
-const (
-	defaultLimit = 50
-	maxLimit     = 10000
-)
+const defaultLimit = 50
 
 // pageFetcher returns a newest-first slice of items for the given offset/limit
 // along with the total buffer size. Implementations are expected to take locks
@@ -45,10 +42,11 @@ func parsePagination(r *http.Request) (limit, offset int) {
 	q := r.URL.Query()
 	if v := q.Get("limit"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			// No upper clamp: RingBuffer.Page allocates at most the actual buffer
+			// count, so the store's capacity is the real bound. Keeping a hardcoded
+			// max would silently truncate pages when users configure a large
+			// --trace-cap / --metric-cap / --log-cap.
 			limit = n
-			if limit > maxLimit {
-				limit = maxLimit
-			}
 		}
 	}
 	if v := q.Get("offset"); v != "" {

--- a/internal/server/handler_common.go
+++ b/internal/server/handler_common.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+var tracer = otel.Tracer("otelop.server")
+
+const (
+	defaultLimit = 50
+	maxLimit     = 10000
+)
+
+// pageFetcher returns a newest-first slice of items for the given offset/limit
+// along with the total buffer size. Implementations are expected to take locks
+// internally and return already-paginated data to keep the lock scope tight.
+type pageFetcher[T any] func(offset, limit int) ([]T, int)
+
+// writePaginated runs the fetcher and writes the standard JSON envelope
+// ({data, total, limit, offset}) used by all signal list endpoints.
+func writePaginated[T any](w http.ResponseWriter, r *http.Request, spanName string, fetch pageFetcher[T]) {
+	limit, offset := parsePagination(r)
+
+	_, span := tracer.Start(r.Context(), spanName)
+	items, total := fetch(offset, limit)
+	span.SetAttributes(attribute.Int("total", total), attribute.Int("returned", len(items)))
+	span.End()
+
+	writeJSON(w, map[string]any{
+		"data":   items,
+		"total":  total,
+		"limit":  limit,
+		"offset": offset,
+	})
+}
+
+func parsePagination(r *http.Request) (limit, offset int) {
+	limit = defaultLimit
+	offset = 0
+	q := r.URL.Query()
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+			if limit > maxLimit {
+				limit = maxLimit
+			}
+		}
+	}
+	if v := q.Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	return
+}
+
+func writeJSON(w http.ResponseWriter, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/internal/server/handler_common_test.go
+++ b/internal/server/handler_common_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParsePagination(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantLimit  int
+		wantOffset int
+	}{
+		{"defaults when empty", "", defaultLimit, 0},
+		{"limit only", "limit=25", 25, 0},
+		{"offset only", "offset=10", defaultLimit, 10},
+		{"both", "limit=100&offset=50", 100, 50},
+		{"invalid limit falls back", "limit=abc", defaultLimit, 0},
+		{"negative limit ignored", "limit=-5", defaultLimit, 0},
+		{"zero limit ignored", "limit=0", defaultLimit, 0},
+		{"limit clamped to max", "limit=99999", maxLimit, 0},
+		{"invalid offset ignored", "offset=foo", defaultLimit, 0},
+		{"negative offset ignored", "offset=-1", defaultLimit, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/?"+tt.query, nil)
+			limit, offset := parsePagination(r)
+			if limit != tt.wantLimit {
+				t.Errorf("limit = %d, want %d", limit, tt.wantLimit)
+			}
+			if offset != tt.wantOffset {
+				t.Errorf("offset = %d, want %d", offset, tt.wantOffset)
+			}
+		})
+	}
+}
+
+func TestWritePaginated_EnvelopeShape(t *testing.T) {
+	type item struct {
+		ID int `json:"id"`
+	}
+
+	var gotOffset, gotLimit int
+	fetch := func(offset, limit int) ([]*item, int) {
+		gotOffset = offset
+		gotLimit = limit
+		return []*item{{ID: 1}, {ID: 2}}, 42
+	}
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/?limit=2&offset=5", nil)
+	w := httptest.NewRecorder()
+
+	writePaginated(w, r, "test.span", fetch)
+
+	if gotOffset != 5 {
+		t.Errorf("fetch called with offset %d, want 5", gotOffset)
+	}
+	if gotLimit != 2 {
+		t.Errorf("fetch called with limit %d, want 2", gotLimit)
+	}
+
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("content-type = %q, want json", ct)
+	}
+
+	var envelope struct {
+		Data   []item `json:"data"`
+		Total  int    `json:"total"`
+		Limit  int    `json:"limit"`
+		Offset int    `json:"offset"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if envelope.Total != 42 {
+		t.Errorf("total = %d, want 42", envelope.Total)
+	}
+	if envelope.Limit != 2 || envelope.Offset != 5 {
+		t.Errorf("limit/offset = %d/%d, want 2/5", envelope.Limit, envelope.Offset)
+	}
+	if len(envelope.Data) != 2 || envelope.Data[0].ID != 1 {
+		t.Errorf("data = %+v, want 2 items starting with id 1", envelope.Data)
+	}
+}

--- a/internal/server/handler_common_test.go
+++ b/internal/server/handler_common_test.go
@@ -22,7 +22,7 @@ func TestParsePagination(t *testing.T) {
 		{"invalid limit falls back", "limit=abc", defaultLimit, 0},
 		{"negative limit ignored", "limit=-5", defaultLimit, 0},
 		{"zero limit ignored", "limit=0", defaultLimit, 0},
-		{"limit clamped to max", "limit=99999", maxLimit, 0},
+		{"large limit passed through", "limit=99999", 99999, 0},
 		{"invalid offset ignored", "offset=foo", defaultLimit, 0},
 		{"negative offset ignored", "offset=-1", defaultLimit, 0},
 	}

--- a/internal/server/handler_logs.go
+++ b/internal/server/handler_logs.go
@@ -3,30 +3,11 @@ package server
 import (
 	"net/http"
 
-	"go.opentelemetry.io/otel/attribute"
+	"github.com/mashiro/otelop/internal/store"
 )
 
 func (s *Server) handleGetLogs(w http.ResponseWriter, r *http.Request) {
-	limit, offset := parsePagination(r)
-
-	_, span := tracer.Start(r.Context(), "store.GetLogs")
-	logs := s.store.GetLogs()
-	total := len(logs)
-	span.SetAttributes(attribute.Int("total", total))
-	span.End()
-	if offset > total {
-		offset = total
-	}
-	end := offset + limit
-	if end > total {
-		end = total
-	}
-	page := logs[offset:end]
-
-	writeJSON(w, map[string]any{
-		"data":   page,
-		"total":  total,
-		"limit":  limit,
-		"offset": offset,
+	writePaginated(w, r, "store.GetLogsPage", func(offset, limit int) ([]*store.LogData, int) {
+		return s.store.GetLogsPage(offset, limit)
 	})
 }

--- a/internal/server/handler_metrics.go
+++ b/internal/server/handler_metrics.go
@@ -3,30 +3,11 @@ package server
 import (
 	"net/http"
 
-	"go.opentelemetry.io/otel/attribute"
+	"github.com/mashiro/otelop/internal/store"
 )
 
 func (s *Server) handleGetMetrics(w http.ResponseWriter, r *http.Request) {
-	limit, offset := parsePagination(r)
-
-	_, span := tracer.Start(r.Context(), "store.GetMetrics")
-	metrics := s.store.GetMetrics()
-	total := len(metrics)
-	span.SetAttributes(attribute.Int("total", total))
-	span.End()
-	if offset > total {
-		offset = total
-	}
-	end := offset + limit
-	if end > total {
-		end = total
-	}
-	page := metrics[offset:end]
-
-	writeJSON(w, map[string]any{
-		"data":   page,
-		"total":  total,
-		"limit":  limit,
-		"offset": offset,
+	writePaginated(w, r, "store.GetMetricsPage", func(offset, limit int) ([]*store.MetricData, int) {
+		return s.store.GetMetricsPage(offset, limit)
 	})
 }

--- a/internal/server/handler_traces.go
+++ b/internal/server/handler_traces.go
@@ -1,38 +1,16 @@
 package server
 
 import (
-	"encoding/json"
 	"net/http"
-	"strconv"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/mashiro/otelop/internal/store"
 )
 
-var tracer = otel.Tracer("otelop.server")
-
 func (s *Server) handleGetTraces(w http.ResponseWriter, r *http.Request) {
-	limit, offset := parsePagination(r)
-
-	_, span := tracer.Start(r.Context(), "store.GetTraces")
-	traces := s.store.GetTraces()
-	total := len(traces)
-	span.SetAttributes(attribute.Int("total", total))
-	span.End()
-	if offset > total {
-		offset = total
-	}
-	end := offset + limit
-	if end > total {
-		end = total
-	}
-	page := traces[offset:end]
-
-	writeJSON(w, map[string]any{
-		"data":   page,
-		"total":  total,
-		"limit":  limit,
-		"offset": offset,
+	writePaginated(w, r, "store.GetTracesPage", func(offset, limit int) ([]*store.TraceData, int) {
+		return s.store.GetTracesPage(offset, limit)
 	})
 }
 
@@ -47,28 +25,4 @@ func (s *Server) handleGetTraceByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, trace)
-}
-
-func parsePagination(r *http.Request) (limit, offset int) {
-	limit = 50
-	offset = 0
-
-	if v := r.URL.Query().Get("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			limit = n
-		}
-	}
-	if v := r.URL.Query().Get("offset"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-			offset = n
-		}
-	}
-	return
-}
-
-func writeJSON(w http.ResponseWriter, data any) {
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(data); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
 }

--- a/internal/store/ringbuffer_test.go
+++ b/internal/store/ringbuffer_test.go
@@ -1,0 +1,129 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRingBuffer_Add_ReturnsEvicted(t *testing.T) {
+	rb := NewRingBuffer[string](2)
+
+	_, _, evicted := rb.Add("a")
+	if evicted {
+		t.Errorf("initial Add should not evict")
+	}
+	_, _, evicted = rb.Add("b")
+	if evicted {
+		t.Errorf("second Add should not evict")
+	}
+	_, ev, wasEv := rb.Add("c") // should evict "a"
+	if !wasEv {
+		t.Fatal("third Add should evict")
+	}
+	if ev != "a" {
+		t.Errorf("evicted = %q, want a", ev)
+	}
+
+	_, ev, wasEv = rb.Add("d") // should evict "b"
+	if !wasEv || ev != "b" {
+		t.Errorf("fourth Add: evicted=%q wasEv=%v, want b/true", ev, wasEv)
+	}
+
+	items := rb.Items()
+	if !reflect.DeepEqual(items, []string{"c", "d"}) {
+		t.Errorf("items = %v, want [c d]", items)
+	}
+}
+
+func TestRingBuffer_Page(t *testing.T) {
+	rb := NewRingBuffer[int](5)
+	for i := 1; i <= 5; i++ {
+		rb.Add(i)
+	}
+
+	tests := []struct {
+		name      string
+		offset    int
+		limit     int
+		wantItems []int
+		wantTotal int
+	}{
+		{"all newest first", 0, 0, []int{5, 4, 3, 2, 1}, 5},
+		{"limit 2 from newest", 0, 2, []int{5, 4}, 5},
+		{"offset 2 limit 2", 2, 2, []int{3, 2}, 5},
+		{"offset past end", 10, 5, nil, 5},
+		{"offset 4 limit 10", 4, 10, []int{1}, 5},
+		{"negative offset treated as 0", -5, 1, []int{5}, 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			items, total := rb.Page(tt.offset, tt.limit)
+			if !reflect.DeepEqual(items, tt.wantItems) {
+				t.Errorf("items = %v, want %v", items, tt.wantItems)
+			}
+			if total != tt.wantTotal {
+				t.Errorf("total = %d, want %d", total, tt.wantTotal)
+			}
+		})
+	}
+}
+
+func TestRingBuffer_Page_AfterWrap(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+	// Insert 1..5, wrapping so buffer holds [3, 4, 5] (oldest first).
+	for i := 1; i <= 5; i++ {
+		rb.Add(i)
+	}
+
+	items, total := rb.Page(0, 0)
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	// newest-first = [5, 4, 3]
+	if !reflect.DeepEqual(items, []int{5, 4, 3}) {
+		t.Errorf("items = %v, want [5 4 3]", items)
+	}
+
+	items, _ = rb.Page(1, 1)
+	if !reflect.DeepEqual(items, []int{4}) {
+		t.Errorf("page(1,1) = %v, want [4]", items)
+	}
+}
+
+func TestRingBuffer_Page_Empty(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+	items, total := rb.Page(0, 10)
+	if total != 0 {
+		t.Errorf("total = %d, want 0", total)
+	}
+	if items != nil {
+		t.Errorf("items = %v, want nil", items)
+	}
+}
+
+func TestStore_TraceIndex_SurvivesEviction(t *testing.T) {
+	s := NewStore(2, 2, 2, 100, nil)
+
+	// Add 3 traces into a cap=2 buffer. The first should be evicted.
+	for i := 1; i <= 3; i++ {
+		s.mu.Lock()
+		trace := &TraceData{TraceID: string(rune('a' + i - 1))}
+		idx, evicted, wasEv := s.traces.Add(trace)
+		if wasEv && evicted != nil {
+			delete(s.traceIndex, evicted.TraceID)
+		}
+		s.traceIndex[trace.TraceID] = idx
+		s.mu.Unlock()
+	}
+
+	if _, ok := s.traceIndex["a"]; ok {
+		t.Error("evicted trace 'a' should be removed from index")
+	}
+	if _, ok := s.traceIndex["b"]; !ok {
+		t.Error("trace 'b' should remain in index")
+	}
+	if _, ok := s.traceIndex["c"]; !ok {
+		t.Error("trace 'c' should be in index")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,10 +17,12 @@ const (
 	SignalLogs    SignalType = "logs"
 )
 
-// OnAddFunc is called when new data is added to the store.
+// OnAddFunc is called when new data is added to the store. It runs outside the
+// store's write lock so implementations may take their time (e.g. serialize
+// and broadcast over a WebSocket).
 type OnAddFunc func(signalType SignalType, data any)
 
-// Store holds telemetry data in bounded ring buffers.
+// Store holds telemetry data in bounded ring buffers keyed for O(1) upsert.
 type Store struct {
 	mu            sync.RWMutex
 	traces        *RingBuffer[*TraceData]
@@ -41,53 +43,10 @@ func NewStore(traceCap, metricCap, logCap, maxDataPoints int, onAdd OnAddFunc) *
 		traces:        NewRingBuffer[*TraceData](traceCap),
 		metrics:       NewRingBuffer[*MetricData](metricCap),
 		logs:          NewRingBuffer[*LogData](logCap),
-		traceIndex:    make(map[string]int),
-		metricIndex:   make(map[string]int),
+		traceIndex:    make(map[string]int, traceCap),
+		metricIndex:   make(map[string]int, metricCap),
 		maxDataPoints: maxDataPoints,
 		onAdd:         onAdd,
-	}
-}
-
-// AddTraces converts and stores trace data.
-func (s *Store) AddTraces(td ptrace.Traces) {
-	converted := ConvertTraces(td)
-	s.mu.Lock()
-	for _, trace := range converted {
-		if idx, ok := s.traceIndex[trace.TraceID]; ok {
-			existing := s.traces.Get(idx)
-			if existing != nil && existing.TraceID == trace.TraceID {
-				// Deduplicate spans by spanID.
-				seen := make(map[string]struct{}, len(existing.Spans))
-				for _, s := range existing.Spans {
-					seen[s.SpanID] = struct{}{}
-				}
-				for _, s := range trace.Spans {
-					if _, dup := seen[s.SpanID]; !dup {
-						existing.Spans = append(existing.Spans, s)
-						seen[s.SpanID] = struct{}{}
-					}
-				}
-				existing.SpanCount = len(existing.Spans)
-				if trace.RootSpan != nil {
-					existing.RootSpan = trace.RootSpan
-					existing.ServiceName = trace.ServiceName
-					existing.Duration = trace.Duration
-				}
-				if trace.StartTime.Before(existing.StartTime) {
-					existing.StartTime = trace.StartTime
-				}
-				continue
-			}
-		}
-		idx := s.traces.Add(trace)
-		s.traceIndex[trace.TraceID] = idx
-	}
-	s.mu.Unlock()
-
-	if s.onAdd != nil {
-		for _, trace := range converted {
-			s.onAdd(SignalTraces, trace)
-		}
 	}
 }
 
@@ -99,30 +58,75 @@ func metricKey(serviceName, name string) string {
 	return serviceName + "\x00" + name
 }
 
+// AddTraces converts and stores trace data. Broadcasts fire outside the lock.
+func (s *Store) AddTraces(td ptrace.Traces) {
+	converted := ConvertTraces(td)
+	if len(converted) == 0 {
+		return
+	}
+
+	notify := make([]*TraceData, 0, len(converted))
+	s.mu.Lock()
+	for _, trace := range converted {
+		if idx, ok := s.traceIndex[trace.TraceID]; ok {
+			if existing := s.traces.Get(idx); existing != nil && existing.TraceID == trace.TraceID {
+				existing.Merge(trace)
+				notify = append(notify, existing)
+				continue
+			}
+			// index was stale — fall through to re-insert
+			delete(s.traceIndex, trace.TraceID)
+		}
+		idx, evicted, wasEvicted := s.traces.Add(trace)
+		if wasEvicted && evicted != nil {
+			delete(s.traceIndex, evicted.TraceID)
+		}
+		s.traceIndex[trace.TraceID] = idx
+		notify = append(notify, trace)
+	}
+	s.mu.Unlock()
+
+	if s.onAdd != nil {
+		for _, trace := range notify {
+			s.onAdd(SignalTraces, trace)
+		}
+	}
+}
+
 // AddMetrics converts and stores metric data, merging data points for the same metric.
 func (s *Store) AddMetrics(md pmetric.Metrics) {
 	converted := ConvertMetrics(md)
+	if len(converted) == 0 {
+		return
+	}
+
+	notify := make([]*MetricData, 0, len(converted))
 	s.mu.Lock()
 	for _, m := range converted {
 		key := metricKey(m.ServiceName, m.Name)
 		if idx, ok := s.metricIndex[key]; ok {
-			existing := s.metrics.Get(idx)
-			if existing != nil && existing.Name == m.Name && existing.ServiceName == m.ServiceName {
+			if existing := s.metrics.Get(idx); existing != nil && existing.Name == m.Name && existing.ServiceName == m.ServiceName {
 				existing.DataPoints = append(existing.DataPoints, m.DataPoints...)
 				if len(existing.DataPoints) > s.maxDataPoints {
 					existing.DataPoints = existing.DataPoints[len(existing.DataPoints)-s.maxDataPoints:]
 				}
 				existing.ReceivedAt = m.ReceivedAt
+				notify = append(notify, existing)
 				continue
 			}
+			delete(s.metricIndex, key)
 		}
-		idx := s.metrics.Add(m)
+		idx, evicted, wasEvicted := s.metrics.Add(m)
+		if wasEvicted && evicted != nil {
+			delete(s.metricIndex, metricKey(evicted.ServiceName, evicted.Name))
+		}
 		s.metricIndex[key] = idx
+		notify = append(notify, m)
 	}
 	s.mu.Unlock()
 
 	if s.onAdd != nil {
-		for _, m := range converted {
+		for _, m := range notify {
 			s.onAdd(SignalMetrics, m)
 		}
 	}
@@ -131,6 +135,10 @@ func (s *Store) AddMetrics(md pmetric.Metrics) {
 // AddLogs converts and stores log data.
 func (s *Store) AddLogs(ld plog.Logs) {
 	converted := ConvertLogs(ld)
+	if len(converted) == 0 {
+		return
+	}
+
 	s.mu.Lock()
 	for _, l := range converted {
 		s.logs.Add(l)
@@ -144,59 +152,59 @@ func (s *Store) AddLogs(ld plog.Logs) {
 	}
 }
 
-// GetTraces returns all stored traces, newest first.
-func (s *Store) GetTraces() []*TraceData {
+// GetTracesPage returns a newest-first page of traces plus the total buffer count.
+func (s *Store) GetTracesPage(offset, limit int) (items []*TraceData, total int) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	items := s.traces.Items()
-	// Reverse to return newest first.
-	reversed := make([]*TraceData, len(items))
-	for i, item := range items {
-		reversed[len(items)-1-i] = item
-	}
-	return reversed
+	return s.traces.Page(offset, limit)
+}
+
+// GetMetricsPage returns a newest-first page of metrics plus the total buffer count.
+func (s *Store) GetMetricsPage(offset, limit int) (items []*MetricData, total int) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.metrics.Page(offset, limit)
+}
+
+// GetLogsPage returns a newest-first page of logs plus the total buffer count.
+func (s *Store) GetLogsPage(offset, limit int) (items []*LogData, total int) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.logs.Page(offset, limit)
+}
+
+// GetTraces returns all stored traces, newest first.
+func (s *Store) GetTraces() []*TraceData {
+	items, _ := s.GetTracesPage(0, 0)
+	return items
 }
 
 // GetMetrics returns all stored metrics, newest first.
 func (s *Store) GetMetrics() []*MetricData {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	items := s.metrics.Items()
-	reversed := make([]*MetricData, len(items))
-	for i, item := range items {
-		reversed[len(items)-1-i] = item
-	}
-	return reversed
+	items, _ := s.GetMetricsPage(0, 0)
+	return items
 }
 
 // GetLogs returns all stored logs, newest first.
 func (s *Store) GetLogs() []*LogData {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	items := s.logs.Items()
-	reversed := make([]*LogData, len(items))
-	for i, item := range items {
-		reversed[len(items)-1-i] = item
-	}
-	return reversed
+	items, _ := s.GetLogsPage(0, 0)
+	return items
 }
 
-// GetTraceByID returns a trace by its trace ID.
+// GetTraceByID returns a trace by its trace ID. Lookup is O(1) — the index is
+// kept in sync with the ring buffer via eviction callbacks in AddTraces.
 func (s *Store) GetTraceByID(traceID string) (*TraceData, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if idx, ok := s.traceIndex[traceID]; ok {
-		if item := s.traces.Get(idx); item != nil {
-			return item, true
-		}
+	idx, ok := s.traceIndex[traceID]
+	if !ok {
+		return nil, false
 	}
-	// Fallback: linear scan (in case index is stale after ring buffer wrap).
-	for _, item := range s.traces.Items() {
-		if item.TraceID == traceID {
-			return item, true
-		}
+	item := s.traces.Get(idx)
+	if item == nil || item.TraceID != traceID {
+		return nil, false
 	}
-	return nil, false
+	return item, true
 }
 
 // Capacity returns the store's configured limits.
@@ -218,11 +226,12 @@ func (s *Store) Clear() {
 	s.traces.Clear()
 	s.metrics.Clear()
 	s.logs.Clear()
-	s.traceIndex = make(map[string]int)
-	s.metricIndex = make(map[string]int)
+	clear(s.traceIndex)
+	clear(s.metricIndex)
 }
 
-// RingBuffer is a generic bounded FIFO buffer.
+// RingBuffer is a generic bounded FIFO buffer. Not safe for concurrent use —
+// callers (e.g. Store) synchronize externally.
 type RingBuffer[T any] struct {
 	items []T
 	head  int
@@ -238,19 +247,21 @@ func NewRingBuffer[T any](cap int) *RingBuffer[T] {
 	}
 }
 
-// Add appends an item to the buffer, overwriting the oldest if full.
-// Returns the index at which the item was stored.
-func (rb *RingBuffer[T]) Add(item T) int {
-	idx := (rb.head + rb.count) % rb.cap
+// Add appends an item to the buffer, overwriting the oldest if full. It returns
+// the stored index, the evicted value (zero if none), and whether an eviction
+// happened — giving callers enough to maintain secondary indexes.
+func (rb *RingBuffer[T]) Add(item T) (idx int, evicted T, wasEvicted bool) {
 	if rb.count == rb.cap {
-		// Buffer is full, overwrite oldest.
 		idx = rb.head
+		evicted = rb.items[idx]
+		wasEvicted = true
 		rb.head = (rb.head + 1) % rb.cap
 	} else {
+		idx = (rb.head + rb.count) % rb.cap
 		rb.count++
 	}
 	rb.items[idx] = item
-	return idx
+	return
 }
 
 // Get returns the item at the given absolute index, or the zero value if invalid.
@@ -269,6 +280,34 @@ func (rb *RingBuffer[T]) Items() []T {
 		result[i] = rb.items[(rb.head+i)%rb.cap]
 	}
 	return result
+}
+
+// Page returns up to `limit` items starting at `offset` counted from the newest.
+// When limit == 0, all items from offset to the end are returned. `total` is the
+// total number of items currently stored. The returned slice never aliases the
+// underlying buffer.
+func (rb *RingBuffer[T]) Page(offset, limit int) (items []T, total int) {
+	total = rb.count
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= total {
+		return nil, total
+	}
+	end := total
+	if limit > 0 && offset+limit < end {
+		end = offset + limit
+	}
+	n := end - offset
+	items = make([]T, n)
+	// Position of newest item: (head + count - 1) mod cap. Step backwards.
+	// Use +rb.cap before modulo to avoid negative intermediates.
+	for i := 0; i < n; i++ {
+		rank := offset + i
+		pos := (rb.head + rb.count - 1 - rank + rb.cap) % rb.cap
+		items[i] = rb.items[pos]
+	}
+	return
 }
 
 // Len returns the number of items in the buffer.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -315,6 +315,79 @@ func TestStore_Clear(t *testing.T) {
 	}
 }
 
+func TestStore_AddTraces_EvictionClearsIndex(t *testing.T) {
+	// Capacity 2 so that the 3rd distinct trace evicts the 1st.
+	s := NewStore(2, 10, 10, 100, nil)
+
+	add := func(traceByte byte) {
+		td := ptrace.NewTraces()
+		rs := td.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr("service.name", "svc")
+		ss := rs.ScopeSpans().AppendEmpty()
+		sp := ss.Spans().AppendEmpty()
+		sp.SetTraceID(pcommon.TraceID([16]byte{traceByte}))
+		sp.SetSpanID(pcommon.SpanID([8]byte{traceByte}))
+		sp.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		sp.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		s.AddTraces(td)
+	}
+
+	add(1)
+	add(2)
+	add(3) // evicts trace 1
+
+	traces := s.GetTraces()
+	if len(traces) != 2 {
+		t.Fatalf("expected 2 traces after eviction, got %d", len(traces))
+	}
+	// The evicted traceID should not be findable.
+	firstID := pcommon.TraceID([16]byte{1}).String()
+	if _, ok := s.GetTraceByID(firstID); ok {
+		t.Error("evicted trace should not be findable by ID")
+	}
+	// Surviving traces should still be findable.
+	secondID := pcommon.TraceID([16]byte{2}).String()
+	if _, ok := s.GetTraceByID(secondID); !ok {
+		t.Error("trace 2 should still be findable by ID")
+	}
+	thirdID := pcommon.TraceID([16]byte{3}).String()
+	if _, ok := s.GetTraceByID(thirdID); !ok {
+		t.Error("trace 3 should be findable by ID")
+	}
+}
+
+func TestStore_GetTracesPage(t *testing.T) {
+	s := NewStore(10, 10, 10, 100, nil)
+
+	for i := 1; i <= 5; i++ {
+		td := ptrace.NewTraces()
+		rs := td.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr("service.name", "svc")
+		ss := rs.ScopeSpans().AppendEmpty()
+		sp := ss.Spans().AppendEmpty()
+		sp.SetTraceID(pcommon.TraceID([16]byte{byte(i)}))
+		sp.SetSpanID(pcommon.SpanID([8]byte{byte(i)}))
+		sp.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Duration(i) * time.Millisecond)))
+		sp.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Duration(i) * time.Millisecond)))
+		s.AddTraces(td)
+	}
+
+	page, total := s.GetTracesPage(1, 2)
+	if total != 5 {
+		t.Errorf("total = %d, want 5", total)
+	}
+	if len(page) != 2 {
+		t.Fatalf("page len = %d, want 2", len(page))
+	}
+	// newest-first: rank 0 is trace 5, rank 1 is trace 4, rank 2 is trace 3.
+	if page[0].TraceID != pcommon.TraceID([16]byte{4}).String() {
+		t.Errorf("page[0] = %s, want trace 4", page[0].TraceID)
+	}
+	if page[1].TraceID != pcommon.TraceID([16]byte{3}).String() {
+		t.Errorf("page[1] = %s, want trace 3", page[1].TraceID)
+	}
+}
+
 func TestStore_NewestFirst(t *testing.T) {
 	s := NewStore(10, 10, 10, 100, nil)
 

--- a/internal/store/trace.go
+++ b/internal/store/trace.go
@@ -15,6 +15,35 @@ type TraceData struct {
 	SpanCount   int           `json:"spanCount"`
 	StartTime   time.Time     `json:"startTime"`
 	Duration    time.Duration `json:"duration"`
+
+	// spanIDs tracks known spanIDs for O(1) deduplication on merge. Not serialized.
+	spanIDs map[string]struct{} `json:"-"`
+}
+
+// Merge incorporates another TraceData sharing the same TraceID, deduplicating spans.
+func (t *TraceData) Merge(other *TraceData) {
+	if t.spanIDs == nil {
+		t.spanIDs = make(map[string]struct{}, len(t.Spans)+len(other.Spans))
+		for _, s := range t.Spans {
+			t.spanIDs[s.SpanID] = struct{}{}
+		}
+	}
+	for _, s := range other.Spans {
+		if _, dup := t.spanIDs[s.SpanID]; dup {
+			continue
+		}
+		t.spanIDs[s.SpanID] = struct{}{}
+		t.Spans = append(t.Spans, s)
+	}
+	t.SpanCount = len(t.Spans)
+	if other.RootSpan != nil {
+		t.RootSpan = other.RootSpan
+		t.ServiceName = other.ServiceName
+		t.Duration = other.Duration
+	}
+	if !other.StartTime.IsZero() && other.StartTime.Before(t.StartTime) {
+		t.StartTime = other.StartTime
+	}
 }
 
 // SpanData represents a single span.
@@ -42,23 +71,30 @@ type SpanEvent struct {
 	Attributes map[string]any `json:"attributes"`
 }
 
-// ConvertTraces converts ptrace.Traces into a map of TraceData keyed by trace ID.
-func ConvertTraces(td ptrace.Traces) map[string]*TraceData {
-	result := make(map[string]*TraceData)
+// ConvertTraces converts ptrace.Traces into a slice of TraceData, grouped by trace ID.
+// The returned slice preserves first-seen order, which callers rely on for deterministic
+// ingestion into the store.
+func ConvertTraces(td ptrace.Traces) []*TraceData {
+	var result []*TraceData
+	index := make(map[string]*TraceData)
 
-	for i := 0; i < td.ResourceSpans().Len(); i++ {
-		rs := td.ResourceSpans().At(i)
+	resourceSpans := td.ResourceSpans()
+	for i := 0; i < resourceSpans.Len(); i++ {
+		rs := resourceSpans.At(i)
 		resource := attributesToMap(rs.Resource().Attributes())
 		var svcName string
 		if serviceName, ok := rs.Resource().Attributes().Get("service.name"); ok {
 			svcName = serviceName.AsString()
 		}
 
-		for j := 0; j < rs.ScopeSpans().Len(); j++ {
-			ss := rs.ScopeSpans().At(j)
-			for k := 0; k < ss.Spans().Len(); k++ {
-				span := ss.Spans().At(k)
+		scopeSpans := rs.ScopeSpans()
+		for j := 0; j < scopeSpans.Len(); j++ {
+			spans := scopeSpans.At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				span := spans.At(k)
 				traceID := span.TraceID().String()
+				start := span.StartTimestamp().AsTime()
+				end := span.EndTimestamp().AsTime()
 
 				sd := &SpanData{
 					TraceID:      traceID,
@@ -67,9 +103,9 @@ func ConvertTraces(td ptrace.Traces) map[string]*TraceData {
 					Name:         span.Name(),
 					Kind:         span.Kind().String(),
 					ServiceName:  svcName,
-					StartTime:    span.StartTimestamp().AsTime(),
-					EndTime:      span.EndTimestamp().AsTime(),
-					Duration:     span.EndTimestamp().AsTime().Sub(span.StartTimestamp().AsTime()),
+					StartTime:    start,
+					EndTime:      end,
+					Duration:     end.Sub(start),
 					StatusCode:   span.Status().Code().String(),
 					StatusMsg:    span.Status().Message(),
 					Attributes:   attributesToMap(span.Attributes()),
@@ -77,13 +113,14 @@ func ConvertTraces(td ptrace.Traces) map[string]*TraceData {
 					Resource:     resource,
 				}
 
-				trace, ok := result[traceID]
+				trace, ok := index[traceID]
 				if !ok {
 					trace = &TraceData{
 						TraceID:   traceID,
 						StartTime: sd.StartTime,
 					}
-					result[traceID] = trace
+					index[traceID] = trace
+					result = append(result, trace)
 				}
 
 				trace.Spans = append(trace.Spans, sd)
@@ -93,7 +130,6 @@ func ConvertTraces(td ptrace.Traces) map[string]*TraceData {
 					trace.StartTime = sd.StartTime
 				}
 
-				// Root span: no parent
 				if span.ParentSpanID().IsEmpty() {
 					trace.RootSpan = sd
 					trace.ServiceName = svcName
@@ -103,22 +139,24 @@ func ConvertTraces(td ptrace.Traces) map[string]*TraceData {
 		}
 	}
 
-	// For traces without a root span, derive service name and duration from the earliest span.
+	// For traces without an explicit root span, derive service name and duration
+	// from the earliest/latest span in a single pass.
 	for _, trace := range result {
-		if trace.RootSpan == nil && len(trace.Spans) > 0 {
-			earliest := trace.Spans[0]
-			latest := trace.Spans[0]
-			for _, s := range trace.Spans[1:] {
-				if s.StartTime.Before(earliest.StartTime) {
-					earliest = s
-				}
-				if s.EndTime.After(latest.EndTime) {
-					latest = s
-				}
-			}
-			trace.ServiceName = earliest.ServiceName
-			trace.Duration = latest.EndTime.Sub(earliest.StartTime)
+		if trace.RootSpan != nil || len(trace.Spans) == 0 {
+			continue
 		}
+		earliest := trace.Spans[0]
+		latestEnd := earliest.EndTime
+		for _, s := range trace.Spans[1:] {
+			if s.StartTime.Before(earliest.StartTime) {
+				earliest = s
+			}
+			if s.EndTime.After(latestEnd) {
+				latestEnd = s.EndTime
+			}
+		}
+		trace.ServiceName = earliest.ServiceName
+		trace.Duration = latestEnd.Sub(earliest.StartTime)
 	}
 
 	return result

--- a/internal/store/trace_test.go
+++ b/internal/store/trace_test.go
@@ -1,0 +1,146 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTraceData_Merge_DeduplicatesSpansAndPromotesRoot(t *testing.T) {
+	t0 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	t1 := t0.Add(10 * time.Millisecond)
+	t2 := t0.Add(5 * time.Millisecond)
+
+	base := &TraceData{
+		TraceID: "abc",
+		Spans: []*SpanData{
+			{SpanID: "a", StartTime: t0, EndTime: t1},
+		},
+		SpanCount:   1,
+		StartTime:   t0,
+		ServiceName: "",
+	}
+
+	incoming := &TraceData{
+		TraceID: "abc",
+		Spans: []*SpanData{
+			{SpanID: "a", StartTime: t0, EndTime: t1}, // duplicate, should drop
+			{SpanID: "b", StartTime: t2, EndTime: t1}, // new
+		},
+		RootSpan:    &SpanData{SpanID: "b", StartTime: t2, EndTime: t1, Duration: t1.Sub(t2)},
+		ServiceName: "svc-b",
+		Duration:    t1.Sub(t2),
+		StartTime:   t2,
+	}
+
+	base.Merge(incoming)
+
+	if len(base.Spans) != 2 {
+		t.Fatalf("expected 2 spans after merge, got %d", len(base.Spans))
+	}
+	if base.SpanCount != 2 {
+		t.Errorf("SpanCount = %d, want 2", base.SpanCount)
+	}
+	if base.RootSpan == nil || base.RootSpan.SpanID != "b" {
+		t.Errorf("RootSpan not promoted: %+v", base.RootSpan)
+	}
+	if base.ServiceName != "svc-b" {
+		t.Errorf("ServiceName = %q, want svc-b", base.ServiceName)
+	}
+	// base.StartTime (t0) is earlier than incoming.StartTime (t2); must not regress.
+	if !base.StartTime.Equal(t0) {
+		t.Errorf("StartTime = %v, want %v (base is earlier)", base.StartTime, t0)
+	}
+	if base.Duration != t1.Sub(t2) {
+		t.Errorf("Duration = %v, want %v", base.Duration, t1.Sub(t2))
+	}
+}
+
+func TestTraceData_Merge_PreservesRootWhenIncomingHasNone(t *testing.T) {
+	t0 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	rootSpan := &SpanData{SpanID: "root", StartTime: t0, EndTime: t0.Add(100 * time.Millisecond)}
+	base := &TraceData{
+		TraceID:     "abc",
+		Spans:       []*SpanData{rootSpan},
+		RootSpan:    rootSpan,
+		ServiceName: "svc",
+		SpanCount:   1,
+		StartTime:   t0,
+		Duration:    100 * time.Millisecond,
+	}
+
+	incoming := &TraceData{
+		TraceID: "abc",
+		Spans: []*SpanData{
+			{SpanID: "child", StartTime: t0.Add(10 * time.Millisecond), EndTime: t0.Add(20 * time.Millisecond)},
+		},
+		StartTime: t0.Add(10 * time.Millisecond),
+	}
+
+	base.Merge(incoming)
+
+	if base.RootSpan == nil || base.RootSpan.SpanID != "root" {
+		t.Errorf("RootSpan should remain root, got %+v", base.RootSpan)
+	}
+	if base.ServiceName != "svc" {
+		t.Errorf("ServiceName should remain svc, got %q", base.ServiceName)
+	}
+	if !base.StartTime.Equal(t0) {
+		t.Errorf("StartTime should remain %v, got %v", t0, base.StartTime)
+	}
+	if len(base.Spans) != 2 {
+		t.Errorf("expected 2 spans, got %d", len(base.Spans))
+	}
+}
+
+func TestTraceData_Merge_AdvancesStartTimeBackwards(t *testing.T) {
+	t0 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	earlier := t0.Add(-1 * time.Second)
+
+	base := &TraceData{
+		TraceID:   "abc",
+		Spans:     []*SpanData{{SpanID: "a", StartTime: t0}},
+		SpanCount: 1,
+		StartTime: t0,
+	}
+	incoming := &TraceData{
+		TraceID:   "abc",
+		Spans:     []*SpanData{{SpanID: "b", StartTime: earlier}},
+		StartTime: earlier,
+	}
+
+	base.Merge(incoming)
+
+	if !base.StartTime.Equal(earlier) {
+		t.Errorf("StartTime should be rolled back to %v, got %v", earlier, base.StartTime)
+	}
+}
+
+func TestTraceData_Merge_IsIdempotentOnRepeatedCalls(t *testing.T) {
+	t0 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	base := &TraceData{
+		TraceID: "abc",
+		Spans: []*SpanData{
+			{SpanID: "a", StartTime: t0},
+		},
+		SpanCount: 1,
+		StartTime: t0,
+	}
+	incoming := &TraceData{
+		TraceID: "abc",
+		Spans: []*SpanData{
+			{SpanID: "a", StartTime: t0},
+			{SpanID: "b", StartTime: t0},
+		},
+		StartTime: t0,
+	}
+
+	base.Merge(incoming)
+	base.Merge(incoming) // repeated merge should not duplicate span b
+
+	if len(base.Spans) != 2 {
+		t.Fatalf("expected 2 spans after repeated merge, got %d", len(base.Spans))
+	}
+	if base.SpanCount != 2 {
+		t.Errorf("SpanCount = %d, want 2", base.SpanCount)
+	}
+}

--- a/internal/websocket/hub.go
+++ b/internal/websocket/hub.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"sync"
+	"sync/atomic"
 
 	"github.com/mashiro/otelop/internal/store"
 )
+
+// broadcastQueueSize bounds how many pending broadcasts the hub will queue
+// before dropping them. Large enough to absorb bursts, small enough that a
+// stuck hub goroutine can't OOM the process.
+const broadcastQueueSize = 1024
 
 // Message is sent to WebSocket clients.
 type Message struct {
@@ -16,11 +21,13 @@ type Message struct {
 }
 
 // Hub manages WebSocket client connections and broadcasts messages.
+// All map mutations happen inside Run, so no mutex is needed on the hot path.
 type Hub struct {
-	mu         sync.RWMutex
 	clients    map[*Client]struct{}
 	register   chan *Client
 	unregister chan *Client
+	broadcast  chan Message
+	count      atomic.Int64
 }
 
 // NewHub creates a new Hub.
@@ -29,36 +36,55 @@ func NewHub() *Hub {
 		clients:    make(map[*Client]struct{}),
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
+		broadcast:  make(chan Message, broadcastQueueSize),
 	}
 }
 
 // Run starts the hub event loop. It blocks until ctx is cancelled.
+// The Run goroutine is the sole owner of the clients map and the only writer
+// to client.send, which means Broadcast callers never block on JSON marshaling.
 func (h *Hub) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			h.mu.Lock()
 			for client := range h.clients {
 				close(client.send)
 				delete(h.clients, client)
 			}
-			h.mu.Unlock()
+			h.count.Store(0)
 			return
 		case client := <-h.register:
-			h.mu.Lock()
 			h.clients[client] = struct{}{}
-			count := len(h.clients)
-			h.mu.Unlock()
-			slog.Debug("websocket: client connected", "clients", count)
+			h.count.Store(int64(len(h.clients)))
+			slog.Debug("websocket: client connected", "clients", len(h.clients))
 		case client := <-h.unregister:
-			h.mu.Lock()
 			if _, ok := h.clients[client]; ok {
 				close(client.send)
 				delete(h.clients, client)
+				h.count.Store(int64(len(h.clients)))
 			}
-			count := len(h.clients)
-			h.mu.Unlock()
-			slog.Debug("websocket: client disconnected", "clients", count)
+			slog.Debug("websocket: client disconnected", "clients", len(h.clients))
+		case msg := <-h.broadcast:
+			h.dispatch(msg)
+		}
+	}
+}
+
+// dispatch marshals and fans out a single broadcast message. Runs only inside Run.
+func (h *Hub) dispatch(msg Message) {
+	if len(h.clients) == 0 {
+		return
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		slog.Error("websocket: failed to marshal message", "error", err)
+		return
+	}
+	for client := range h.clients {
+		select {
+		case client.send <- data:
+		default:
+			// Client buffer full, drop this message for the slow client.
 		}
 	}
 }
@@ -73,37 +99,21 @@ func (h *Hub) Unregister(c *Client) {
 	h.unregister <- c
 }
 
-// Broadcast sends a message to all connected clients.
-// This is safe to call from any goroutine.
+// Broadcast enqueues a message for asynchronous fan-out. It is non-blocking:
+// if the broadcast queue is full the message is dropped rather than stalling
+// the caller (typically a store write path).
 func (h *Hub) Broadcast(msg Message) {
-	h.mu.RLock()
-	n := len(h.clients)
-	h.mu.RUnlock()
-	if n == 0 {
+	if h.count.Load() == 0 {
 		return
 	}
-
-	data, err := json.Marshal(msg)
-	if err != nil {
-		slog.Error("websocket: failed to marshal message", "error", err)
-		return
-	}
-
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-
-	for client := range h.clients {
-		select {
-		case client.send <- data:
-		default:
-			// Client buffer full, skip this message.
-		}
+	select {
+	case h.broadcast <- msg:
+	default:
+		slog.Warn("websocket: broadcast queue full, dropping message")
 	}
 }
 
 // ClientCount returns the number of connected clients.
 func (h *Hub) ClientCount() int {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	return len(h.clients)
+	return int(h.count.Load())
 }

--- a/internal/websocket/hub_test.go
+++ b/internal/websocket/hub_test.go
@@ -78,27 +78,74 @@ func TestHub_BroadcastDropsSlowClient(t *testing.T) {
 	defer cancel()
 	go hub.Run(ctx)
 
-	// Client with tiny buffer.
+	// Client with tiny buffer, intentionally pre-filled to simulate a slow reader.
 	slowClient := &Client{hub: hub, send: make(chan []byte, 1)}
+	slowClient.send <- []byte("placeholder")
+
 	hub.Register(slowClient)
 	time.Sleep(10 * time.Millisecond)
 
-	// Fill the buffer.
-	hub.Broadcast(Message{Type: store.SignalLogs, Data: "msg1"})
-	// This should be dropped (buffer full).
-	hub.Broadcast(Message{Type: store.SignalLogs, Data: "msg2"})
+	// Dispatch a broadcast. Because the client buffer is already full, the hub
+	// must drop the new payload rather than block waiting for the slow reader.
+	hub.Broadcast(Message{Type: store.SignalLogs, Data: "msg-should-drop"})
 
-	// Should only receive one message.
+	// Give the hub Run goroutine a chance to attempt delivery and drop.
+	time.Sleep(20 * time.Millisecond)
+
+	// Drain the pre-filled value.
 	select {
-	case <-slowClient.send:
+	case msg := <-slowClient.send:
+		if string(msg) != "placeholder" {
+			t.Errorf("first message = %q, want placeholder", string(msg))
+		}
 	case <-time.After(100 * time.Millisecond):
-		t.Error("expected at least one message")
+		t.Fatal("expected placeholder message")
 	}
 
+	// Nothing more should arrive — the broadcast was dropped for this slow client.
 	select {
-	case <-slowClient.send:
-		t.Error("expected second message to be dropped")
+	case extra := <-slowClient.send:
+		t.Errorf("expected broadcast to be dropped, but got %q", string(extra))
 	case <-time.After(50 * time.Millisecond):
-		// Good, message was dropped.
+	}
+}
+
+func TestHub_BroadcastIsNonBlockingAndPreservesOrder(t *testing.T) {
+	hub := NewHub()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go hub.Run(ctx)
+
+	client := &Client{hub: hub, send: make(chan []byte, 8)}
+	hub.Register(client)
+	time.Sleep(10 * time.Millisecond)
+
+	for i := 0; i < 5; i++ {
+		hub.Broadcast(Message{Type: store.SignalLogs, Data: i})
+	}
+
+	received := 0
+	timeout := time.After(200 * time.Millisecond)
+	for received < 5 {
+		select {
+		case <-client.send:
+			received++
+		case <-timeout:
+			t.Fatalf("only received %d of 5 messages", received)
+		}
+	}
+}
+
+func TestHub_BroadcastWithNoClients_IsNoop(t *testing.T) {
+	hub := NewHub()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go hub.Run(ctx)
+
+	// Must not panic or block even without any clients connected.
+	hub.Broadcast(Message{Type: store.SignalTraces, Data: "x"})
+	time.Sleep(10 * time.Millisecond)
+	if hub.ClientCount() != 0 {
+		t.Errorf("ClientCount = %d, want 0", hub.ClientCount())
 	}
 }


### PR DESCRIPTION
## Summary
- **store**: `TraceData.Merge` tracks known spanIDs in a persistent set so repeat ingestion of the same trace is O(n) instead of O(n²); `RingBuffer.Add` now reports evicted items so the trace/metric indexes stay in sync with the ring, dropping the linear-scan fallback in `GetTraceByID`.
- **store**: `RingBuffer.Page` walks newest-first with a single allocation sized to the returned page, replacing the `Items() + reverse copy` pattern in `GetTraces/GetMetrics/GetLogs`.
- **websocket**: `Hub` dispatches broadcasts from a bounded channel inside `Run`, so the clients map no longer needs a mutex, marshal happens off the store's write path, and slow clients are dropped without blocking callers.
- **server**: `writePaginated[T]` generic collapses the three signal list handlers into one code path. Pagination defaults to `limit=50`, no artificial upper cap — the store capacity is the real bound (fixes silent truncation when `--trace-cap` / `--metric-cap` / `--log-cap` exceed the handler cap).

## Test plan
- [x] `mise run check`
- [x] `mise run test`
- [x] New unit tests: `TraceData.Merge` (dedup, root promotion, start-time regression, idempotence), `RingBuffer.Add`/`Page` (eviction, wrap-around, negative offset), store trace-index eviction + `GetTracesPage`, hub async broadcast / slow-client drop / no-client noop, `parsePagination` edge cases, `writePaginated` envelope.