### PR TITLE
fix(store): stringify non-finite double attributes

### DIFF
--- a/internal/store/attrs.go
+++ b/internal/store/attrs.go
@@ -1,6 +1,11 @@
 package store
 
-import "go.opentelemetry.io/collector/pdata/pcommon"
+import (
+	"math"
+	"strconv"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
 
 // attributesToMap converts pcommon.Map to a plain map[string]any.
 func attributesToMap(attrs pcommon.Map) map[string]any {
@@ -19,7 +24,13 @@ func valueToAny(v pcommon.Value) any {
 	case pcommon.ValueTypeInt:
 		return v.Int()
 	case pcommon.ValueTypeDouble:
-		return v.Double()
+		// encoding/json rejects NaN/±Inf, so fall back to a string so the
+		// original information survives without breaking the broadcast.
+		d := v.Double()
+		if math.IsNaN(d) || math.IsInf(d, 0) {
+			return strconv.FormatFloat(d, 'g', -1, 64)
+		}
+		return d
 	case pcommon.ValueTypeBool:
 		return v.Bool()
 	case pcommon.ValueTypeBytes:

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -311,6 +311,33 @@ func TestConvertMetrics_SkipsNonFinite(t *testing.T) {
 	}
 }
 
+func TestAttributesToMap_NonFiniteDoubles(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutDouble("nan", math.NaN())
+	attrs.PutDouble("pos_inf", math.Inf(1))
+	attrs.PutDouble("neg_inf", math.Inf(-1))
+	attrs.PutDouble("finite", 1.5)
+
+	got := attributesToMap(attrs)
+
+	if got["nan"] != "NaN" {
+		t.Errorf("nan: expected %q, got %v", "NaN", got["nan"])
+	}
+	if got["pos_inf"] != "+Inf" {
+		t.Errorf("pos_inf: expected %q, got %v", "+Inf", got["pos_inf"])
+	}
+	if got["neg_inf"] != "-Inf" {
+		t.Errorf("neg_inf: expected %q, got %v", "-Inf", got["neg_inf"])
+	}
+	if got["finite"] != 1.5 {
+		t.Errorf("finite: expected 1.5, got %v", got["finite"])
+	}
+
+	if _, err := json.Marshal(got); err != nil {
+		t.Fatalf("expected sanitized attributes to be JSON-marshalable, got %v", err)
+	}
+}
+
 func TestStore_AddMetrics_DifferentNames(t *testing.T) {
 	s := NewStore(10, 10, 10, 100, nil)
 


### PR DESCRIPTION
## Summary
- #19 はメトリクスのデータポイント値が NaN/±Inf な場合の対応だったが、span/log/metric の **属性** 側にも同じ問題があり、graphql-go 経由で `json: unsupported value: NaN` panic が発生していた
- `valueToAny` で `Double` 属性が非有限なら `strconv.FormatFloat` で文字列化（例: `"NaN"`, `"+Inf"`）。元の情報は保ちつつ JSON シリアライズ可能にする
- span 属性 / span event 属性 / log 属性 / metric data point 属性 / resource はすべて `attributesToMap` 経由なので一箇所の修正で全パスをカバー

## Test plan
- [x] `mise run check`
- [x] `mise run test`
- [x] `TestAttributesToMap_NonFiniteDoubles` を追加し、NaN/+Inf/-Inf/finite が正しく扱われ `json.Marshal` 可能であることを検証