### PR TITLE
ci(release-please): pin initial version to 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
     ".": {
       "release-type": "go",
       "package-name": "otelop",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "initial-version": "0.1.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

release-please's `BaseStrategy.initialReleaseVersion()` hardcodes `1.0.0` as the default first release when no prior tag exists ([source](https://github.com/googleapis/release-please/blob/main/src/strategies/base.ts)). PR #7 surfaced this by proposing v1.0.0.

Set `initial-version: "0.1.0"` in release-please config so the project stays pre-1.0 until the API is ready to stabilize.

## Test plan

- [x] CI passes

## After merge

release-please re-runs on main and opens a new release PR targeting v0.1.0.