### PR TITLE
fix(metric-detail): make the outer scroll area actually scroll

### DIFF
--- a/frontend/src/components/metrics/metric-detail.tsx
+++ b/frontend/src/components/metrics/metric-detail.tsx
@@ -29,7 +29,7 @@ export function MetricDetail() {
         </>
       }
     >
-      <ScrollArea className="flex-1">
+      <ScrollArea className="min-h-0 flex-1">
         <div className="p-4">
           {metric.description && (
             <p className="mb-4 text-sm text-muted-foreground">{metric.description}</p>
@@ -48,7 +48,7 @@ export function MetricDetail() {
               <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
                 Data Points ({metric.dataPoints.length})
               </h4>
-              <div className="max-h-[200px] overflow-auto rounded-md border border-border/30 bg-muted/50">
+              <div className="max-h-[360px] overflow-auto rounded-md border border-border/30 bg-muted/50">
                 <table className="w-full text-xs">
                   <thead>
                     <tr className="border-b border-border/30">


### PR DESCRIPTION
## Summary
The metric detail panel's outer ScrollArea used `flex-1` only. Because flex items default to `min-height: auto`, its contents pushed past the DetailPanel shell and the whole panel stopped scrolling — the data points table got clipped at the bottom of the viewport with no way to reach it.

Fix: add `min-h-0` (the same pattern used by the trace list ScrollArea) so the ScrollArea can actually constrain and scroll its content. Also bump the inner data points table from `max-h-[200px]` to `max-h-[360px]` so more rows are visible before the user has to scroll within the table.

## Test plan
- [x] `mise run check`
- [x] `mise run test`
- [x] Manual: select a metric with many data points (e.g. `go.memory.type`) — outer ScrollArea scrolls chart + data points section, inner data points table shows ~13 rows before its own scroll kicks in.