### PR TITLE
chore(frontend): raise chunk size warning limit to 800kB

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   build: {
     outDir: "dist",
     emptyOutDir: true,
+    chunkSizeWarningLimit: 800,
   },
   server: {
     proxy: {


### PR DESCRIPTION
## Summary
- The single bundle is ~554kB (177kB gzip). For a SPA served from localhost via embedded FS, code-splitting adds latency without benefit, so just raise `chunkSizeWarningLimit` to silence the build warning.

## Test plan
- [x] `pnpm --filter otelop-frontend build` completes without the chunk-size warning