### PR TITLE
fix(store): return empty slice from RingBuffer.Page when empty

### DIFF
--- a/internal/store/ringbuffer_test.go
+++ b/internal/store/ringbuffer_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -51,7 +52,7 @@ func TestRingBuffer_Page(t *testing.T) {
 		{"all newest first", 0, 0, []int{5, 4, 3, 2, 1}, 5},
 		{"limit 2 from newest", 0, 2, []int{5, 4}, 5},
 		{"offset 2 limit 2", 2, 2, []int{3, 2}, 5},
-		{"offset past end", 10, 5, nil, 5},
+		{"offset past end", 10, 5, []int{}, 5},
 		{"offset 4 limit 10", 4, 10, []int{1}, 5},
 		{"negative offset treated as 0", -5, 1, []int{5}, 5},
 	}
@@ -97,8 +98,25 @@ func TestRingBuffer_Page_Empty(t *testing.T) {
 	if total != 0 {
 		t.Errorf("total = %d, want 0", total)
 	}
-	if items != nil {
-		t.Errorf("items = %v, want nil", items)
+	// The slice must be non-nil so JSON API responses marshal to [] not null;
+	// the frontend assumes `data` is always an array.
+	if items == nil {
+		t.Fatal("items should be empty slice, not nil")
+	}
+	if len(items) != 0 {
+		t.Errorf("items = %v, want empty", items)
+	}
+}
+
+func TestRingBuffer_Page_Empty_MarshalsToArray(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+	items, _ := rb.Page(0, 0)
+	encoded, err := json.Marshal(items)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if string(encoded) != "[]" {
+		t.Errorf("json = %s, want []", encoded)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -284,15 +284,16 @@ func (rb *RingBuffer[T]) Items() []T {
 
 // Page returns up to `limit` items starting at `offset` counted from the newest.
 // When limit == 0, all items from offset to the end are returned. `total` is the
-// total number of items currently stored. The returned slice never aliases the
-// underlying buffer.
+// total number of items currently stored. The returned slice is always non-nil
+// (empty when there is nothing to return) so JSON-marshaled API responses emit
+// `[]` rather than `null`, and never aliases the underlying buffer.
 func (rb *RingBuffer[T]) Page(offset, limit int) (items []T, total int) {
 	total = rb.count
 	if offset < 0 {
 		offset = 0
 	}
 	if offset >= total {
-		return nil, total
+		return []T{}, total
 	}
 	end := total
 	if limit > 0 && offset+limit < end {


### PR DESCRIPTION
## Summary
`RingBuffer.Page(offset, limit)` took an early `return nil, total` when the buffer was empty (or the offset was past the end). A nil Go slice JSON-marshals to `null`, so `/api/traces`, `/api/metrics`, and `/api/logs` started returning `{"data": null, ...}` on a fresh backend.

That silently broke the frontend on startup: `useInitialLoad` called `setTracesAtom(null)`, and the next render of `traceCountAtom` (via the header counter) tried to read `null.length` and crashed.

Fix: always return a non-nil empty slice from the early-return path. Added a JSON marshal test so this regression can't come back silently.

## Test plan
- [x] `mise run check`
- [x] `mise run test` (Go + frontend)
- [x] `TestRingBuffer_Page_Empty` and the new `TestRingBuffer_Page_Empty_MarshalsToArray` pin the invariant.
- [x] Reload the UI with an empty backend store — header + list views should render without the `Cannot read properties of null` crash.