### PR TITLE
fix(store): skip non-finite metric data points

### DIFF
--- a/internal/store/metric.go
+++ b/internal/store/metric.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"log/slog"
+	"math"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -41,6 +43,14 @@ func ConvertMetrics(md pmetric.Metrics) []*MetricData {
 			sm := rm.ScopeMetrics().At(j)
 			for k := 0; k < sm.Metrics().Len(); k++ {
 				m := sm.Metrics().At(k)
+				points, skipped := extractDataPoints(m)
+				if skipped > 0 {
+					slog.Warn("store: skipped non-finite metric data points",
+						"metric", m.Name(),
+						"service", svcName,
+						"skipped", skipped,
+					)
+				}
 				metric := &MetricData{
 					Name:        m.Name(),
 					Description: m.Description(),
@@ -48,7 +58,7 @@ func ConvertMetrics(md pmetric.Metrics) []*MetricData {
 					Type:        m.Type().String(),
 					ServiceName: svcName,
 					Resource:    resource,
-					DataPoints:  extractDataPoints(m),
+					DataPoints:  points,
 					ReceivedAt:  time.Now(),
 				}
 				result = append(result, metric)
@@ -59,17 +69,20 @@ func ConvertMetrics(md pmetric.Metrics) []*MetricData {
 	return result
 }
 
-func extractDataPoints(m pmetric.Metric) []DataPoint {
-	var points []DataPoint
-
+func extractDataPoints(m pmetric.Metric) (points []DataPoint, skipped int) {
 	switch m.Type() {
 	case pmetric.MetricTypeGauge:
 		dps := m.Gauge().DataPoints()
 		for i := 0; i < dps.Len(); i++ {
 			dp := dps.At(i)
+			v := numberValue(dp)
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				skipped++
+				continue
+			}
 			points = append(points, DataPoint{
 				Timestamp:  dp.Timestamp().AsTime(),
-				Value:      numberValue(dp),
+				Value:      v,
 				Attributes: attributesToMap(dp.Attributes()),
 			})
 		}
@@ -77,9 +90,14 @@ func extractDataPoints(m pmetric.Metric) []DataPoint {
 		dps := m.Sum().DataPoints()
 		for i := 0; i < dps.Len(); i++ {
 			dp := dps.At(i)
+			v := numberValue(dp)
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				skipped++
+				continue
+			}
 			points = append(points, DataPoint{
 				Timestamp:  dp.Timestamp().AsTime(),
-				Value:      numberValue(dp),
+				Value:      v,
 				Attributes: attributesToMap(dp.Attributes()),
 			})
 		}
@@ -115,7 +133,7 @@ func extractDataPoints(m pmetric.Metric) []DataPoint {
 		}
 	}
 
-	return points
+	return points, skipped
 }
 
 func numberValue(dp pmetric.NumberDataPoint) float64 {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"encoding/json"
+	"math"
 	"testing"
 	"time"
 
@@ -266,6 +268,46 @@ func TestStore_AddMetrics_Merge(t *testing.T) {
 	}
 	if metrics[0].DataPoints[1].Value != 55.0 {
 		t.Errorf("expected second data point value 55.0, got %f", metrics[0].DataPoints[1].Value)
+	}
+}
+
+func TestConvertMetrics_SkipsNonFinite(t *testing.T) {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "test-svc")
+	sm := rm.ScopeMetrics().AppendEmpty()
+
+	gauge := sm.Metrics().AppendEmpty()
+	gauge.SetName("ratio.gauge")
+	gauge.SetEmptyGauge()
+	gauge.Gauge().DataPoints().AppendEmpty().SetDoubleValue(math.NaN())
+	gauge.Gauge().DataPoints().AppendEmpty().SetDoubleValue(math.Inf(1))
+	gauge.Gauge().DataPoints().AppendEmpty().SetDoubleValue(math.Inf(-1))
+	gauge.Gauge().DataPoints().AppendEmpty().SetDoubleValue(1.5)
+
+	sum := sm.Metrics().AppendEmpty()
+	sum.SetName("rate.sum")
+	sum.SetEmptySum()
+	sum.Sum().DataPoints().AppendEmpty().SetDoubleValue(math.NaN())
+
+	got := ConvertMetrics(md)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 metrics, got %d", len(got))
+	}
+
+	if len(got[0].DataPoints) != 1 {
+		t.Fatalf("expected 1 finite data point on gauge, got %d", len(got[0].DataPoints))
+	}
+	if got[0].DataPoints[0].Value != 1.5 {
+		t.Errorf("expected gauge value 1.5, got %f", got[0].DataPoints[0].Value)
+	}
+
+	if len(got[1].DataPoints) != 0 {
+		t.Errorf("expected sum to have all data points skipped, got %d", len(got[1].DataPoints))
+	}
+
+	if _, err := json.Marshal(got); err != nil {
+		t.Fatalf("expected sanitized metrics to be JSON-marshalable, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- 計装側が NaN / ±Inf を含む double 値の Gauge / Sum を送ってきたとき、`json.Marshal` が失敗して WebSocket ブロードキャストが丸ごとドロップしていた問題を修正
- `extractDataPoints` で該当データポイントだけスキップし、`MetricData` 自体は残して UI 上にメトリクス名が見えるようにした
- スキップ発生時は `slog.Warn` を 1 メトリクスにつき 1 回出して計装バグに気付けるようにした

## Test plan
- [x] `TestConvertMetrics_SkipsNonFinite` を追加し、NaN / ±Inf を含む Gauge / Sum を投入して有限値のみが残ること、結果が `json.Marshal` 可能であることを検証
- [x] `mise run check`
- [x] `mise run test`