### PR TITLE
refactor(frontend): extract shared list/detail primitives and signal config

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,58 +1,40 @@
-import { useEffect } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useThemeSync } from "@/hooks/use-theme";
+import { useWebSocket } from "@/hooks/use-websocket";
+import { useInitialLoad } from "@/hooks/use-initial-load";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Header } from "@/components/layout/header";
 import { TraceList } from "@/components/traces/trace-list";
 import { MetricList } from "@/components/metrics/metric-list";
 import { LogList } from "@/components/logs/log-list";
-import { useWebSocket } from "@/hooks/use-websocket";
-import {
-  setTracesAtom,
-  setMetricsAtom,
-  setLogsAtom,
-  activeTabAtom,
-  serverConfigAtom,
-} from "@/stores/telemetry";
-import type { PaginatedResponse, TraceData, MetricData, LogData } from "@/types/telemetry";
-import type { ServerConfig, TabValue } from "@/stores/telemetry";
+import { activeTabAtom } from "@/stores/telemetry";
+import type { TabValue } from "@/stores/telemetry";
+import { SIGNAL_LIST } from "@/lib/signals";
+
+const tabBody: Record<TabValue, () => React.ReactElement> = {
+  traces: () => <TraceList />,
+  metrics: () => <MetricList />,
+  logs: () => <LogList />,
+};
+
+// Tailwind scans class literals, so triggers must use pre-formed strings
+// per signal. Keep this table close to App so it's obvious when a new signal
+// is added.
+const tabTriggerClasses: Record<TabValue, string> = {
+  traces:
+    "rounded-lg px-4 py-1.5 text-sm font-medium text-muted-foreground transition-all data-active:bg-trace/15 data-active:text-trace data-active:shadow-[0_0_12px_oklch(0.80_0.14_195/20%)] dark:data-active:bg-trace/15 dark:data-active:text-trace hover:text-foreground",
+  metrics:
+    "rounded-lg px-4 py-1.5 text-sm font-medium text-muted-foreground transition-all data-active:bg-metric/15 data-active:text-metric data-active:shadow-[0_0_12px_oklch(0.82_0.14_80/20%)] dark:data-active:bg-metric/15 dark:data-active:text-metric hover:text-foreground",
+  logs: "rounded-lg px-4 py-1.5 text-sm font-medium text-muted-foreground transition-all data-active:bg-log/15 data-active:text-log data-active:shadow-[0_0_12px_oklch(0.78_0.14_300/20%)] dark:data-active:bg-log/15 dark:data-active:text-log hover:text-foreground",
+};
 
 function App() {
   useThemeSync();
   useWebSocket();
+  useInitialLoad();
 
-  const setTraces = useSetAtom(setTracesAtom);
-  const setMetrics = useSetAtom(setMetricsAtom);
-  const setLogs = useSetAtom(setLogsAtom);
-  const setConfig = useSetAtom(serverConfigAtom);
   const activeTab = useAtomValue(activeTabAtom);
   const setActiveTab = useSetAtom(activeTabAtom);
-
-  useEffect(() => {
-    const load = async () => {
-      try {
-        // Fetch server config first to use correct limits.
-        const cfgRes = await fetch("/api/config");
-        const cfg: ServerConfig = await cfgRes.json();
-        setConfig(cfg);
-
-        const [tRes, mRes, lRes] = await Promise.all([
-          fetch(`/api/traces?limit=${cfg.traceCap}`),
-          fetch(`/api/metrics?limit=${cfg.metricCap}`),
-          fetch(`/api/logs?limit=${cfg.logCap}`),
-        ]);
-        const traces: PaginatedResponse<TraceData> = await tRes.json();
-        const metrics: PaginatedResponse<MetricData> = await mRes.json();
-        const logs: PaginatedResponse<LogData> = await lRes.json();
-        setTraces(traces.data);
-        setMetrics(metrics.data);
-        setLogs(logs.data);
-      } catch {
-        // WebSocket will deliver data later
-      }
-    };
-    void load();
-  }, [setTraces, setMetrics, setLogs, setConfig]);
 
   return (
     <div className="noise-bg mesh-bg flex h-screen flex-col text-foreground">
@@ -64,38 +46,29 @@ function App() {
       >
         <div className="px-5 pt-3">
           <TabsList className="w-fit gap-1 bg-transparent p-0">
-            <TabsTrigger
-              value="traces"
-              className="rounded-lg px-4 py-1.5 text-sm font-medium text-muted-foreground transition-all data-active:bg-trace/15 data-active:text-trace data-active:shadow-[0_0_12px_oklch(0.80_0.14_195/20%)] dark:data-active:bg-trace/15 dark:data-active:text-trace hover:text-foreground"
-            >
-              Traces
-            </TabsTrigger>
-            <TabsTrigger
-              value="metrics"
-              className="rounded-lg px-4 py-1.5 text-sm font-medium text-muted-foreground transition-all data-active:bg-metric/15 data-active:text-metric data-active:shadow-[0_0_12px_oklch(0.82_0.14_80/20%)] dark:data-active:bg-metric/15 dark:data-active:text-metric hover:text-foreground"
-            >
-              Metrics
-            </TabsTrigger>
-            <TabsTrigger
-              value="logs"
-              className="rounded-lg px-4 py-1.5 text-sm font-medium text-muted-foreground transition-all data-active:bg-log/15 data-active:text-log data-active:shadow-[0_0_12px_oklch(0.78_0.14_300/20%)] dark:data-active:bg-log/15 dark:data-active:text-log hover:text-foreground"
-            >
-              Logs
-            </TabsTrigger>
+            {SIGNAL_LIST.map((signal) => (
+              <TabsTrigger
+                key={signal.key}
+                value={signal.key}
+                className={tabTriggerClasses[signal.key]}
+              >
+                {signal.label}
+              </TabsTrigger>
+            ))}
           </TabsList>
         </div>
-        <TabsContent value="traces" className="relative z-10 flex-1 overflow-hidden px-5 pb-4 pt-2">
-          <TraceList />
-        </TabsContent>
-        <TabsContent
-          value="metrics"
-          className="relative z-10 flex-1 overflow-hidden px-5 pb-4 pt-2"
-        >
-          <MetricList />
-        </TabsContent>
-        <TabsContent value="logs" className="relative z-10 flex-1 overflow-hidden px-5 pb-4 pt-2">
-          <LogList />
-        </TabsContent>
+        {SIGNAL_LIST.map((signal) => {
+          const Body = tabBody[signal.key];
+          return (
+            <TabsContent
+              key={signal.key}
+              value={signal.key}
+              className="relative z-10 flex-1 overflow-hidden px-5 pb-4 pt-2"
+            >
+              <Body />
+            </TabsContent>
+          );
+        })}
       </Tabs>
     </div>
   );

--- a/frontend/src/components/common/detail-panel.tsx
+++ b/frontend/src/components/common/detail-panel.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface DetailPanelProps {
+  // Left-hand side of the header, after the close button: typically title +
+  // inline metadata/badges.
+  header: ReactNode;
+  // Right-hand side of the header: action buttons (copy, download, navigate…).
+  actions?: ReactNode;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+// DetailPanel is the glass-card shell used by trace/metric detail views.
+// It owns the outer card, header bar, close button, and layout so individual
+// detail pages only supply header content, actions, and body.
+export function DetailPanel({ header, actions, onClose, children }: DetailPanelProps) {
+  return (
+    <div className="glass-card animate-fade-in flex h-full flex-col overflow-hidden">
+      <div className="flex items-center justify-between border-b border-border/50 px-4 py-2.5">
+        <div className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+          {header}
+        </div>
+        {actions && <div className="flex items-center gap-1">{actions}</div>}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/common/empty-state.tsx
+++ b/frontend/src/components/common/empty-state.tsx
@@ -1,0 +1,36 @@
+import type { SignalConfig } from "@/lib/signals";
+import { SignalIcon } from "./signal-icon";
+
+interface EmptyStateProps {
+  signal: SignalConfig;
+}
+
+export function EmptyState({ signal }: EmptyStateProps) {
+  return (
+    <div className="glass-card flex h-full items-center justify-center">
+      <div className="animate-slide-up-fade flex flex-col items-center gap-4">
+        <div
+          className={`flex h-14 w-14 items-center justify-center rounded-2xl ${signal.classes.bgLight}`}
+        >
+          <SignalIcon signal={signal} />
+        </div>
+        <div className="text-center">
+          <p className="text-sm font-medium text-foreground/70">{signal.emptyTitle}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{signal.emptyHint}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface EmptyMatchesProps {
+  label: string;
+}
+
+export function EmptyMatches({ label }: EmptyMatchesProps) {
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <p className="text-sm text-muted-foreground">No matching {label}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/common/list-panel.tsx
+++ b/frontend/src/components/common/list-panel.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+import { ListToolbar } from "@/components/filters/list-toolbar";
+
+interface ListPanelProps {
+  toolbar: ReactNode;
+  children: ReactNode;
+}
+
+// ListPanel is the glass-card + toolbar shell shared by every signal list view.
+// The body is left to the caller because list pages need different layouts
+// (flat table, service map, multi-mode views, etc.).
+export function ListPanel({ toolbar, children }: ListPanelProps) {
+  return (
+    <div className="glass-card flex h-full flex-col overflow-hidden">
+      <ListToolbar>{toolbar}</ListToolbar>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/common/pill.tsx
+++ b/frontend/src/components/common/pill.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import type { Tone } from "@/lib/tones";
+
+const toneBg: Record<Tone, string> = {
+  success: "bg-success/15 text-success",
+  destructive: "bg-destructive/15 text-destructive",
+  warning: "bg-warning/15 text-warning",
+  primary: "bg-primary/15 text-primary",
+  muted: "bg-muted text-muted-foreground",
+  trace: "bg-trace/15 text-trace",
+  metric: "bg-metric/15 text-metric",
+  log: "bg-log/15 text-log",
+};
+
+const toneDot: Record<Tone, string> = {
+  success: "bg-success",
+  destructive: "bg-destructive",
+  warning: "bg-warning",
+  primary: "bg-primary",
+  muted: "bg-muted-foreground/40",
+  trace: "bg-trace",
+  metric: "bg-metric",
+  log: "bg-log",
+};
+
+interface PillProps {
+  tone: Tone;
+  dot?: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+// Pill is the compact rounded badge used for statuses, severities, and type
+// markers across signals. Pass `dot` to show a small colored leading indicator
+// (typical for status and severity chips).
+export function Pill({ tone, dot = false, className, children }: PillProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium",
+        toneBg[tone],
+        className,
+      )}
+    >
+      {dot && <span className={cn("h-1.5 w-1.5 rounded-full", toneDot[tone])} />}
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/common/signal-icon.tsx
+++ b/frontend/src/components/common/signal-icon.tsx
@@ -1,0 +1,25 @@
+import type { SignalConfig } from "@/lib/signals";
+
+interface SignalIconProps {
+  signal: SignalConfig;
+  size?: number;
+  className?: string;
+}
+
+export function SignalIcon({ signal, size = 28, className }: SignalIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={`var(${signal.cssVar})`}
+      strokeWidth="1.5"
+      className={className}
+    >
+      {signal.iconPaths.map((d, i) => (
+        <path key={i} d={d} />
+      ))}
+    </svg>
+  );
+}

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -9,6 +9,7 @@ import {
   clearAllAtom,
 } from "@/stores/telemetry";
 import { themeAtom, type Theme } from "@/stores/theme";
+import { SIGNALS, type SignalConfig } from "@/lib/signals";
 
 const statusConfig: Record<string, { color: string; glow: string; label: string }> = {
   connected: {
@@ -61,9 +62,9 @@ export function Header() {
 
         {/* Signal counters */}
         <div className="flex items-center gap-3">
-          <CounterBadge label="T" count={traceCount} color="trace" />
-          <CounterBadge label="M" count={metricCount} color="metric" />
-          <CounterBadge label="L" count={logCount} color="log" />
+          <CounterBadge signal={SIGNALS.traces} count={traceCount} />
+          <CounterBadge signal={SIGNALS.metrics} count={metricCount} />
+          <CounterBadge signal={SIGNALS.logs} count={logCount} />
         </div>
       </div>
 
@@ -91,29 +92,14 @@ export function Header() {
   );
 }
 
-const counterStyles: Record<string, { wrapper: string; text: string }> = {
-  trace: {
-    wrapper: "bg-trace/10",
-    text: "text-trace",
-  },
-  metric: {
-    wrapper: "bg-metric/10",
-    text: "text-metric",
-  },
-  log: {
-    wrapper: "bg-log/10",
-    text: "text-log",
-  },
-};
-
-function CounterBadge({ label, count, color }: { label: string; count: number; color: string }) {
-  const style = counterStyles[color] ?? counterStyles.trace;
+function CounterBadge({ signal, count }: { signal: SignalConfig; count: number }) {
+  const { bgLight, text } = signal.classes;
   return (
-    <div className={`flex items-center gap-1.5 rounded-md px-2 py-0.5 ${style.wrapper}`}>
-      <span className={`text-[10px] font-bold uppercase tracking-wider ${style.text}`}>
-        {label}
+    <div className={`flex items-center gap-1.5 rounded-md px-2 py-0.5 ${bgLight}`}>
+      <span className={`text-[10px] font-bold uppercase tracking-wider ${text}`}>
+        {signal.shortLabel}
       </span>
-      <span className={`font-mono text-xs font-semibold ${style.text}`}>{count}</span>
+      <span className={`font-mono text-xs font-semibold ${text}`}>{count}</span>
     </div>
   );
 }

--- a/frontend/src/components/logs/log-list.tsx
+++ b/frontend/src/components/logs/log-list.tsx
@@ -16,23 +16,12 @@ import { CopyJsonButton } from "@/components/ui/copy-json-button";
 import { formatTimestamp, isZeroID, shortID } from "@/lib/format";
 import { KVSection } from "@/components/ui/kv-section";
 import { SearchFilter } from "@/components/filters/search-filter";
-import { ListToolbar } from "@/components/filters/list-toolbar";
+import { ListPanel } from "@/components/common/list-panel";
+import { EmptyState, EmptyMatches } from "@/components/common/empty-state";
+import { Pill } from "@/components/common/pill";
+import { SIGNALS } from "@/lib/signals";
+import { severityTone } from "@/lib/tones";
 import type { LogData } from "@/types/telemetry";
-
-const severityStyle: Record<string, { bg: string; text: string; dot: string }> = {
-  TRACE: { bg: "bg-muted", text: "text-muted-foreground", dot: "bg-muted-foreground/40" },
-  DEBUG: { bg: "bg-muted", text: "text-muted-foreground", dot: "bg-muted-foreground/40" },
-  INFO: { bg: "bg-primary/15", text: "text-primary", dot: "bg-primary" },
-  WARN: { bg: "bg-warning/15", text: "text-warning", dot: "bg-warning" },
-  ERROR: { bg: "bg-destructive/15", text: "text-destructive", dot: "bg-destructive" },
-  FATAL: { bg: "bg-destructive/20", text: "text-destructive", dot: "bg-destructive" },
-};
-
-const defaultSeverity = {
-  bg: "bg-muted",
-  text: "text-muted-foreground",
-  dot: "bg-muted-foreground/40",
-};
 
 export function LogList() {
   const allLogs = useAtomValue(logsAtom);
@@ -43,51 +32,31 @@ export function LogList() {
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
 
   if (allLogs.length === 0) {
-    return (
-      <div className="glass-card flex h-full items-center justify-center">
-        <div className="animate-slide-up-fade flex flex-col items-center gap-4">
-          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-log/10">
-            <svg
-              width="28"
-              height="28"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="var(--log)"
-              strokeWidth="1.5"
-            >
-              <path d="M4 6h16M4 12h16M4 18h10" />
-            </svg>
-          </div>
-          <div className="text-center">
-            <p className="text-sm font-medium text-foreground/70">No logs yet</p>
-            <p className="mt-1 text-xs text-muted-foreground">Send OTLP data to see them here</p>
-          </div>
-        </div>
-      </div>
-    );
+    return <EmptyState signal={SIGNALS.logs} />;
   }
 
   return (
-    <div className="glass-card flex h-full flex-col overflow-hidden">
-      <ListToolbar>
-        {traceFilter && (
-          <div className="flex items-center gap-1 rounded bg-trace/10 px-2 py-0.5 text-[11px] text-trace">
-            <span className="font-mono">{traceFilter.slice(0, 12)}...</span>
-            <button
-              type="button"
-              onClick={() => setTraceFilter(null)}
-              className="text-trace hover:text-foreground"
-            >
-              <X className="h-2.5 w-2.5" />
-            </button>
-          </div>
-        )}
-        <SearchFilter atom={logSearchAtom} placeholder="Search logs..." />
-      </ListToolbar>
+    <ListPanel
+      toolbar={
+        <>
+          {traceFilter && (
+            <div className="flex items-center gap-1 rounded bg-trace/10 px-2 py-0.5 text-[11px] text-trace">
+              <span className="font-mono">{traceFilter.slice(0, 12)}...</span>
+              <button
+                type="button"
+                onClick={() => setTraceFilter(null)}
+                className="text-trace hover:text-foreground"
+              >
+                <X className="h-2.5 w-2.5" />
+              </button>
+            </div>
+          )}
+          <SearchFilter atom={logSearchAtom} placeholder="Search logs..." />
+        </>
+      }
+    >
       {logs.length === 0 ? (
-        <div className="flex flex-1 items-center justify-center">
-          <p className="text-sm text-muted-foreground">No matching logs</p>
-        </div>
+        <EmptyMatches label="logs" />
       ) : (
         <ScrollArea className="min-h-0 flex-1">
           <Table>
@@ -102,7 +71,6 @@ export function LogList() {
             </TableHeader>
             <TableBody>
               {logs.map((log, i) => {
-                const style = severityStyle[log.severityText] ?? defaultSeverity;
                 const hasTrace = !isZeroID(log.traceID);
                 return (
                   <Fragment key={i}>
@@ -115,12 +83,9 @@ export function LogList() {
                         {formatTimestamp(log.timestamp)}
                       </TableCell>
                       <TableCell>
-                        <span
-                          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${style.bg} ${style.text}`}
-                        >
-                          <span className={`h-1.5 w-1.5 rounded-full ${style.dot}`} />
+                        <Pill tone={severityTone(log.severityText)} dot>
                           {log.severityText || "UNSET"}
-                        </span>
+                        </Pill>
                       </TableCell>
                       <TableCell className="font-medium">{log.serviceName || "-"}</TableCell>
                       <TableCell className="max-w-[400px] truncate text-sm text-foreground/80">
@@ -158,7 +123,7 @@ export function LogList() {
           </Table>
         </ScrollArea>
       )}
-    </div>
+    </ListPanel>
   );
 }
 

--- a/frontend/src/components/metrics/metric-detail.tsx
+++ b/frontend/src/components/metrics/metric-detail.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
-import { X } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { selectedMetricAtom } from "@/stores/telemetry";
 import { MetricChart, attrKey } from "./metric-chart";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { DetailPanel } from "@/components/common/detail-panel";
+import { Pill } from "@/components/common/pill";
 
 export function MetricDetail() {
   const metric = useAtomValue(selectedMetricAtom);
@@ -18,28 +18,17 @@ export function MetricDetail() {
   if (!metric) return null;
 
   return (
-    <div className="glass-card animate-fade-in flex h-full flex-col overflow-hidden">
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-border/50 px-4 py-2.5">
-        <div className="flex items-center gap-3">
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={() => setSelected(null)}
-            className="text-muted-foreground hover:text-foreground"
-          >
-            <X className="h-4 w-4" />
-          </Button>
+    <DetailPanel
+      onClose={() => setSelected(null)}
+      header={
+        <>
           <span className="font-semibold text-foreground">{metric.name}</span>
-          <span className="rounded-full bg-metric/15 px-2 py-0.5 text-[11px] font-medium text-metric">
-            {metric.type}
-          </span>
+          <Pill tone="metric">{metric.type}</Pill>
           {metric.unit && <span className="text-xs text-muted-foreground">({metric.unit})</span>}
           <span className="text-xs text-muted-foreground">{metric.serviceName}</span>
-        </div>
-      </div>
-
-      {/* Content */}
+        </>
+      }
+    >
       <ScrollArea className="flex-1">
         <div className="p-4">
           {metric.description && (
@@ -102,6 +91,6 @@ export function MetricDetail() {
           )}
         </div>
       </ScrollArea>
-    </div>
+    </DetailPanel>
   );
 }

--- a/frontend/src/components/metrics/metric-list.tsx
+++ b/frontend/src/components/metrics/metric-list.tsx
@@ -4,7 +4,8 @@ import { metricsAtom, selectedMetricAtom } from "@/stores/telemetry";
 import { filteredMetricsAtom, metricSearchAtom } from "@/stores/filters";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { SearchFilter } from "@/components/filters/search-filter";
-import { ListToolbar } from "@/components/filters/list-toolbar";
+import { ListPanel } from "@/components/common/list-panel";
+import { EmptyMatches } from "@/components/common/empty-state";
 import {
   Table,
   TableBody,
@@ -15,6 +16,9 @@ import {
 } from "@/components/ui/table";
 import { formatRelativeTime } from "@/lib/format";
 import { MetricDetail } from "./metric-detail";
+import { EmptyState } from "@/components/common/empty-state";
+import { Pill } from "@/components/common/pill";
+import { SIGNALS } from "@/lib/signals";
 
 export function MetricList() {
   const allMetrics = useAtomValue(metricsAtom);
@@ -31,40 +35,13 @@ export function MetricList() {
   }
 
   if (allMetrics.length === 0) {
-    return (
-      <div className="glass-card flex h-full items-center justify-center">
-        <div className="animate-slide-up-fade flex flex-col items-center gap-4">
-          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-metric/10">
-            <svg
-              width="28"
-              height="28"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="var(--metric)"
-              strokeWidth="1.5"
-            >
-              <path d="M3 3v18h18" />
-              <path d="M7 16l4-8 4 4 6-10" />
-            </svg>
-          </div>
-          <div className="text-center">
-            <p className="text-sm font-medium text-foreground/70">No metrics yet</p>
-            <p className="mt-1 text-xs text-muted-foreground">Send OTLP data to see them here</p>
-          </div>
-        </div>
-      </div>
-    );
+    return <EmptyState signal={SIGNALS.metrics} />;
   }
 
   return (
-    <div className="glass-card flex h-full flex-col overflow-hidden">
-      <ListToolbar>
-        <SearchFilter atom={metricSearchAtom} placeholder="Search metrics..." />
-      </ListToolbar>
+    <ListPanel toolbar={<SearchFilter atom={metricSearchAtom} placeholder="Search metrics..." />}>
       {metrics.length === 0 ? (
-        <div className="flex flex-1 items-center justify-center">
-          <p className="text-sm text-muted-foreground">No matching metrics</p>
-        </div>
+        <EmptyMatches label="metrics" />
       ) : (
         <ScrollArea className="min-h-0 flex-1">
           <Table>
@@ -96,9 +73,7 @@ export function MetricList() {
                       {metric.description || "-"}
                     </TableCell>
                     <TableCell>
-                      <span className="rounded-full bg-metric/15 px-2 py-0.5 text-[11px] font-medium text-metric">
-                        {metric.type}
-                      </span>
+                      <Pill tone="metric">{metric.type}</Pill>
                     </TableCell>
                     <TableCell className="text-muted-foreground">{metric.unit || "-"}</TableCell>
                     <TableCell className="text-right font-mono text-xs">
@@ -117,6 +92,6 @@ export function MetricList() {
           </Table>
         </ScrollArea>
       )}
-    </div>
+    </ListPanel>
   );
 }

--- a/frontend/src/components/traces/trace-detail.tsx
+++ b/frontend/src/components/traces/trace-detail.tsx
@@ -8,6 +8,8 @@ import { formatDuration, shortID } from "@/lib/format";
 import { downloadJson } from "@/lib/export";
 import { SpanWaterfall } from "./span-waterfall";
 import { KVSection } from "@/components/ui/kv-section";
+import { DetailPanel } from "@/components/common/detail-panel";
+import { Pill } from "@/components/common/pill";
 import type { SpanData } from "@/types/telemetry";
 import { useState } from "react";
 
@@ -20,28 +22,20 @@ export function TraceDetail() {
   if (!trace) return null;
 
   return (
-    <div className="glass-card animate-fade-in flex h-full flex-col overflow-hidden">
-      {/* Header bar */}
-      <div className="flex items-center justify-between border-b border-border/50 px-4 py-2.5">
-        <div className="flex items-center gap-3">
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={() => setSelected(null)}
-            className="text-muted-foreground hover:text-foreground"
-          >
-            <X className="h-4 w-4" />
-          </Button>
+    <DetailPanel
+      onClose={() => setSelected(null)}
+      header={
+        <>
           <span className="font-semibold text-foreground">
             {trace.rootSpan?.name ?? trace.spans[0]?.name}
           </span>
           <span className="font-mono text-xs text-muted-foreground">{shortID(trace.traceID)}</span>
-          <span className="rounded-full bg-trace/15 px-2 py-0.5 text-[11px] font-medium text-trace">
-            {trace.spanCount} spans
-          </span>
+          <Pill tone="trace">{trace.spanCount} spans</Pill>
           <span className="font-mono text-xs text-trace">{formatDuration(trace.duration)}</span>
-        </div>
-        <div className="flex items-center gap-1">
+        </>
+      }
+      actions={
+        <>
           <CopyJsonButton data={trace} />
           <Button
             variant="ghost"
@@ -62,10 +56,9 @@ export function TraceDetail() {
             <FileText className="h-3.5 w-3.5" />
             Logs
           </Button>
-        </div>
-      </div>
-
-      {/* Content */}
+        </>
+      }
+    >
       <div className="flex flex-1 overflow-hidden">
         <div className="flex-1 overflow-hidden">
           <SpanWaterfall trace={trace} onSelectSpan={setSelectedSpan} selectedSpan={selectedSpan} />
@@ -76,7 +69,7 @@ export function TraceDetail() {
           </div>
         )}
       </div>
-    </div>
+    </DetailPanel>
   );
 }
 

--- a/frontend/src/components/traces/trace-list.tsx
+++ b/frontend/src/components/traces/trace-list.tsx
@@ -5,7 +5,8 @@ import { tracesAtom, selectedTraceAtom } from "@/stores/telemetry";
 import { filteredTracesAtom, traceSearchAtom } from "@/stores/filters";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { SearchFilter } from "@/components/filters/search-filter";
-import { ListToolbar } from "@/components/filters/list-toolbar";
+import { ListPanel } from "@/components/common/list-panel";
+import { EmptyMatches } from "@/components/common/empty-state";
 import { ServiceMap } from "./service-map";
 import {
   Table,
@@ -17,6 +18,10 @@ import {
 } from "@/components/ui/table";
 import { formatDuration, formatRelativeTime, shortID } from "@/lib/format";
 import { TraceDetail } from "./trace-detail";
+import { EmptyState } from "@/components/common/empty-state";
+import { Pill } from "@/components/common/pill";
+import { SIGNALS } from "@/lib/signals";
+import { traceStatusTone } from "@/lib/tones";
 
 export function TraceList() {
   const allTraces = useAtomValue(tracesAtom);
@@ -30,61 +35,41 @@ export function TraceList() {
   }
 
   if (allTraces.length === 0) {
-    return (
-      <div className="glass-card flex h-full items-center justify-center">
-        <div className="animate-slide-up-fade flex flex-col items-center gap-4">
-          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-trace/10">
-            <svg
-              width="28"
-              height="28"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="var(--trace)"
-              strokeWidth="1.5"
-            >
-              <path d="M3 12h4l3-9 4 18 3-9h4" />
-            </svg>
-          </div>
-          <div className="text-center">
-            <p className="text-sm font-medium text-foreground/70">No traces yet</p>
-            <p className="mt-1 text-xs text-muted-foreground">Send OTLP data to see them here</p>
-          </div>
-        </div>
-      </div>
-    );
+    return <EmptyState signal={SIGNALS.traces} />;
   }
 
   return (
-    <div className="glass-card flex h-full flex-col overflow-hidden">
-      <ListToolbar>
-        <SearchFilter atom={traceSearchAtom} placeholder="Search traces..." />
-        <div className="ml-auto flex items-center gap-1 px-3">
-          <button
-            type="button"
-            onClick={() => setView("list")}
-            className={`rounded p-1 transition-colors ${view === "list" ? "bg-trace/15 text-trace" : "text-muted-foreground hover:text-foreground"}`}
-            title="List view"
-          >
-            <List className="h-3.5 w-3.5" />
-          </button>
-          <button
-            type="button"
-            onClick={() => setView("map")}
-            className={`rounded p-1 transition-colors ${view === "map" ? "bg-trace/15 text-trace" : "text-muted-foreground hover:text-foreground"}`}
-            title="Service map"
-          >
-            <Network className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      </ListToolbar>
+    <ListPanel
+      toolbar={
+        <>
+          <SearchFilter atom={traceSearchAtom} placeholder="Search traces..." />
+          <div className="ml-auto flex items-center gap-1 px-3">
+            <button
+              type="button"
+              onClick={() => setView("list")}
+              className={`rounded p-1 transition-colors ${view === "list" ? "bg-trace/15 text-trace" : "text-muted-foreground hover:text-foreground"}`}
+              title="List view"
+            >
+              <List className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setView("map")}
+              className={`rounded p-1 transition-colors ${view === "map" ? "bg-trace/15 text-trace" : "text-muted-foreground hover:text-foreground"}`}
+              title="Service map"
+            >
+              <Network className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </>
+      }
+    >
       {view === "map" ? (
         <div className="min-h-0 flex-1">
           <ServiceMap />
         </div>
       ) : traces.length === 0 ? (
-        <div className="flex flex-1 items-center justify-center">
-          <p className="text-sm text-muted-foreground">No matching traces</p>
-        </div>
+        <EmptyMatches label="traces" />
       ) : (
         <ScrollArea className="min-h-0 flex-1">
           <Table>
@@ -126,7 +111,9 @@ export function TraceList() {
                       {formatRelativeTime(trace.startTime)}
                     </TableCell>
                     <TableCell>
-                      <StatusBadge status={status} />
+                      <Pill tone={traceStatusTone(status)} dot>
+                        {status === "Unset" ? "Unset" : status}
+                      </Pill>
                     </TableCell>
                   </TableRow>
                 );
@@ -135,29 +122,6 @@ export function TraceList() {
           </Table>
         </ScrollArea>
       )}
-    </div>
-  );
-}
-
-function StatusBadge({ status }: { status: string }) {
-  if (status === "Ok")
-    return (
-      <span className="inline-flex items-center gap-1 rounded-full bg-success/15 px-2 py-0.5 text-[11px] font-medium text-success">
-        <span className="h-1.5 w-1.5 rounded-full bg-success" />
-        Ok
-      </span>
-    );
-  if (status === "Error")
-    return (
-      <span className="inline-flex items-center gap-1 rounded-full bg-destructive/15 px-2 py-0.5 text-[11px] font-medium text-destructive">
-        <span className="h-1.5 w-1.5 rounded-full bg-destructive" />
-        Error
-      </span>
-    );
-  return (
-    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-      <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/40" />
-      Unset
-    </span>
+    </ListPanel>
   );
 }

--- a/frontend/src/hooks/use-initial-load.ts
+++ b/frontend/src/hooks/use-initial-load.ts
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import { useSetAtom } from "jotai";
+import {
+  setTracesAtom,
+  setMetricsAtom,
+  setLogsAtom,
+  serverConfigAtom,
+  type ServerConfig,
+} from "@/stores/telemetry";
+import type { TraceData, MetricData, LogData } from "@/types/telemetry";
+
+// useInitialLoad fetches /api/config and then traces/metrics/logs once on
+// mount, seeding the Jotai store so the UI has data before the WebSocket
+// starts streaming deltas. Failures are swallowed — the WebSocket hook will
+// deliver data later.
+export function useInitialLoad() {
+  const setTraces = useSetAtom(setTracesAtom);
+  const setMetrics = useSetAtom(setMetricsAtom);
+  const setLogs = useSetAtom(setLogsAtom);
+  const setConfig = useSetAtom(serverConfigAtom);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const cfgRes = await fetch("/api/config");
+        const cfg: ServerConfig = await cfgRes.json();
+        setConfig(cfg);
+
+        const [tRes, mRes, lRes] = await Promise.all([
+          fetch(`/api/traces?limit=${cfg.traceCap}`),
+          fetch(`/api/metrics?limit=${cfg.metricCap}`),
+          fetch(`/api/logs?limit=${cfg.logCap}`),
+        ]);
+        const [traces, metrics, logs] = (await Promise.all([
+          tRes.json(),
+          mRes.json(),
+          lRes.json(),
+        ])) as [{ data: TraceData[] }, { data: MetricData[] }, { data: LogData[] }];
+        setTraces(traces.data);
+        setMetrics(metrics.data);
+        setLogs(logs.data);
+      } catch {
+        // WebSocket will deliver data later.
+      }
+    };
+    void load();
+  }, [setTraces, setMetrics, setLogs, setConfig]);
+}

--- a/frontend/src/lib/signals.ts
+++ b/frontend/src/lib/signals.ts
@@ -1,0 +1,91 @@
+export type SignalKey = "traces" | "metrics" | "logs";
+
+// Signal-specific Tailwind class literals. Tailwind v4 scans source files for
+// exact class tokens, so we keep all combinations here as plain strings.
+// Using `bg-${token}/10` at call sites would fail to produce the class.
+export interface SignalClasses {
+  bgLight: string; // bg-{token}/10
+  bgMedium: string; // bg-{token}/15
+  text: string; // text-{token}
+  textMuted: string; // text-{token}/70
+  hoverBgFaint: string; // hover:bg-{token}/5
+}
+
+export interface SignalConfig {
+  key: SignalKey;
+  label: string;
+  singular: string;
+  // Tailwind color token. Used for constructing class names; the actual
+  // literals live in `classes`.
+  token: "trace" | "metric" | "log";
+  classes: SignalClasses;
+  // Matching CSS custom property for the signal's accent color, usable as `stroke`.
+  cssVar: "--trace" | "--metric" | "--log";
+  // Short label used in compact counters (header badge).
+  shortLabel: string;
+  // SVG path string for the decorative icon used in empty states. Intentionally
+  // simple so it renders at any size with currentColor / CSS var strokes.
+  iconPaths: string[];
+  // Empty-state copy.
+  emptyTitle: string;
+  emptyHint: string;
+}
+
+export const SIGNALS: Record<SignalKey, SignalConfig> = {
+  traces: {
+    key: "traces",
+    label: "Traces",
+    singular: "trace",
+    token: "trace",
+    classes: {
+      bgLight: "bg-trace/10",
+      bgMedium: "bg-trace/15",
+      text: "text-trace",
+      textMuted: "text-trace/70",
+      hoverBgFaint: "hover:bg-trace/5",
+    },
+    cssVar: "--trace",
+    shortLabel: "T",
+    iconPaths: ["M3 12h4l3-9 4 18 3-9h4"],
+    emptyTitle: "No traces yet",
+    emptyHint: "Send OTLP data to see them here",
+  },
+  metrics: {
+    key: "metrics",
+    label: "Metrics",
+    singular: "metric",
+    token: "metric",
+    classes: {
+      bgLight: "bg-metric/10",
+      bgMedium: "bg-metric/15",
+      text: "text-metric",
+      textMuted: "text-metric/70",
+      hoverBgFaint: "hover:bg-metric/5",
+    },
+    cssVar: "--metric",
+    shortLabel: "M",
+    iconPaths: ["M3 3v18h18", "M7 16l4-8 4 4 6-10"],
+    emptyTitle: "No metrics yet",
+    emptyHint: "Send OTLP data to see them here",
+  },
+  logs: {
+    key: "logs",
+    label: "Logs",
+    singular: "log",
+    token: "log",
+    classes: {
+      bgLight: "bg-log/10",
+      bgMedium: "bg-log/15",
+      text: "text-log",
+      textMuted: "text-log/70",
+      hoverBgFaint: "hover:bg-log/5",
+    },
+    cssVar: "--log",
+    shortLabel: "L",
+    iconPaths: ["M4 6h16M4 12h16M4 18h10"],
+    emptyTitle: "No logs yet",
+    emptyHint: "Send OTLP data to see them here",
+  },
+};
+
+export const SIGNAL_LIST: SignalConfig[] = [SIGNALS.traces, SIGNALS.metrics, SIGNALS.logs];

--- a/frontend/src/lib/tones.test.ts
+++ b/frontend/src/lib/tones.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { severityTone, traceStatusTone } from "./tones";
+
+describe("traceStatusTone", () => {
+  it("maps Ok to success", () => {
+    expect(traceStatusTone("Ok")).toBe("success");
+  });
+  it("maps Error to destructive", () => {
+    expect(traceStatusTone("Error")).toBe("destructive");
+  });
+  it("maps unknown/unset values to muted", () => {
+    expect(traceStatusTone("Unset")).toBe("muted");
+    expect(traceStatusTone("")).toBe("muted");
+    expect(traceStatusTone("weird")).toBe("muted");
+  });
+});
+
+describe("severityTone", () => {
+  it("maps INFO to primary", () => {
+    expect(severityTone("INFO")).toBe("primary");
+  });
+  it("maps WARN to warning", () => {
+    expect(severityTone("WARN")).toBe("warning");
+  });
+  it("maps ERROR and FATAL to destructive", () => {
+    expect(severityTone("ERROR")).toBe("destructive");
+    expect(severityTone("FATAL")).toBe("destructive");
+  });
+  it("maps TRACE/DEBUG and unknown values to muted", () => {
+    expect(severityTone("TRACE")).toBe("muted");
+    expect(severityTone("DEBUG")).toBe("muted");
+    expect(severityTone("")).toBe("muted");
+    expect(severityTone(undefined)).toBe("muted");
+    expect(severityTone("WHAT")).toBe("muted");
+  });
+});

--- a/frontend/src/lib/tones.ts
+++ b/frontend/src/lib/tones.ts
@@ -1,0 +1,40 @@
+// Tone names used by the shared Pill component. Each tone maps to a fixed set
+// of Tailwind color classes defined in components/common/pill.tsx. Keep this
+// list small — reuse existing tones before adding new ones.
+export type Tone =
+  | "success"
+  | "destructive"
+  | "warning"
+  | "primary"
+  | "muted"
+  | "trace"
+  | "metric"
+  | "log";
+
+// traceStatusTone maps a span/trace OTel status code to a Pill tone.
+export function traceStatusTone(status: string): Tone {
+  switch (status) {
+    case "Ok":
+      return "success";
+    case "Error":
+      return "destructive";
+    default:
+      return "muted";
+  }
+}
+
+// severityTone maps an OTel log severity text to a Pill tone. Unknown or
+// absent severities fall back to muted so the UI stays quiet.
+export function severityTone(severity: string | undefined): Tone {
+  switch (severity) {
+    case "INFO":
+      return "primary";
+    case "WARN":
+      return "warning";
+    case "ERROR":
+    case "FATAL":
+      return "destructive";
+    default:
+      return "muted";
+  }
+}


### PR DESCRIPTION
## Summary
- `lib/signals.ts` is the single source of truth for trace/metric/log config — token, CSS accent var, icon paths, empty-state copy, and Tailwind class literals (v4 scanner can't resolve dynamic interpolation, so all combinations are kept as strings).
- `lib/tones.ts` adds the `Tone` type plus `severityTone` / `traceStatusTone` helpers, covered by unit tests.
- `components/common/` gains `EmptyState` + `EmptyMatches`, `SignalIcon`, `Pill`, `ListPanel` (glass-card shell + toolbar), and `DetailPanel` (close + header/actions bar).
- The three signal list/detail pages drop their copy-pasted shells and inline status/severity/type badges in favor of the new primitives; header counter badges pull classes from the signal config.
- `App.tsx` initial fetch moves into a dedicated `useInitialLoad` hook, and tabs iterate `SIGNAL_LIST` instead of hand-rolled triggers.

## Test plan
- [x] `mise run check`
- [x] `mise run test` (Go + frontend, 31 frontend tests pass including new `tones.test.ts`)
- [x] Manual check in the browser: empty states, list/detail shells, tab colors, header counters, reload after data is loaded.