### PR TITLE
refactor(frontend): move WebSocket lifecycle into a module-level manager

### DIFF
--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -1,97 +1,37 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect } from "react";
 import { useSetAtom } from "jotai";
 import { addTraceAtom, addMetricAtom, addLogAtom, wsStatusAtom } from "@/stores/telemetry";
-import type { TraceData, MetricData, LogData, WsMessage } from "@/types/telemetry";
+import type { TraceData, MetricData, LogData } from "@/types/telemetry";
+import { wsManager } from "@/lib/websocket-manager";
 
-const MAX_RECONNECT_DELAY = 30_000;
-const INITIAL_RECONNECT_DELAY = 1_000;
-
-function getWsUrl(): string {
-  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
-  return `${proto}//${window.location.host}/ws`;
-}
-
+// useWebSocket is a thin adapter that bridges the module-level WsManager to
+// this component's jotai atoms. The actual WebSocket lifecycle (connect,
+// reconnect, teardown) lives in WsManager — keeping it out of React means
+// Strict Mode's double-invoke effect cycle no longer creates-then-closes a
+// fresh socket on every mount.
 export function useWebSocket(): void {
   const setWsStatus = useSetAtom(wsStatusAtom);
   const addTrace = useSetAtom(addTraceAtom);
   const addMetric = useSetAtom(addMetricAtom);
   const addLog = useSetAtom(addLogAtom);
 
-  const wsRef = useRef<WebSocket | null>(null);
-  const reconnectDelayRef = useRef(INITIAL_RECONNECT_DELAY);
-  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const mountIdRef = useRef(0);
-
-  const connect = useCallback(
-    (mountId: number) => {
-      if (mountIdRef.current !== mountId) return;
-
-      if (wsRef.current) {
-        wsRef.current.close();
-      }
-
-      setWsStatus("connecting");
-      const ws = new WebSocket(getWsUrl());
-      wsRef.current = ws;
-
-      ws.onopen = () => {
-        if (mountIdRef.current !== mountId) {
-          ws.close();
-          return;
-        }
-        setWsStatus("connected");
-        reconnectDelayRef.current = INITIAL_RECONNECT_DELAY;
-      };
-
-      ws.onmessage = (event: MessageEvent) => {
-        if (mountIdRef.current !== mountId) return;
-        try {
-          const msg: WsMessage = JSON.parse(event.data as string);
-          switch (msg.type) {
-            case "traces":
-              addTrace(msg.data as TraceData);
-              break;
-            case "metrics":
-              addMetric(msg.data as MetricData);
-              break;
-            case "logs":
-              addLog(msg.data as LogData);
-              break;
-          }
-        } catch {
-          // ignore parse errors
-        }
-      };
-
-      ws.onclose = () => {
-        if (mountIdRef.current !== mountId) return;
-        setWsStatus("disconnected");
-        wsRef.current = null;
-        const delay = reconnectDelayRef.current;
-        reconnectTimerRef.current = setTimeout(() => {
-          reconnectDelayRef.current = Math.min(delay * 2, MAX_RECONNECT_DELAY);
-          connect(mountId);
-        }, delay);
-      };
-
-      ws.onerror = () => {
-        // onclose will fire after this
-      };
-    },
-    [setWsStatus, addTrace, addMetric, addLog],
-  );
-
   useEffect(() => {
-    const mountId = ++mountIdRef.current;
-    connect(mountId);
-    return () => {
-      mountIdRef.current = -1;
-      clearTimeout(reconnectTimerRef.current);
-      const ws = wsRef.current;
-      if (ws) {
-        wsRef.current = null;
-        ws.close();
-      }
-    };
-  }, [connect]);
+    const unsubscribe = wsManager.subscribe({
+      onStatus: setWsStatus,
+      onMessage: (msg) => {
+        switch (msg.type) {
+          case "traces":
+            addTrace(msg.data as TraceData);
+            break;
+          case "metrics":
+            addMetric(msg.data as MetricData);
+            break;
+          case "logs":
+            addLog(msg.data as LogData);
+            break;
+        }
+      },
+    });
+    return unsubscribe;
+  }, [setWsStatus, addTrace, addMetric, addLog]);
 }

--- a/frontend/src/lib/websocket-manager.test.ts
+++ b/frontend/src/lib/websocket-manager.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { WsManager } from "./websocket-manager";
+import type { WsMessage } from "@/types/telemetry";
+import type { WsStatus } from "@/stores/telemetry";
+
+// Minimal mock that emulates just enough of the browser WebSocket interface
+// for WsManager. Each instance records its event handlers so tests can
+// manually drive open/message/close.
+class MockSocket {
+  static instances: MockSocket[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = 0; // CONNECTING
+  closed = false;
+
+  constructor() {
+    MockSocket.instances.push(this);
+  }
+
+  close = vi.fn(() => {
+    this.closed = true;
+    this.readyState = 3; // CLOSED
+  });
+
+  // Test-only helpers:
+  simulateOpen() {
+    this.readyState = 1; // OPEN
+    this.onopen?.();
+  }
+  simulateMessage(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+  simulateClose() {
+    this.readyState = 3;
+    this.onclose?.();
+  }
+}
+
+// The manager reads WebSocket.CONNECTING / WebSocket.OPEN on the global.
+// Polyfill the constants so the code under test compares against real ints.
+beforeEach(() => {
+  vi.stubGlobal("WebSocket", {
+    CONNECTING: 0,
+    OPEN: 1,
+    CLOSING: 2,
+    CLOSED: 3,
+  });
+  MockSocket.instances = [];
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+function newManager() {
+  return new WsManager({
+    createSocket: () => new MockSocket() as unknown as WebSocket,
+    initialReconnectDelay: 100,
+    maxReconnectDelay: 1_000,
+  });
+}
+
+describe("WsManager.subscribe", () => {
+  it("creates a socket only on the first subscriber", () => {
+    const mgr = newManager();
+    const unsub1 = mgr.subscribe({ onMessage: vi.fn(), onStatus: vi.fn() });
+    expect(MockSocket.instances).toHaveLength(1);
+
+    const unsub2 = mgr.subscribe({ onMessage: vi.fn(), onStatus: vi.fn() });
+    expect(MockSocket.instances).toHaveLength(1); // still one — shared
+
+    unsub1();
+    unsub2();
+  });
+
+  it("seeds new subscribers with the current status", () => {
+    const mgr = newManager();
+    const onStatus1 = vi.fn<(s: WsStatus) => void>();
+    mgr.subscribe({ onMessage: vi.fn(), onStatus: onStatus1 });
+    expect(onStatus1).toHaveBeenCalledWith("connecting");
+
+    MockSocket.instances[0].simulateOpen();
+
+    const onStatus2 = vi.fn<(s: WsStatus) => void>();
+    mgr.subscribe({ onMessage: vi.fn(), onStatus: onStatus2 });
+    expect(onStatus2).toHaveBeenCalledWith("connected");
+  });
+
+  it("fans out messages to every subscriber", () => {
+    const mgr = newManager();
+    const a = vi.fn<(m: WsMessage) => void>();
+    const b = vi.fn<(m: WsMessage) => void>();
+    mgr.subscribe({ onMessage: a, onStatus: vi.fn() });
+    mgr.subscribe({ onMessage: b, onStatus: vi.fn() });
+
+    MockSocket.instances[0].simulateOpen();
+    MockSocket.instances[0].simulateMessage({
+      type: "traces",
+      data: { traceID: "t1" },
+    });
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(a.mock.calls[0][0]).toEqual({ type: "traces", data: { traceID: "t1" } });
+  });
+
+  it("ignores unparseable messages", () => {
+    const mgr = newManager();
+    const onMessage = vi.fn();
+    mgr.subscribe({ onMessage, onStatus: vi.fn() });
+    const sock = MockSocket.instances[0];
+    sock.simulateOpen();
+
+    // Directly deliver garbage; parse should swallow the error.
+    sock.onmessage?.({ data: "not json" } as MessageEvent);
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("WsManager.unsubscribe", () => {
+  it("keeps the socket alive when a new subscriber arrives before the deferred disconnect fires (Strict Mode remount)", () => {
+    const mgr = newManager();
+    const unsub = mgr.subscribe({ onMessage: vi.fn(), onStatus: vi.fn() });
+    expect(MockSocket.instances).toHaveLength(1);
+    const sock = MockSocket.instances[0];
+
+    unsub();
+    // Simulates React Strict Mode immediately re-subscribing on remount.
+    mgr.subscribe({ onMessage: vi.fn(), onStatus: vi.fn() });
+
+    // Advance all timers: the pending disconnect should have been cancelled.
+    vi.runAllTimers();
+
+    expect(sock.close).not.toHaveBeenCalled();
+    expect(MockSocket.instances).toHaveLength(1);
+  });
+
+  it("tears down the socket after the deferred window if no subscriber returns", () => {
+    const mgr = newManager();
+    const unsub = mgr.subscribe({ onMessage: vi.fn(), onStatus: vi.fn() });
+    const sock = MockSocket.instances[0];
+    sock.simulateOpen();
+
+    unsub();
+    // Defer tick.
+    vi.advanceTimersByTime(1);
+
+    expect(sock.close).toHaveBeenCalledTimes(1);
+    expect(mgr.subscriberCount).toBe(0);
+  });
+});
+
+describe("WsManager reconnect", () => {
+  it("reconnects after an unexpected close using exponential backoff", () => {
+    const mgr = newManager();
+    const onStatus = vi.fn<(s: WsStatus) => void>();
+    mgr.subscribe({ onMessage: vi.fn(), onStatus });
+    MockSocket.instances[0].simulateOpen();
+
+    // Server drops the connection.
+    MockSocket.instances[0].simulateClose();
+
+    // Disconnected status emitted.
+    expect(onStatus).toHaveBeenCalledWith("disconnected");
+
+    // First backoff delay = 100ms.
+    vi.advanceTimersByTime(100);
+    expect(MockSocket.instances).toHaveLength(2);
+
+    MockSocket.instances[1].simulateClose();
+    // Second delay doubles = 200ms.
+    vi.advanceTimersByTime(200);
+    expect(MockSocket.instances).toHaveLength(3);
+  });
+
+  it("does not reconnect once the last subscriber has left", () => {
+    const mgr = newManager();
+    const unsub = mgr.subscribe({ onMessage: vi.fn(), onStatus: vi.fn() });
+    MockSocket.instances[0].simulateOpen();
+    unsub();
+    vi.advanceTimersByTime(1); // fire deferred disconnect
+
+    // Advance well beyond the initial backoff to make sure no reconnect fires.
+    vi.advanceTimersByTime(5_000);
+    expect(MockSocket.instances).toHaveLength(1);
+  });
+});

--- a/frontend/src/lib/websocket-manager.ts
+++ b/frontend/src/lib/websocket-manager.ts
@@ -1,0 +1,172 @@
+import type { WsMessage } from "@/types/telemetry";
+import type { WsStatus } from "@/stores/telemetry";
+
+type MessageListener = (msg: WsMessage) => void;
+type StatusListener = (status: WsStatus) => void;
+
+export interface Subscriber {
+  onMessage: MessageListener;
+  onStatus: StatusListener;
+}
+
+export interface WsManagerOptions {
+  createSocket: () => WebSocket;
+  initialReconnectDelay?: number;
+  maxReconnectDelay?: number;
+}
+
+// WsManager owns the WebSocket lifecycle outside React so that Strict Mode's
+// double-invoke useEffect cycle doesn't create-then-tear-down a new socket on
+// every mount. React components subscribe through `subscribe()`, and the
+// manager connects on the first subscriber and disconnects a tick after the
+// last one leaves — giving Strict Mode's remount time to rescue the
+// connection without the browser printing "closed before connection
+// established" warnings.
+export class WsManager {
+  private ws: WebSocket | null = null;
+  private subscribers = new Set<Subscriber>();
+  private status: WsStatus = "disconnected";
+  private reconnectDelay: number;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private disconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly createSocket: () => WebSocket;
+  private readonly initialReconnectDelay: number;
+  private readonly maxReconnectDelay: number;
+
+  constructor(opts: WsManagerOptions) {
+    this.createSocket = opts.createSocket;
+    this.initialReconnectDelay = opts.initialReconnectDelay ?? 1_000;
+    this.maxReconnectDelay = opts.maxReconnectDelay ?? 30_000;
+    this.reconnectDelay = this.initialReconnectDelay;
+  }
+
+  subscribe(subscriber: Subscriber): () => void {
+    // If a deferred disconnect was pending from a previous unmount, cancel it
+    // — a new subscriber arrived in time to rescue the connection.
+    if (this.disconnectTimer !== null) {
+      clearTimeout(this.disconnectTimer);
+      this.disconnectTimer = null;
+    }
+
+    this.subscribers.add(subscriber);
+    // Seed the new subscriber with the current status so it doesn't start in
+    // a stale state.
+    subscriber.onStatus(this.status);
+
+    if (this.subscribers.size === 1 && !this.ws) {
+      this.connect();
+    }
+
+    return () => {
+      this.subscribers.delete(subscriber);
+      if (this.subscribers.size === 0) {
+        // Defer the actual disconnect by a tick so React Strict Mode's
+        // immediate remount (which unsubscribes then resubscribes within the
+        // same JS turn) doesn't cause us to tear down the socket we're about
+        // to need again.
+        this.disconnectTimer = setTimeout(() => {
+          this.disconnectTimer = null;
+          if (this.subscribers.size === 0) {
+            this.disconnect();
+          }
+        }, 0);
+      }
+    };
+  }
+
+  // For tests and diagnostics.
+  get subscriberCount(): number {
+    return this.subscribers.size;
+  }
+
+  private setStatus(status: WsStatus) {
+    this.status = status;
+    for (const sub of this.subscribers) {
+      sub.onStatus(status);
+    }
+  }
+
+  private connect() {
+    this.setStatus("connecting");
+    const ws = this.createSocket();
+    this.ws = ws;
+
+    ws.onopen = () => {
+      if (this.ws !== ws) return;
+      this.setStatus("connected");
+      this.reconnectDelay = this.initialReconnectDelay;
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      if (this.ws !== ws) return;
+      try {
+        const msg: WsMessage = JSON.parse(event.data as string);
+        for (const sub of this.subscribers) {
+          sub.onMessage(msg);
+        }
+      } catch {
+        // ignore parse errors
+      }
+    };
+
+    ws.onclose = () => {
+      if (this.ws !== ws) return;
+      this.ws = null;
+      this.setStatus("disconnected");
+      if (this.subscribers.size > 0) {
+        this.scheduleReconnect();
+      }
+    };
+
+    ws.onerror = () => {
+      // onclose will fire after this.
+    };
+  }
+
+  private scheduleReconnect() {
+    const delay = this.reconnectDelay;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.reconnectDelay = Math.min(delay * 2, this.maxReconnectDelay);
+      if (this.subscribers.size > 0 && !this.ws) {
+        this.connect();
+      }
+    }, delay);
+  }
+
+  private disconnect() {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    const ws = this.ws;
+    if (ws) {
+      this.ws = null;
+      // Detach listeners so an in-flight close event doesn't re-enter the
+      // manager after we've decided to disconnect.
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onerror = null;
+      ws.onclose = null;
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close();
+      }
+    }
+
+    this.setStatus("disconnected");
+    this.reconnectDelay = this.initialReconnectDelay;
+  }
+}
+
+function getWsUrl(): string {
+  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${proto}//${window.location.host}/ws`;
+}
+
+// Module-level singleton used by the React hook. The factory closure is
+// captured at import time so tests can construct their own WsManager with a
+// mock createSocket instead.
+export const wsManager = new WsManager({
+  createSocket: () => new WebSocket(getWsUrl()),
+});


### PR DESCRIPTION
## Summary
Strict Mode's dev-only double-invoke useEffect cycle meant every page load created a fresh WebSocket and closed it mid-handshake, producing a \`closed before connection established\` browser warning on every reload.

Root fix: pull the lifecycle out of React. \`WsManager\` (module-level singleton) owns the socket, reconnect backoff, and fan-out. \`useWebSocket\` becomes a thin subscribe adapter that pipes messages into the jotai atoms.

Key detail: the manager defers the actual disconnect by one macrotask after the last subscriber leaves, so Strict Mode's synchronous re-subscribe on remount cancels the pending disconnect before the socket is torn down.

## Test plan
- [x] \`mise run check\`
- [x] \`mise run test\` — 8 new unit tests using a mock WebSocket cover: first-subscriber connect, shared socket on subsequent subscribers, status seeding, message fan-out, Strict Mode remount rescue (cancelled deferred disconnect), deferred disconnect actually firing, reconnect exponential backoff, no reconnect after the last subscriber leaves.
- [x] Manual: dev server reload — no \`closed before connection established\` warning, header status transitions correctly, OTLP data streams in, reconnect works after bouncing the backend.