### PR TITLE
feat(cli): add logs/restart commands and tighten config validation

### DIFF
--- a/cmd/otelop/logs.go
+++ b/cmd/otelop/logs.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/mashiro/otelop/internal/daemon"
+)
+
+func logsCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "logs",
+		Usage: "Print the daemon log file",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "follow",
+				Aliases: []string{"f"},
+				Usage:   "stream new log lines as they are written (Ctrl-C to exit)",
+			},
+		},
+		Action: runLogs,
+	}
+}
+
+func runLogs(_ context.Context, cmd *cli.Command) error {
+	path, err := daemon.LogFile()
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			_, _ = fmt.Fprintf(cmd.Writer, "no log file at %s — has otelop been started?\n", path)
+			return nil
+		}
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := io.Copy(cmd.Writer, f); err != nil {
+		return err
+	}
+	if !cmd.Bool("follow") {
+		return nil
+	}
+
+	// Tail mode: re-read whatever the daemon appends until the user sends
+	// SIGINT/SIGTERM. The fd is at EOF after the io.Copy above, so the
+	// next Read returns only newly-written bytes.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-sigCh:
+			return nil
+		case <-ticker.C:
+			if _, err := io.Copy(cmd.Writer, f); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/cmd/otelop/main.go
+++ b/cmd/otelop/main.go
@@ -18,8 +18,10 @@ func main() {
 		Version: version,
 		Commands: []*cli.Command{
 			startCommand(),
+			restartCommand(),
 			stopCommand(),
 			statusCommand(),
+			logsCommand(),
 			{
 				Name:  "version",
 				Usage: "Print version",

--- a/cmd/otelop/restart.go
+++ b/cmd/otelop/restart.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/mashiro/otelop/internal/daemon"
+)
+
+const restartStopTimeout = 10 * time.Second
+
+func restartCommand() *cli.Command {
+	cmd := startCommand()
+	cmd.Name = "restart"
+	cmd.Usage = "Stop the running otelop server and start it again"
+	cmd.Action = runRestart
+	cmd.Description = "Stops any running otelop daemon and re-runs `start` with the current flags, env vars, and config file values."
+	return cmd
+}
+
+func runRestart(ctx context.Context, cmd *cli.Command) error {
+	// The daemon child re-execs itself with the same argv, so without this
+	// guard it would re-enter runRestart, see no running daemon, and call
+	// runStart from the wrong layer. Skip the stop in the child and let
+	// runStart take the daemon-child path normally.
+	if !daemon.IsDaemonChild() {
+		if err := stopForRestart(restartStopTimeout, cmd.Writer); err != nil {
+			return err
+		}
+	}
+	return runStart(ctx, cmd)
+}
+
+// stopForRestart is the quiet variant of stop. It only prints a message when
+// it actually terminates a running daemon — stale metadata and "nothing to
+// stop" cases are silent so `otelop restart` reads as one operation.
+func stopForRestart(timeout time.Duration, w io.Writer) error {
+	meta, running, err := daemon.Running()
+	if err != nil {
+		return err
+	}
+	if meta == nil {
+		return nil
+	}
+	if !running {
+		return daemon.RemoveState()
+	}
+	if err := daemon.StopAndWait(meta.PID, timeout); err != nil {
+		return err
+	}
+	_ = daemon.RemoveState()
+	_, _ = fmt.Fprintf(w, "stopped existing otelop (pid %d)\n", meta.PID)
+	return nil
+}

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -120,6 +120,8 @@ export type Query = {
   logs: LogConnection;
   /** List metrics newest-first. */
   metrics: MetricConnection;
+  /** Runtime info for the running otelop instance. Consumed by `otelop status`. */
+  status: Status;
   /** Fetch a single trace by its hex-encoded trace ID. */
   trace?: Maybe<Trace>;
   /** List traces newest-first. */
@@ -178,6 +180,25 @@ export type SpanEvent = {
   attributes: Scalars['JSON']['output'];
   name: Scalars['String']['output'];
   timestamp: Scalars['Time']['output'];
+};
+
+export type Status = {
+  __typename?: 'Status';
+  /** Ring buffer capacity and current counts. */
+  config: Config;
+  /** True when self-telemetry is enabled via --debug. */
+  debug: Scalars['Boolean']['output'];
+  /** HTTP / Web UI listen address as passed on the command line. */
+  httpAddr: Scalars['String']['output'];
+  /** OTLP gRPC receiver listen address. */
+  otlpGrpcAddr: Scalars['String']['output'];
+  /** OTLP HTTP receiver listen address. */
+  otlpHttpAddr: Scalars['String']['output'];
+  /** Server start time (RFC3339). */
+  startedAt: Scalars['Time']['output'];
+  /** Milliseconds since the server started. */
+  uptimeMs: Scalars['Float']['output'];
+  version: Scalars['String']['output'];
 };
 
 export type Trace = {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -107,8 +109,19 @@ func loadFile(path string) (Config, error) {
 	}
 	// Decode into the already-defaulted struct so omitted keys keep their
 	// fallback values without explicit handling per field.
-	if _, err := toml.Decode(string(data), &cfg); err != nil {
+	md, err := toml.Decode(string(data), &cfg)
+	if err != nil {
 		return Defaults(), fmt.Errorf("parse %s: %w", path, err)
+	}
+	// Refuse unknown keys so a typo (e.g. `htttp = ":4319"`) fails loudly
+	// at startup instead of silently falling back to the default.
+	if undecoded := md.Undecoded(); len(undecoded) > 0 {
+		keys := make([]string, len(undecoded))
+		for i, k := range undecoded {
+			keys[i] = k.String()
+		}
+		sort.Strings(keys)
+		return Defaults(), fmt.Errorf("%s: unknown keys: %s", path, strings.Join(keys, ", "))
 	}
 	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -62,6 +62,32 @@ debug = true
 	}
 }
 
+func TestLoad_UnknownKeyRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := `
+http = ":4319"
+htttp = ":9999"  # typo
+some_other = 42
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv(EnvConfigFile, path)
+
+	_, _, err := Load()
+	if err == nil {
+		t.Fatal("Load returned nil for config with unknown keys")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unknown keys") {
+		t.Errorf("error message = %q, want it to mention 'unknown keys'", msg)
+	}
+	if !strings.Contains(msg, "htttp") || !strings.Contains(msg, "some_other") {
+		t.Errorf("error message = %q, want both unknown keys listed", msg)
+	}
+}
+
 func TestLoad_ParseError(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")

--- a/internal/daemon/spawn_unix.go
+++ b/internal/daemon/spawn_unix.go
@@ -35,6 +35,11 @@ const (
 // classical daemon dance is skipped — otelop never opens /dev/tty, so the
 // "don't acquire a controlling terminal" guarantee is not needed.
 func Spawn(ctx context.Context, logPath string) error {
+	// Append rather than truncate: an `otelop logs --follow` running across
+	// a `restart` keeps its fd parked at the previous EOF, so a truncate
+	// would leave the follower stuck reading EOF until the new run grew
+	// past the old size. Unbounded growth is a theoretical concern for a
+	// dev tool — handle it externally if it ever bites.
 	logFile, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("open daemon log: %w", err)


### PR DESCRIPTION
## Summary

- New `otelop logs` command prints the daemon log file. `--follow` (`-f`) tails the file with a 200 ms poll loop and exits cleanly on SIGINT/SIGTERM. Missing log files print a friendly hint instead of an error.
- New `otelop restart` command stops the running daemon and re-runs `start` with the current flags, env vars, and config-file values. Skips the stop step in the daemon child to avoid re-entering the re-exec loop.
- `internal/config` rejects unknown TOML keys via `toml.MetaData.Undecoded()` so a typo like `htttp = ":4319"` fails fast at startup instead of silently falling back to the default. New test covers it.
- Documents why `daemon.Spawn` keeps `O_APPEND` for the log file — a live `otelop logs --follow` would otherwise stay parked at the previous EOF across a restart and miss the restarted daemon's output. (Codex review caught this regression on an earlier truncate-on-start attempt.)
- Syncs the autogenerated `frontend/src/gql/graphql.ts` with the schema-side `Status` type added in #27 so the file stays consistent even though the frontend doesn't consume it yet.

## Test plan

- [x] `mise run check` passes (golangci-lint + frontend type/format)
- [x] `mise run test` passes (Go + frontend, including new `TestLoad_UnknownKeyRejected`)
- [x] `otelop start` → `otelop logs` prints the (debug-level) collector startup log → `otelop stop`
- [x] `otelop restart` swaps PID and re-prints the banner
- [x] Concurrent `otelop start` while another is running still refuses with the existing "already running" error
- [x] `otelop logs` on a fresh state dir prints "no log file at … — has otelop been started?"
- [x] Config with `htttp = ":4319"` fails with `unknown keys: htttp` and exits non-zero