### PR TITLE
feat(cli): load start defaults from TOML config and env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,30 @@ otelop version
 
 PID, log, and metadata files live in `$XDG_STATE_HOME/otelop/` (defaults to `~/.local/state/otelop/`).
 
+## Configuration
+
+Every `start` flag can be set three ways. Higher precedence wins:
+
+1. CLI flag (`otelop start --http :4319`)
+2. Environment variable (`OTELOP_HTTP=:4319 otelop start`)
+3. TOML config file at `$XDG_CONFIG_HOME/otelop/config.toml` (defaults to `~/.config/otelop/config.toml`; override with `OTELOP_CONFIG_FILE=/path/to/config.toml`)
+
+Example `~/.config/otelop/config.toml`:
+
+```toml
+http = ":4319"
+otlp_grpc = "0.0.0.0:4317"
+otlp_http = "0.0.0.0:4318"
+trace_cap = 1000
+metric_cap = 3000
+log_cap = 1000
+max_data_points = 1000
+log_level = "warn"
+debug = false
+```
+
+The matching environment variables are `OTELOP_HTTP`, `OTELOP_OTLP_GRPC`, `OTELOP_OTLP_HTTP`, `OTELOP_TRACE_CAP`, `OTELOP_METRIC_CAP`, `OTELOP_LOG_CAP`, `OTELOP_MAX_DATA_POINTS`, `OTELOP_LOG_LEVEL`, and `OTELOP_DEBUG`.
+
 ## License
 
 MIT

--- a/cmd/otelop/start.go
+++ b/cmd/otelop/start.go
@@ -20,6 +20,7 @@ import (
 
 	otelop "github.com/mashiro/otelop"
 	"github.com/mashiro/otelop/internal/collector"
+	"github.com/mashiro/otelop/internal/config"
 	"github.com/mashiro/otelop/internal/daemon"
 	otelopexporter "github.com/mashiro/otelop/internal/exporter"
 	otelopgraphql "github.com/mashiro/otelop/internal/graphql"
@@ -31,26 +32,40 @@ import (
 )
 
 func startCommand() *cli.Command {
+	// Load the TOML config file once at command-construction time. Its
+	// values become each flag's Default, so the resolved precedence is:
+	//   CLI flag > env var (Sources) > config file (Default) > built-in.
+	// A missing file is silently treated as "all defaults". A parse error
+	// is fatal at the next runtime call, surfaced from runStart.
+	cfg, cfgPath, cfgErr := config.Load()
+
 	return &cli.Command{
 		Name:  "start",
 		Usage: "Start the otelop server (backgrounded by default)",
+		Before: func(_ context.Context, _ *cli.Command) (context.Context, error) {
+			if cfgErr != nil {
+				return nil, fmt.Errorf("config: %w", cfgErr)
+			}
+			return nil, nil
+		},
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "foreground",
 				Aliases: []string{"f"},
 				Usage:   "run in the foreground instead of detaching",
 			},
-			&cli.StringFlag{Name: "http", Value: ":4319", Usage: "Web UI + REST API listen address"},
-			&cli.StringFlag{Name: "otlp-grpc", Value: "0.0.0.0:4317", Usage: "OTLP gRPC receiver endpoint"},
-			&cli.StringFlag{Name: "otlp-http", Value: "0.0.0.0:4318", Usage: "OTLP HTTP receiver endpoint"},
-			&cli.IntFlag{Name: "trace-cap", Value: 1000, Usage: "max traces to keep in memory"},
-			&cli.IntFlag{Name: "metric-cap", Value: 3000, Usage: "max metric series to keep in memory"},
-			&cli.IntFlag{Name: "log-cap", Value: 1000, Usage: "max log entries to keep in memory"},
-			&cli.IntFlag{Name: "max-data-points", Value: 1000, Usage: "max data points per metric series"},
-			&cli.StringFlag{Name: "log-level", Value: "warn", Usage: "log level (debug|info|warn|error)"},
-			&cli.BoolFlag{Name: "debug", Usage: "export otelop's own telemetry to itself"},
+			&cli.StringFlag{Name: "http", Value: cfg.HTTPAddr, Usage: "Web UI + REST API listen address", Sources: cli.EnvVars("OTELOP_HTTP")},
+			&cli.StringFlag{Name: "otlp-grpc", Value: cfg.OTLPGRPCAddr, Usage: "OTLP gRPC receiver endpoint", Sources: cli.EnvVars("OTELOP_OTLP_GRPC")},
+			&cli.StringFlag{Name: "otlp-http", Value: cfg.OTLPHTTPAddr, Usage: "OTLP HTTP receiver endpoint", Sources: cli.EnvVars("OTELOP_OTLP_HTTP")},
+			&cli.IntFlag{Name: "trace-cap", Value: cfg.TraceCap, Usage: "max traces to keep in memory", Sources: cli.EnvVars("OTELOP_TRACE_CAP")},
+			&cli.IntFlag{Name: "metric-cap", Value: cfg.MetricCap, Usage: "max metric series to keep in memory", Sources: cli.EnvVars("OTELOP_METRIC_CAP")},
+			&cli.IntFlag{Name: "log-cap", Value: cfg.LogCap, Usage: "max log entries to keep in memory", Sources: cli.EnvVars("OTELOP_LOG_CAP")},
+			&cli.IntFlag{Name: "max-data-points", Value: cfg.MaxDataPoints, Usage: "max data points per metric series", Sources: cli.EnvVars("OTELOP_MAX_DATA_POINTS")},
+			&cli.StringFlag{Name: "log-level", Value: cfg.LogLevel, Usage: "log level (debug|info|warn|error)", Sources: cli.EnvVars("OTELOP_LOG_LEVEL")},
+			&cli.BoolFlag{Name: "debug", Value: cfg.Debug, Usage: "export otelop's own telemetry to itself", Sources: cli.EnvVars("OTELOP_DEBUG")},
 		},
-		Action: runStart,
+		Action:      runStart,
+		Description: fmt.Sprintf("Reads defaults from %s when present. Override with environment variables (OTELOP_HTTP, OTELOP_OTLP_GRPC, ...) or CLI flags.", cfgPath),
 	}
 }
 
@@ -72,10 +87,10 @@ func optionsFromCmd(cmd *cli.Command) startOptions {
 		HTTPAddr:      cmd.String("http"),
 		OTLPGRPCAddr:  cmd.String("otlp-grpc"),
 		OTLPHTTPAddr:  cmd.String("otlp-http"),
-		TraceCap:      int(cmd.Int("trace-cap")),
-		MetricCap:     int(cmd.Int("metric-cap")),
-		LogCap:        int(cmd.Int("log-cap")),
-		MaxDataPoints: int(cmd.Int("max-data-points")),
+		TraceCap:      cmd.Int("trace-cap"),
+		MetricCap:     cmd.Int("metric-cap"),
+		LogCap:        cmd.Int("log-cap"),
+		MaxDataPoints: cmd.Int("max-data-points"),
 		LogLevel:      cmd.String("log-level"),
 		Debug:         cmd.Bool("debug"),
 		Foreground:    cmd.Bool("foreground"),

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/CAFxX/httpcompression v0.0.9 h1:0ue2X8dOLEpxTm8tt+OdHcgA+gbDge0OqFQWGKSqgrg=
 github.com/CAFxX/httpcompression v0.0.9/go.mod h1:XX8oPZA+4IDcfZ0A71Hz0mZsv/YJOgYygkFhizVPilM=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,114 @@
+// Package config loads the optional otelop TOML config file. The file
+// supplies defaults for `otelop start` flags; CLI flags and environment
+// variables still take precedence at the command layer.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+const (
+	// EnvConfigFile lets callers point Load at a non-default path. Used by
+	// tests and by users who keep multiple otelop profiles.
+	EnvConfigFile = "OTELOP_CONFIG_FILE"
+
+	configFilename = "config.toml"
+	configDir      = "otelop"
+)
+
+// Default values used when neither the config file nor environment override
+// a given field. Mirrored as the built-in CLI flag defaults so the values
+// stay visible in `otelop start --help`.
+const (
+	DefaultHTTPAddr      = ":4319"
+	DefaultOTLPGRPCAddr  = "0.0.0.0:4317"
+	DefaultOTLPHTTPAddr  = "0.0.0.0:4318"
+	DefaultTraceCap      = 1000
+	DefaultMetricCap     = 3000
+	DefaultLogCap        = 1000
+	DefaultMaxDataPoints = 1000
+	DefaultLogLevel      = "warn"
+)
+
+// Config is the on-disk shape of the TOML config file. Fields use snake_case
+// keys to match TOML conventions (CLI flags are kebab-case, env vars are
+// SCREAMING_SNAKE — pick whichever surface is most ergonomic).
+type Config struct {
+	HTTPAddr      string `toml:"http"`
+	OTLPGRPCAddr  string `toml:"otlp_grpc"`
+	OTLPHTTPAddr  string `toml:"otlp_http"`
+	TraceCap      int    `toml:"trace_cap"`
+	MetricCap     int    `toml:"metric_cap"`
+	LogCap        int    `toml:"log_cap"`
+	MaxDataPoints int    `toml:"max_data_points"`
+	LogLevel      string `toml:"log_level"`
+	Debug         bool   `toml:"debug"`
+}
+
+// Defaults returns a Config populated with the built-in fallback values.
+// Used as the starting point for Load — fields the file omits keep these
+// values.
+func Defaults() Config {
+	return Config{
+		HTTPAddr:      DefaultHTTPAddr,
+		OTLPGRPCAddr:  DefaultOTLPGRPCAddr,
+		OTLPHTTPAddr:  DefaultOTLPHTTPAddr,
+		TraceCap:      DefaultTraceCap,
+		MetricCap:     DefaultMetricCap,
+		LogCap:        DefaultLogCap,
+		MaxDataPoints: DefaultMaxDataPoints,
+		LogLevel:      DefaultLogLevel,
+	}
+}
+
+// DefaultPath returns the path Load reads when no override is set. Honours
+// OTELOP_CONFIG_FILE first, then $XDG_CONFIG_HOME/otelop/config.toml,
+// falling back to ~/.config/otelop/config.toml on both macOS and Linux.
+func DefaultPath() (string, error) {
+	if p := os.Getenv(EnvConfigFile); p != "" {
+		return p, nil
+	}
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return filepath.Join(dir, configDir, configFilename), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".config", configDir, configFilename), nil
+}
+
+// Load reads the config file at the resolved default path and merges it
+// onto Defaults(). A missing file is not an error — callers get the
+// built-in defaults. Returns the path that was actually read so it can be
+// surfaced in errors and `--help` output.
+func Load() (Config, string, error) {
+	path, err := DefaultPath()
+	if err != nil {
+		return Defaults(), "", err
+	}
+	cfg, err := loadFile(path)
+	return cfg, path, err
+}
+
+func loadFile(path string) (Config, error) {
+	cfg := Defaults()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return cfg, nil
+		}
+		return cfg, fmt.Errorf("read %s: %w", path, err)
+	}
+	// Decode into the already-defaulted struct so omitted keys keep their
+	// fallback values without explicit handling per field.
+	if _, err := toml.Decode(string(data), &cfg); err != nil {
+		return Defaults(), fmt.Errorf("parse %s: %w", path, err)
+	}
+	return cfg, nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaults_AppliedWhenFileMissing(t *testing.T) {
+	t.Setenv(EnvConfigFile, filepath.Join(t.TempDir(), "missing.toml"))
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.HTTPAddr != DefaultHTTPAddr {
+		t.Errorf("HTTPAddr = %q, want %q", cfg.HTTPAddr, DefaultHTTPAddr)
+	}
+	if cfg.TraceCap != DefaultTraceCap {
+		t.Errorf("TraceCap = %d, want %d", cfg.TraceCap, DefaultTraceCap)
+	}
+	if cfg.LogLevel != DefaultLogLevel {
+		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, DefaultLogLevel)
+	}
+}
+
+func TestLoad_MergesPartialFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := `
+http = ":15000"
+trace_cap = 42
+debug = true
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv(EnvConfigFile, path)
+
+	cfg, gotPath, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if gotPath != path {
+		t.Errorf("path = %q, want %q", gotPath, path)
+	}
+	if cfg.HTTPAddr != ":15000" {
+		t.Errorf("HTTPAddr = %q, want :15000", cfg.HTTPAddr)
+	}
+	if cfg.TraceCap != 42 {
+		t.Errorf("TraceCap = %d, want 42", cfg.TraceCap)
+	}
+	if !cfg.Debug {
+		t.Errorf("Debug = false, want true")
+	}
+	// Untouched fields keep defaults.
+	if cfg.OTLPGRPCAddr != DefaultOTLPGRPCAddr {
+		t.Errorf("OTLPGRPCAddr = %q, want default %q", cfg.OTLPGRPCAddr, DefaultOTLPGRPCAddr)
+	}
+	if cfg.LogLevel != DefaultLogLevel {
+		t.Errorf("LogLevel = %q, want default %q", cfg.LogLevel, DefaultLogLevel)
+	}
+}
+
+func TestLoad_ParseError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("not valid = = toml\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv(EnvConfigFile, path)
+
+	_, _, err := Load()
+	if err == nil {
+		t.Fatal("Load returned nil error for invalid TOML")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("error message = %q, want it to mention 'parse'", err.Error())
+	}
+}
+
+func TestDefaultPath_HonoursOverride(t *testing.T) {
+	t.Setenv(EnvConfigFile, "/tmp/explicit.toml")
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if got != "/tmp/explicit.toml" {
+		t.Errorf("DefaultPath = %q, want /tmp/explicit.toml", got)
+	}
+}
+
+func TestDefaultPath_HonoursXDG(t *testing.T) {
+	t.Setenv(EnvConfigFile, "")
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg")
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := filepath.Join("/tmp/xdg", configDir, configFilename)
+	if got != want {
+		t.Errorf("DefaultPath = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/config` package reads `$XDG_CONFIG_HOME/otelop/config.toml` (fallback `~/.config/otelop/config.toml`, override via `OTELOP_CONFIG_FILE`). Missing files fall back to built-in defaults silently; parse errors are surfaced from `start`'s `Before` hook so the daemon never silently picks up a corrupt file.
- Each `otelop start` flag gains a matching environment variable via urfave/cli/v3 `Sources: cli.EnvVars(...)` — `OTELOP_HTTP`, `OTELOP_OTLP_GRPC`, `OTELOP_OTLP_HTTP`, `OTELOP_TRACE_CAP`, `OTELOP_METRIC_CAP`, `OTELOP_LOG_CAP`, `OTELOP_MAX_DATA_POINTS`, `OTELOP_LOG_LEVEL`, `OTELOP_DEBUG`.
- The config-file values become each flag's `Value` (default), so the resolved precedence is **CLI flag > env var > config file > built-in default**.
- `otelop start --help` shows the resolved config path and per-flag env var bindings.
- Added `github.com/BurntSushi/toml` as the only new dependency.

## Test plan

- [x] `mise run check` passes (golangci-lint + frontend type/format)
- [x] `mise run test` passes (Go + frontend; new tests in `internal/config`)
- [x] Config file only — TOML `http = ":15001"` produces `Web UI http://localhost:15001`
- [x] Env var overrides config — `OTELOP_HTTP=:25001` wins over the file
- [x] CLI flag overrides env and config — `--http :35001` wins over both
- [x] Invalid TOML fails fast with `exit=1` and a `parse <path>: ...` error
- [x] `otelop start --help` shows the resolved config path in `Description` and `[$OTELOP_HTTP]` bindings on each flag