### PR TITLE
Add OTLP proxy forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It's meant for the loop where you're writing instrumentation and just want to se
 
 - Single binary with the frontend embedded
 - OTLP gRPC and HTTP receivers (built-in OpenTelemetry Collector)
+- Optional OTLP forwarding to one upstream endpoint
 - Traces, metrics, and logs in one UI
 - Live updates over WebSocket
 - GraphQL API at `/graphql`
@@ -92,6 +93,8 @@ otelop version
   --http             Web UI listen address           (default :4319)
   --otlp-grpc        OTLP gRPC receiver endpoint     (default 0.0.0.0:4317)
   --otlp-http        OTLP HTTP receiver endpoint     (default 0.0.0.0:4318)
+  --proxy-url        upstream OTLP endpoint for forwarding
+  --proxy-protocol   upstream OTLP protocol          (grpc|http)
   --trace-cap        max traces in memory            (default 1000)
   --metric-cap       max metric series in memory     (default 3000)
   --log-cap          max log entries in memory       (default 1000)
@@ -115,6 +118,8 @@ Example `~/.config/otelop/config.toml`:
 http = ":4319"
 otlp_grpc = "0.0.0.0:4317"
 otlp_http = "0.0.0.0:4318"
+proxy_url = "http://collector.internal:4318"
+proxy_protocol = "http"
 trace_cap = 1000
 metric_cap = 3000
 log_cap = 1000
@@ -123,7 +128,9 @@ log_level = "warn"
 debug = false
 ```
 
-The matching environment variables are `OTELOP_HTTP`, `OTELOP_OTLP_GRPC`, `OTELOP_OTLP_HTTP`, `OTELOP_TRACE_CAP`, `OTELOP_METRIC_CAP`, `OTELOP_LOG_CAP`, `OTELOP_MAX_DATA_POINTS`, `OTELOP_LOG_LEVEL`, and `OTELOP_DEBUG`.
+The matching environment variables are `OTELOP_HTTP`, `OTELOP_OTLP_GRPC`, `OTELOP_OTLP_HTTP`, `OTELOP_PROXY_URL`, `OTELOP_PROXY_PROTOCOL`, `OTELOP_TRACE_CAP`, `OTELOP_METRIC_CAP`, `OTELOP_LOG_CAP`, `OTELOP_MAX_DATA_POINTS`, `OTELOP_LOG_LEVEL`, and `OTELOP_DEBUG`.
+
+When proxying is enabled, `otelop` still buffers incoming telemetry locally for the UI and also forwards the same traces, metrics, and logs to the configured upstream OTLP endpoint.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ otelop version
   --otlp-http        OTLP HTTP receiver endpoint     (default 0.0.0.0:4318)
   --proxy-url        upstream OTLP endpoint for forwarding
   --proxy-protocol   upstream OTLP protocol          (grpc|http)
+  --proxy-auth-type  upstream OTLP auth type         (bearer|basic|headers)
+  --proxy-auth-token upstream bearer token
+  --proxy-auth-username upstream basic auth username
+  --proxy-auth-password upstream basic auth password
+  --proxy-header     upstream header                 (repeatable key=value)
   --trace-cap        max traces in memory            (default 1000)
   --metric-cap       max metric series in memory     (default 3000)
   --log-cap          max log entries in memory       (default 1000)
@@ -118,8 +123,15 @@ Example `~/.config/otelop/config.toml`:
 http = ":4319"
 otlp_grpc = "0.0.0.0:4317"
 otlp_http = "0.0.0.0:4318"
-proxy_url = "http://collector.internal:4318"
-proxy_protocol = "http"
+
+[proxy]
+url = "https://collector.internal:4318"
+protocol = "http"
+
+[proxy.auth]
+type = "bearer"
+token = "replace-me"
+
 trace_cap = 1000
 metric_cap = 3000
 log_cap = 1000
@@ -128,9 +140,17 @@ log_level = "warn"
 debug = false
 ```
 
-The matching environment variables are `OTELOP_HTTP`, `OTELOP_OTLP_GRPC`, `OTELOP_OTLP_HTTP`, `OTELOP_PROXY_URL`, `OTELOP_PROXY_PROTOCOL`, `OTELOP_TRACE_CAP`, `OTELOP_METRIC_CAP`, `OTELOP_LOG_CAP`, `OTELOP_MAX_DATA_POINTS`, `OTELOP_LOG_LEVEL`, and `OTELOP_DEBUG`.
+The matching environment variables are `OTELOP_HTTP`, `OTELOP_OTLP_GRPC`, `OTELOP_OTLP_HTTP`, `OTELOP_PROXY_URL`, `OTELOP_PROXY_PROTOCOL`, `OTELOP_PROXY_AUTH_TYPE`, `OTELOP_PROXY_AUTH_TOKEN`, `OTELOP_PROXY_AUTH_USERNAME`, `OTELOP_PROXY_AUTH_PASSWORD`, `OTELOP_PROXY_HEADERS`, `OTELOP_TRACE_CAP`, `OTELOP_METRIC_CAP`, `OTELOP_LOG_CAP`, `OTELOP_MAX_DATA_POINTS`, `OTELOP_LOG_LEVEL`, and `OTELOP_DEBUG`.
 
 When proxying is enabled, `otelop` still buffers incoming telemetry locally for the UI and also forwards the same traces, metrics, and logs to the configured upstream OTLP endpoint.
+
+`proxy.auth.type` supports:
+
+- `bearer`: sends `Authorization: Bearer <token>`
+- `basic`: sends `Authorization: Basic <base64(username:password)>`
+- `headers`: sends the exact headers configured under `[proxy.auth.headers]` or `--proxy-header`
+
+Do not embed credentials in `proxy.url`; `otelop` rejects URLs with userinfo such as `https://user:pass@example.com`.
 
 ## License
 

--- a/cmd/otelop/start.go
+++ b/cmd/otelop/start.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -59,8 +62,13 @@ func startCommand() *cli.Command {
 			&cli.StringFlag{Name: "http", Value: cfg.HTTPAddr, Usage: "Web UI + REST API listen address", Sources: cli.EnvVars("OTELOP_HTTP")},
 			&cli.StringFlag{Name: "otlp-grpc", Value: cfg.OTLPGRPCAddr, Usage: "OTLP gRPC receiver endpoint", Sources: cli.EnvVars("OTELOP_OTLP_GRPC")},
 			&cli.StringFlag{Name: "otlp-http", Value: cfg.OTLPHTTPAddr, Usage: "OTLP HTTP receiver endpoint", Sources: cli.EnvVars("OTELOP_OTLP_HTTP")},
-			&cli.StringFlag{Name: "proxy-url", Value: cfg.ProxyURL, Usage: "upstream OTLP endpoint for forwarding", Sources: cli.EnvVars("OTELOP_PROXY_URL")},
-			&cli.StringFlag{Name: "proxy-protocol", Value: cfg.ProxyProtocol, Usage: "upstream OTLP protocol (grpc|http)", Sources: cli.EnvVars("OTELOP_PROXY_PROTOCOL")},
+			&cli.StringFlag{Name: "proxy-url", Value: cfg.Proxy.URL, Usage: "upstream OTLP endpoint for forwarding", Sources: cli.EnvVars("OTELOP_PROXY_URL")},
+			&cli.StringFlag{Name: "proxy-protocol", Value: cfg.Proxy.Protocol, Usage: "upstream OTLP protocol (grpc|http)", Sources: cli.EnvVars("OTELOP_PROXY_PROTOCOL")},
+			&cli.StringFlag{Name: "proxy-auth-type", Value: cfg.Proxy.Auth.Type, Usage: "upstream OTLP auth type (bearer|basic|headers)", Sources: cli.EnvVars("OTELOP_PROXY_AUTH_TYPE")},
+			&cli.StringFlag{Name: "proxy-auth-token", Value: cfg.Proxy.Auth.Token, Usage: "upstream bearer token", Sources: cli.EnvVars("OTELOP_PROXY_AUTH_TOKEN")},
+			&cli.StringFlag{Name: "proxy-auth-username", Value: cfg.Proxy.Auth.Username, Usage: "upstream basic auth username", Sources: cli.EnvVars("OTELOP_PROXY_AUTH_USERNAME")},
+			&cli.StringFlag{Name: "proxy-auth-password", Value: cfg.Proxy.Auth.Password, Usage: "upstream basic auth password", Sources: cli.EnvVars("OTELOP_PROXY_AUTH_PASSWORD")},
+			&cli.StringSliceFlag{Name: "proxy-header", Value: headerPairs(cfg.Proxy.Auth.Headers), Usage: "upstream header in key=value form (repeatable)", Sources: cli.EnvVars("OTELOP_PROXY_HEADERS")},
 			&cli.IntFlag{Name: "trace-cap", Value: cfg.TraceCap, Usage: "max traces to keep in memory", Sources: cli.EnvVars("OTELOP_TRACE_CAP")},
 			&cli.IntFlag{Name: "metric-cap", Value: cfg.MetricCap, Usage: "max metric series to keep in memory", Sources: cli.EnvVars("OTELOP_METRIC_CAP")},
 			&cli.IntFlag{Name: "log-cap", Value: cfg.LogCap, Usage: "max log entries to keep in memory", Sources: cli.EnvVars("OTELOP_LOG_CAP")},
@@ -73,12 +81,21 @@ func startCommand() *cli.Command {
 	}
 }
 
+type proxyAuthOptions struct {
+	Type     string
+	Token    string
+	Username string
+	Password string
+	Headers  map[string]string
+}
+
 type startOptions struct {
 	HTTPAddr      string
 	OTLPGRPCAddr  string
 	OTLPHTTPAddr  string
 	ProxyURL      string
 	ProxyProtocol string
+	ProxyAuth     proxyAuthOptions
 	TraceCap      int
 	MetricCap     int
 	LogCap        int
@@ -95,6 +112,13 @@ func optionsFromCmd(cmd *cli.Command) startOptions {
 		OTLPHTTPAddr:  cmd.String("otlp-http"),
 		ProxyURL:      strings.TrimSpace(cmd.String("proxy-url")),
 		ProxyProtocol: normalizeProxyProtocol(cmd.String("proxy-protocol")),
+		ProxyAuth: proxyAuthOptions{
+			Type:     normalizeProxyAuthType(cmd.String("proxy-auth-type")),
+			Token:    cmd.String("proxy-auth-token"),
+			Username: cmd.String("proxy-auth-username"),
+			Password: cmd.String("proxy-auth-password"),
+			Headers:  parseHeaderArgs(cmd.StringSlice("proxy-header")),
+		},
 		TraceCap:      cmd.Int("trace-cap"),
 		MetricCap:     cmd.Int("metric-cap"),
 		LogCap:        cmd.Int("log-cap"),
@@ -135,7 +159,7 @@ func runServer(ctx context.Context, opts startOptions) error {
 			HTTPAddr:      opts.HTTPAddr,
 			OTLPGRPCAddr:  opts.OTLPGRPCAddr,
 			OTLPHTTPAddr:  opts.OTLPHTTPAddr,
-			ProxyURL:      opts.ProxyURL,
+			ProxyURL:      redactURL(opts.ProxyURL),
 			ProxyProtocol: opts.ProxyProtocol,
 			Version:       version,
 		}
@@ -239,7 +263,7 @@ func bootstrap(ctx context.Context, opts startOptions) (*runtime, error) {
 		HTTPAddr:      opts.HTTPAddr,
 		OTLPGRPCAddr:  opts.OTLPGRPCAddr,
 		OTLPHTTPAddr:  opts.OTLPHTTPAddr,
-		ProxyURL:      opts.ProxyURL,
+		ProxyURL:      redactURL(opts.ProxyURL),
 		ProxyProtocol: opts.ProxyProtocol,
 		Debug:         opts.Debug,
 	}
@@ -263,6 +287,7 @@ func bootstrap(ctx context.Context, opts startOptions) (*runtime, error) {
 		HTTPEndpoint:  opts.OTLPHTTPAddr,
 		ProxyURL:      opts.ProxyURL,
 		ProxyProtocol: opts.ProxyProtocol,
+		ProxyHeaders:  buildProxyHeaders(opts.ProxyAuth),
 		LogLevel:      opts.LogLevel,
 	})
 	if err != nil {
@@ -360,8 +385,15 @@ func normalizeProxyProtocol(v string) string {
 	return strings.ToLower(strings.TrimSpace(v))
 }
 
+func normalizeProxyAuthType(v string) string {
+	return strings.ToLower(strings.TrimSpace(v))
+}
+
 func validateProxyOptions(opts startOptions) error {
 	if opts.ProxyURL == "" && opts.ProxyProtocol == "" {
+		if hasProxyAuth(opts.ProxyAuth) {
+			return errors.New("proxy auth requires --proxy-url and --proxy-protocol")
+		}
 		return nil
 	}
 	if opts.ProxyURL == "" {
@@ -370,14 +402,37 @@ func validateProxyOptions(opts startOptions) error {
 	if opts.ProxyProtocol == "" {
 		return errors.New("proxy-url requires --proxy-protocol (grpc|http)")
 	}
+	if err := validateProxyURLSecrets(opts.ProxyURL); err != nil {
+		return err
+	}
+	if err := validateProxyAuth(opts.ProxyAuth); err != nil {
+		return err
+	}
 	switch opts.ProxyProtocol {
 	case "grpc":
-		return validateGRPCProxyURL(opts.ProxyURL)
+		if err := validateGRPCProxyURL(opts.ProxyURL); err != nil {
+			return err
+		}
+		return validateNoSelfProxy(opts.ProxyURL, opts.OTLPGRPCAddr, "grpc")
 	case "http":
-		return validateHTTPProxyURL(opts.ProxyURL)
+		if err := validateHTTPProxyURL(opts.ProxyURL); err != nil {
+			return err
+		}
+		return validateNoSelfProxy(opts.ProxyURL, opts.OTLPHTTPAddr, "http")
 	default:
 		return fmt.Errorf("invalid proxy-protocol %q: want grpc or http", opts.ProxyProtocol)
 	}
+}
+
+func validateProxyURLSecrets(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid proxy-url: %w", err)
+	}
+	if u.User != nil {
+		return errors.New("proxy-url must not contain embedded credentials; use --proxy-auth-* instead")
+	}
+	return nil
 }
 
 func validateGRPCProxyURL(raw string) error {
@@ -416,6 +471,174 @@ func validateHTTPProxyURL(raw string) error {
 	default:
 		return fmt.Errorf("invalid proxy-url %q for http: unsupported scheme %q", raw, u.Scheme)
 	}
+}
+
+func validateProxyAuth(auth proxyAuthOptions) error {
+	switch auth.Type {
+	case "":
+		if hasProxyAuthFields(auth) {
+			return errors.New("proxy auth fields require --proxy-auth-type")
+		}
+		return nil
+	case "bearer":
+		if auth.Token == "" {
+			return errors.New("proxy-auth-type bearer requires --proxy-auth-token")
+		}
+		if auth.Username != "" || auth.Password != "" || len(auth.Headers) > 0 {
+			return errors.New("proxy-auth-type bearer only supports --proxy-auth-token")
+		}
+	case "basic":
+		if auth.Username == "" || auth.Password == "" {
+			return errors.New("proxy-auth-type basic requires --proxy-auth-username and --proxy-auth-password")
+		}
+		if auth.Token != "" || len(auth.Headers) > 0 {
+			return errors.New("proxy-auth-type basic only supports username/password")
+		}
+	case "headers":
+		if len(auth.Headers) == 0 {
+			return errors.New("proxy-auth-type headers requires at least one --proxy-header")
+		}
+		if auth.Token != "" || auth.Username != "" || auth.Password != "" {
+			return errors.New("proxy-auth-type headers only supports --proxy-header")
+		}
+	default:
+		return fmt.Errorf("invalid proxy-auth-type %q: want bearer, basic, or headers", auth.Type)
+	}
+	return nil
+}
+
+func validateNoSelfProxy(proxyURL, listenAddr, protocol string) error {
+	target, err := comparableProxyHostPort(proxyURL, protocol)
+	if err != nil {
+		return err
+	}
+	local, err := comparableListenHostPort(listenAddr)
+	if err != nil {
+		return err
+	}
+	if target == local {
+		return fmt.Errorf("proxy-url %q points back to otelop's own OTLP %s listener %q", proxyURL, protocol, listenAddr)
+	}
+	return nil
+}
+
+func comparableProxyHostPort(proxyURL, protocol string) (string, error) {
+	if protocol == "grpc" {
+		u, err := url.Parse(proxyURL)
+		if err != nil {
+			return "", fmt.Errorf("invalid proxy-url: %w", err)
+		}
+		if u.Scheme == "" {
+			return normalizeHostPort(proxyURL)
+		}
+		return normalizeHostPort(u.Host)
+	}
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid proxy-url: %w", err)
+	}
+	return normalizeHostPort(u.Host)
+}
+
+func comparableListenHostPort(listenAddr string) (string, error) {
+	loopback, err := resolveLoopback(listenAddr)
+	if err != nil {
+		return "", err
+	}
+	return normalizeHostPort(loopback)
+}
+
+func normalizeHostPort(addr string) (string, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", err
+	}
+	host = strings.ToLower(strings.Trim(host, "[]"))
+	switch host {
+	case "", "0.0.0.0", "::", "::1", "127.0.0.1", "localhost":
+		host = "localhost"
+	}
+	return net.JoinHostPort(host, port), nil
+}
+
+func hasProxyAuth(auth proxyAuthOptions) bool {
+	return auth.Type != "" || hasProxyAuthFields(auth)
+}
+
+func hasProxyAuthFields(auth proxyAuthOptions) bool {
+	return auth.Token != "" || auth.Username != "" || auth.Password != "" || len(auth.Headers) > 0
+}
+
+func buildProxyHeaders(auth proxyAuthOptions) map[string]string {
+	switch auth.Type {
+	case "bearer":
+		return map[string]string{"Authorization": "Bearer " + auth.Token}
+	case "basic":
+		token := base64.StdEncoding.EncodeToString([]byte(auth.Username + ":" + auth.Password))
+		return map[string]string{"Authorization": "Basic " + token}
+	case "headers":
+		out := make(map[string]string, len(auth.Headers))
+		for k, v := range auth.Headers {
+			out[k] = v
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func parseHeaderArgs(args []string) map[string]string {
+	if len(args) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(args))
+	for _, arg := range args {
+		if arg == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(arg, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k == "" {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func headerPairs(headers map[string]string) []string {
+	if len(headers) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(headers))
+	for k := range headers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, k+"="+headers[k])
+	}
+	return out
+}
+
+func redactURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		return raw
+	}
+	u.User = url.UserPassword("REDACTED", "REDACTED")
+	return u.String()
 }
 
 func formatProxyStatus(proxyURL, proxyProtocol string) string {

--- a/cmd/otelop/start.go
+++ b/cmd/otelop/start.go
@@ -391,7 +391,7 @@ func normalizeProxyAuthType(v string) string {
 
 func validateProxyOptions(opts startOptions) error {
 	if opts.ProxyURL == "" && opts.ProxyProtocol == "" {
-		if hasProxyAuth(opts.ProxyAuth) {
+		if opts.ProxyAuth.Type != "" || hasProxyAuthFields(opts.ProxyAuth) {
 			return errors.New("proxy auth requires --proxy-url and --proxy-protocol")
 		}
 		return nil
@@ -402,44 +402,33 @@ func validateProxyOptions(opts startOptions) error {
 	if opts.ProxyProtocol == "" {
 		return errors.New("proxy-url requires --proxy-protocol (grpc|http)")
 	}
-	if err := validateProxyURLSecrets(opts.ProxyURL); err != nil {
-		return err
-	}
-	if err := validateProxyAuth(opts.ProxyAuth); err != nil {
-		return err
-	}
-	switch opts.ProxyProtocol {
-	case "grpc":
-		if err := validateGRPCProxyURL(opts.ProxyURL); err != nil {
-			return err
-		}
-		return validateNoSelfProxy(opts.ProxyURL, opts.OTLPGRPCAddr, "grpc")
-	case "http":
-		if err := validateHTTPProxyURL(opts.ProxyURL); err != nil {
-			return err
-		}
-		return validateNoSelfProxy(opts.ProxyURL, opts.OTLPHTTPAddr, "http")
-	default:
-		return fmt.Errorf("invalid proxy-protocol %q: want grpc or http", opts.ProxyProtocol)
-	}
-}
-
-func validateProxyURLSecrets(raw string) error {
-	u, err := url.Parse(raw)
+	u, err := url.Parse(opts.ProxyURL)
 	if err != nil {
 		return fmt.Errorf("invalid proxy-url: %w", err)
 	}
 	if u.User != nil {
 		return errors.New("proxy-url must not contain embedded credentials; use --proxy-auth-* instead")
 	}
-	return nil
+	if err := validateProxyAuth(opts.ProxyAuth); err != nil {
+		return err
+	}
+	switch opts.ProxyProtocol {
+	case "grpc":
+		if err := validateGRPCProxyURL(u, opts.ProxyURL); err != nil {
+			return err
+		}
+		return validateNoSelfProxy(u, opts.ProxyURL, opts.OTLPGRPCAddr, "grpc")
+	case "http":
+		if err := validateHTTPProxyURL(u, opts.ProxyURL); err != nil {
+			return err
+		}
+		return validateNoSelfProxy(u, opts.ProxyURL, opts.OTLPHTTPAddr, "http")
+	default:
+		return fmt.Errorf("invalid proxy-protocol %q: want grpc or http", opts.ProxyProtocol)
+	}
 }
 
-func validateGRPCProxyURL(raw string) error {
-	u, err := url.Parse(raw)
-	if err != nil {
-		return fmt.Errorf("invalid proxy-url: %w", err)
-	}
+func validateGRPCProxyURL(u *url.URL, raw string) error {
 	if u.Scheme == "" {
 		if raw == "" || strings.Contains(raw, "/") {
 			return fmt.Errorf("invalid proxy-url %q for grpc: want host:port or http(s)://host:port", raw)
@@ -457,11 +446,7 @@ func validateGRPCProxyURL(raw string) error {
 	}
 }
 
-func validateHTTPProxyURL(raw string) error {
-	u, err := url.Parse(raw)
-	if err != nil {
-		return fmt.Errorf("invalid proxy-url: %w", err)
-	}
+func validateHTTPProxyURL(u *url.URL, raw string) error {
 	if u.Scheme == "" || u.Host == "" {
 		return fmt.Errorf("invalid proxy-url %q for http: want http://host:port or https://host:port", raw)
 	}
@@ -507,12 +492,12 @@ func validateProxyAuth(auth proxyAuthOptions) error {
 	return nil
 }
 
-func validateNoSelfProxy(proxyURL, listenAddr, protocol string) error {
-	target, err := comparableProxyHostPort(proxyURL, protocol)
+func validateNoSelfProxy(u *url.URL, proxyURL, listenAddr, protocol string) error {
+	target, err := comparableProxyHostPort(u, proxyURL, protocol)
 	if err != nil {
 		return err
 	}
-	local, err := comparableListenHostPort(listenAddr)
+	local, err := normalizeHostPort(listenAddr)
 	if err != nil {
 		return err
 	}
@@ -522,30 +507,11 @@ func validateNoSelfProxy(proxyURL, listenAddr, protocol string) error {
 	return nil
 }
 
-func comparableProxyHostPort(proxyURL, protocol string) (string, error) {
-	if protocol == "grpc" {
-		u, err := url.Parse(proxyURL)
-		if err != nil {
-			return "", fmt.Errorf("invalid proxy-url: %w", err)
-		}
-		if u.Scheme == "" {
-			return normalizeHostPort(proxyURL)
-		}
-		return normalizeHostPort(u.Host)
-	}
-	u, err := url.Parse(proxyURL)
-	if err != nil {
-		return "", fmt.Errorf("invalid proxy-url: %w", err)
+func comparableProxyHostPort(u *url.URL, proxyURL, protocol string) (string, error) {
+	if protocol == "grpc" && u.Scheme == "" {
+		return normalizeHostPort(proxyURL)
 	}
 	return normalizeHostPort(u.Host)
-}
-
-func comparableListenHostPort(listenAddr string) (string, error) {
-	loopback, err := resolveLoopback(listenAddr)
-	if err != nil {
-		return "", err
-	}
-	return normalizeHostPort(loopback)
 }
 
 func normalizeHostPort(addr string) (string, error) {
@@ -559,10 +525,6 @@ func normalizeHostPort(addr string) (string, error) {
 		host = "localhost"
 	}
 	return net.JoinHostPort(host, port), nil
-}
-
-func hasProxyAuth(auth proxyAuthOptions) bool {
-	return auth.Type != "" || hasProxyAuthFields(auth)
 }
 
 func hasProxyAuthFields(auth proxyAuthOptions) bool {

--- a/cmd/otelop/start.go
+++ b/cmd/otelop/start.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -57,6 +59,8 @@ func startCommand() *cli.Command {
 			&cli.StringFlag{Name: "http", Value: cfg.HTTPAddr, Usage: "Web UI + REST API listen address", Sources: cli.EnvVars("OTELOP_HTTP")},
 			&cli.StringFlag{Name: "otlp-grpc", Value: cfg.OTLPGRPCAddr, Usage: "OTLP gRPC receiver endpoint", Sources: cli.EnvVars("OTELOP_OTLP_GRPC")},
 			&cli.StringFlag{Name: "otlp-http", Value: cfg.OTLPHTTPAddr, Usage: "OTLP HTTP receiver endpoint", Sources: cli.EnvVars("OTELOP_OTLP_HTTP")},
+			&cli.StringFlag{Name: "proxy-url", Value: cfg.ProxyURL, Usage: "upstream OTLP endpoint for forwarding", Sources: cli.EnvVars("OTELOP_PROXY_URL")},
+			&cli.StringFlag{Name: "proxy-protocol", Value: cfg.ProxyProtocol, Usage: "upstream OTLP protocol (grpc|http)", Sources: cli.EnvVars("OTELOP_PROXY_PROTOCOL")},
 			&cli.IntFlag{Name: "trace-cap", Value: cfg.TraceCap, Usage: "max traces to keep in memory", Sources: cli.EnvVars("OTELOP_TRACE_CAP")},
 			&cli.IntFlag{Name: "metric-cap", Value: cfg.MetricCap, Usage: "max metric series to keep in memory", Sources: cli.EnvVars("OTELOP_METRIC_CAP")},
 			&cli.IntFlag{Name: "log-cap", Value: cfg.LogCap, Usage: "max log entries to keep in memory", Sources: cli.EnvVars("OTELOP_LOG_CAP")},
@@ -73,6 +77,8 @@ type startOptions struct {
 	HTTPAddr      string
 	OTLPGRPCAddr  string
 	OTLPHTTPAddr  string
+	ProxyURL      string
+	ProxyProtocol string
 	TraceCap      int
 	MetricCap     int
 	LogCap        int
@@ -87,6 +93,8 @@ func optionsFromCmd(cmd *cli.Command) startOptions {
 		HTTPAddr:      cmd.String("http"),
 		OTLPGRPCAddr:  cmd.String("otlp-grpc"),
 		OTLPHTTPAddr:  cmd.String("otlp-http"),
+		ProxyURL:      strings.TrimSpace(cmd.String("proxy-url")),
+		ProxyProtocol: normalizeProxyProtocol(cmd.String("proxy-protocol")),
 		TraceCap:      cmd.Int("trace-cap"),
 		MetricCap:     cmd.Int("metric-cap"),
 		LogCap:        cmd.Int("log-cap"),
@@ -99,6 +107,9 @@ func optionsFromCmd(cmd *cli.Command) startOptions {
 
 func runStart(ctx context.Context, cmd *cli.Command) error {
 	opts := optionsFromCmd(cmd)
+	if err := validateProxyOptions(opts); err != nil {
+		return err
+	}
 	if !daemon.IsDaemonChild() && !opts.Foreground {
 		return runDaemonParent(ctx)
 	}
@@ -119,12 +130,14 @@ func runServer(ctx context.Context, opts startOptions) error {
 
 	if ready != nil {
 		meta := daemon.Metadata{
-			PID:          os.Getpid(),
-			StartedAt:    rt.startedAt,
-			HTTPAddr:     opts.HTTPAddr,
-			OTLPGRPCAddr: opts.OTLPGRPCAddr,
-			OTLPHTTPAddr: opts.OTLPHTTPAddr,
-			Version:      version,
+			PID:           os.Getpid(),
+			StartedAt:     rt.startedAt,
+			HTTPAddr:      opts.HTTPAddr,
+			OTLPGRPCAddr:  opts.OTLPGRPCAddr,
+			OTLPHTTPAddr:  opts.OTLPHTTPAddr,
+			ProxyURL:      opts.ProxyURL,
+			ProxyProtocol: opts.ProxyProtocol,
+			Version:       version,
 		}
 		if err := daemon.WriteMetadata(meta); err != nil {
 			daemon.SignalError(ready, err)
@@ -182,6 +195,7 @@ func runDaemonParent(ctx context.Context) error {
 		{"Web UI", "http://" + webUIDisplay(meta.HTTPAddr)},
 		{"OTLP gRPC", meta.OTLPGRPCAddr},
 		{"OTLP HTTP", meta.OTLPHTTPAddr},
+		{"Proxy", formatProxyStatus(meta.ProxyURL, meta.ProxyProtocol)},
 		{"Log", logPath},
 	})
 	_, _ = fmt.Fprintln(os.Stderr, "  Use `otelop status` to inspect, `otelop stop` to shut down.")
@@ -220,12 +234,14 @@ func bootstrap(ctx context.Context, opts startOptions) (*runtime, error) {
 	})
 
 	runtimeInfo := otelopgraphql.RuntimeInfo{
-		Version:      version,
-		StartedAt:    rt.startedAt,
-		HTTPAddr:     opts.HTTPAddr,
-		OTLPGRPCAddr: opts.OTLPGRPCAddr,
-		OTLPHTTPAddr: opts.OTLPHTTPAddr,
-		Debug:        opts.Debug,
+		Version:       version,
+		StartedAt:     rt.startedAt,
+		HTTPAddr:      opts.HTTPAddr,
+		OTLPGRPCAddr:  opts.OTLPGRPCAddr,
+		OTLPHTTPAddr:  opts.OTLPHTTPAddr,
+		ProxyURL:      opts.ProxyURL,
+		ProxyProtocol: opts.ProxyProtocol,
+		Debug:         opts.Debug,
 	}
 	rt.srv = server.New(rt.store, rt.hub, otelop.FrontendFS(), runtimeInfo)
 
@@ -243,9 +259,11 @@ func bootstrap(ctx context.Context, opts startOptions) (*runtime, error) {
 
 	slog.Debug("starting collector", "grpc", opts.OTLPGRPCAddr, "http", opts.OTLPHTTPAddr)
 	col, err := collector.New(otelopexporter.NewFactory(rt.store), collector.Config{
-		GRPCEndpoint: opts.OTLPGRPCAddr,
-		HTTPEndpoint: opts.OTLPHTTPAddr,
-		LogLevel:     opts.LogLevel,
+		GRPCEndpoint:  opts.OTLPGRPCAddr,
+		HTTPEndpoint:  opts.OTLPHTTPAddr,
+		ProxyURL:      opts.ProxyURL,
+		ProxyProtocol: opts.ProxyProtocol,
+		LogLevel:      opts.LogLevel,
 	})
 	if err != nil {
 		rt.shutdown()
@@ -332,9 +350,79 @@ func (r *runtime) printBanner(w io.Writer, opts startOptions) {
 		{"Web UI", "http://" + webUIDisplay(opts.HTTPAddr)},
 		{"OTLP gRPC", opts.OTLPGRPCAddr},
 		{"OTLP HTTP", opts.OTLPHTTPAddr},
+		{"Proxy", formatProxyStatus(opts.ProxyURL, opts.ProxyProtocol)},
 		{"Capacity", fmt.Sprintf("traces=%d, metrics=%d, logs=%d, points/metric=%d",
 			opts.TraceCap, opts.MetricCap, opts.LogCap, opts.MaxDataPoints)},
 	})
+}
+
+func normalizeProxyProtocol(v string) string {
+	return strings.ToLower(strings.TrimSpace(v))
+}
+
+func validateProxyOptions(opts startOptions) error {
+	if opts.ProxyURL == "" && opts.ProxyProtocol == "" {
+		return nil
+	}
+	if opts.ProxyURL == "" {
+		return errors.New("proxy-protocol requires --proxy-url")
+	}
+	if opts.ProxyProtocol == "" {
+		return errors.New("proxy-url requires --proxy-protocol (grpc|http)")
+	}
+	switch opts.ProxyProtocol {
+	case "grpc":
+		return validateGRPCProxyURL(opts.ProxyURL)
+	case "http":
+		return validateHTTPProxyURL(opts.ProxyURL)
+	default:
+		return fmt.Errorf("invalid proxy-protocol %q: want grpc or http", opts.ProxyProtocol)
+	}
+}
+
+func validateGRPCProxyURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid proxy-url: %w", err)
+	}
+	if u.Scheme == "" {
+		if raw == "" || strings.Contains(raw, "/") {
+			return fmt.Errorf("invalid proxy-url %q for grpc: want host:port or http(s)://host:port", raw)
+		}
+		return nil
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		if u.Host == "" {
+			return fmt.Errorf("invalid proxy-url %q for grpc: missing host", raw)
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid proxy-url %q for grpc: unsupported scheme %q", raw, u.Scheme)
+	}
+}
+
+func validateHTTPProxyURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid proxy-url: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("invalid proxy-url %q for http: want http://host:port or https://host:port", raw)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		return nil
+	default:
+		return fmt.Errorf("invalid proxy-url %q for http: unsupported scheme %q", raw, u.Scheme)
+	}
+}
+
+func formatProxyStatus(proxyURL, proxyProtocol string) string {
+	if proxyURL == "" || proxyProtocol == "" {
+		return "disabled"
+	}
+	return fmt.Sprintf("%s %s", strings.ToUpper(proxyProtocol), proxyURL)
 }
 
 func (r *runtime) waitForSignal(ctx context.Context) {

--- a/cmd/otelop/start_test.go
+++ b/cmd/otelop/start_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateProxyOptions_RejectsSelfProxy(t *testing.T) {
+	opts := startOptions{
+		OTLPGRPCAddr:  "0.0.0.0:4317",
+		OTLPHTTPAddr:  "0.0.0.0:4318",
+		ProxyURL:      "http://127.0.0.1:4317",
+		ProxyProtocol: "grpc",
+	}
+	err := validateProxyOptions(opts)
+	if err == nil || !strings.Contains(err.Error(), "points back to otelop's own OTLP grpc listener") {
+		t.Fatalf("validateProxyOptions error = %v", err)
+	}
+}
+
+func TestValidateProxyOptions_RejectsCredentialsInURL(t *testing.T) {
+	opts := startOptions{
+		OTLPGRPCAddr:  "0.0.0.0:4317",
+		OTLPHTTPAddr:  "0.0.0.0:4318",
+		ProxyURL:      "https://user:pass@example.com:4318",
+		ProxyProtocol: "http",
+	}
+	err := validateProxyOptions(opts)
+	if err == nil || !strings.Contains(err.Error(), "must not contain embedded credentials") {
+		t.Fatalf("validateProxyOptions error = %v", err)
+	}
+}
+
+func TestValidateProxyOptions_BearerAuth(t *testing.T) {
+	opts := startOptions{
+		OTLPGRPCAddr:  "0.0.0.0:4317",
+		OTLPHTTPAddr:  "0.0.0.0:4318",
+		ProxyURL:      "https://collector.example.com:4318",
+		ProxyProtocol: "http",
+		ProxyAuth: proxyAuthOptions{
+			Type:  "bearer",
+			Token: "token",
+		},
+	}
+	if err := validateProxyOptions(opts); err != nil {
+		t.Fatalf("validateProxyOptions: %v", err)
+	}
+}
+
+func TestBuildProxyHeaders(t *testing.T) {
+	headers := buildProxyHeaders(proxyAuthOptions{
+		Type:     "basic",
+		Username: "alice",
+		Password: "secret",
+	})
+	got := headers["Authorization"]
+	if got != "Basic YWxpY2U6c2VjcmV0" {
+		t.Fatalf("Authorization = %q", got)
+	}
+}
+
+func TestRedactURL(t *testing.T) {
+	got := redactURL("https://user:pass@example.com:4318")
+	if got != "https://REDACTED:REDACTED@example.com:4318" {
+		t.Fatalf("redactURL = %q", got)
+	}
+}

--- a/cmd/otelop/status.go
+++ b/cmd/otelop/status.go
@@ -26,14 +26,16 @@ func statusCommand() *cli.Command {
 // statusPayload mirrors the Status type in internal/graphql/schema.graphql.
 // Keep field names in sync when the schema changes.
 type statusPayload struct {
-	Version      string    `json:"version"`
-	StartedAt    time.Time `json:"startedAt"`
-	UptimeMs     float64   `json:"uptimeMs"`
-	HTTPAddr     string    `json:"httpAddr"`
-	OTLPGrpcAddr string    `json:"otlpGrpcAddr"`
-	OTLPHTTPAddr string    `json:"otlpHttpAddr"`
-	Debug        bool      `json:"debug"`
-	Config       struct {
+	Version       string    `json:"version"`
+	StartedAt     time.Time `json:"startedAt"`
+	UptimeMs      float64   `json:"uptimeMs"`
+	HTTPAddr      string    `json:"httpAddr"`
+	OTLPGrpcAddr  string    `json:"otlpGrpcAddr"`
+	OTLPHTTPAddr  string    `json:"otlpHttpAddr"`
+	ProxyURL      string    `json:"proxyUrl"`
+	ProxyProtocol string    `json:"proxyProtocol"`
+	Debug         bool      `json:"debug"`
+	Config        struct {
 		TraceCount  int32 `json:"traceCount"`
 		MetricCount int32 `json:"metricCount"`
 		LogCount    int32 `json:"logCount"`
@@ -51,6 +53,8 @@ const statusQuery = `{
     httpAddr
     otlpGrpcAddr
     otlpHttpAddr
+    proxyUrl
+    proxyProtocol
     debug
     config {
       traceCount
@@ -147,6 +151,7 @@ func printFull(w io.Writer, meta *daemon.Metadata, s *statusPayload) {
 		{"Web UI", "http://" + webUIDisplay(s.HTTPAddr)},
 		{"OTLP gRPC", s.OTLPGrpcAddr},
 		{"OTLP HTTP", s.OTLPHTTPAddr},
+		{"Proxy", formatProxyStatus(s.ProxyURL, s.ProxyProtocol)},
 		{"Buffered", fmt.Sprintf("traces=%d/%d metrics=%d/%d logs=%d/%d",
 			s.Config.TraceCount, s.Config.TraceCap,
 			s.Config.MetricCount, s.Config.MetricCap,
@@ -163,6 +168,7 @@ func printMetaOnly(w io.Writer, meta *daemon.Metadata) {
 		{"Web UI", "http://" + webUIDisplay(meta.HTTPAddr)},
 		{"OTLP gRPC", meta.OTLPGRPCAddr},
 		{"OTLP HTTP", meta.OTLPHTTPAddr},
+		{"Proxy", formatProxyStatus(meta.ProxyURL, meta.ProxyProtocol)},
 		{"Log", logFile},
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -111,9 +111,13 @@ require (
 	go.opentelemetry.io/collector/connector/connectortest v0.149.0 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.149.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.149.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.149.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.149.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.149.0 // indirect
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.149.0 // indirect
 	go.opentelemetry.io/collector/exporter/exportertest v0.149.0 // indirect
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.149.0 // indirect
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.149.0 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.149.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.55.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.149.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ go.opentelemetry.io/collector/consumer v1.55.0 h1:7Per8P4J0nlBrFVSXb+nwZ+egiel1B
 go.opentelemetry.io/collector/consumer v1.55.0/go.mod h1:Qrn5fDp/HpDmUp+l2RGKsdKyOPlgGlaZPKvw/z9FfEc=
 go.opentelemetry.io/collector/consumer/consumererror v0.149.0 h1:lXJv8UySfvnISJnCbkxf9ghYRQoWcXC78PxGurdnhKY=
 go.opentelemetry.io/collector/consumer/consumererror v0.149.0/go.mod h1:8mZKwHejnZpD0+hjg6T2ZYPzs/Ib8512DMFnx4yaknY=
+go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.149.0 h1:igOwSP5ytu2WKKl8pSzzQPWt97IY/MWA2pZ6TRlLhv8=
+go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.149.0/go.mod h1:2Ni6IZUmiqXMP8z25ka2TjedglJgXZOTkgUUmn2pzD4=
 go.opentelemetry.io/collector/consumer/consumertest v0.149.0 h1:IxOkDInfuUM8mT+rMNGtdUuuDlV9X2VS4WAQ/dZSYqg=
 go.opentelemetry.io/collector/consumer/consumertest v0.149.0/go.mod h1:ZMvFzch5IRjYBvj6WPc30HRy19smS0WFBXaOu16Wac0=
 go.opentelemetry.io/collector/consumer/xconsumer v0.149.0 h1:2z0wRTDsWqPdcC8xp9HJIAJej+07g4/yJrS0xkJJ4hA=
@@ -217,8 +219,14 @@ go.opentelemetry.io/collector/exporter v1.55.0 h1:1pExfXXKDPbwY4Be6cHd8LQOIpP7pt
 go.opentelemetry.io/collector/exporter v1.55.0/go.mod h1:Hp85myjvKjC+rLeMdVpatzYCglAv4V0MaFN8HXHfnaQ=
 go.opentelemetry.io/collector/exporter/exporterhelper v0.149.0 h1:y5eKO5aFBWYv/cSL2QnLxJ8k57STn9r+g1gdTVw9Z6Q=
 go.opentelemetry.io/collector/exporter/exporterhelper v0.149.0/go.mod h1:mR78r/JKfxu0x87YGplZsbYG6PBUyTr5bKgluc1qqNQ=
+go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.149.0 h1:oV8Yc9zgCEA2S13u0mqOdWYaPq/6VVg4dNgY7XW3p/A=
+go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.149.0/go.mod h1:nyLVBRGcwOOk9+uYpDA/+Gt3b3V7Mfu3HPvI8E2esk8=
 go.opentelemetry.io/collector/exporter/exportertest v0.149.0 h1:bmBvcffsXbDoWIEq2nSiY36+n0s2/Qd70ps5N5xObWA=
 go.opentelemetry.io/collector/exporter/exportertest v0.149.0/go.mod h1:4PrrXXNfTdkWxGT5fNiJ/70g8eRDLlQgh64UwhcjUzU=
+go.opentelemetry.io/collector/exporter/otlpexporter v0.149.0 h1:8ARBKbaxKz/pXagsHTCGCjvMzSdf5n0bVJGzC1ksilk=
+go.opentelemetry.io/collector/exporter/otlpexporter v0.149.0/go.mod h1:f0qnHmSPbCj6l/jNEyE0FMs4BtEpzY7s6Z0wEItVMBQ=
+go.opentelemetry.io/collector/exporter/otlphttpexporter v0.149.0 h1:o+Wao+WnlM4ByGsoqbnRbf3p9IwlChuHsM6R4vVg2kE=
+go.opentelemetry.io/collector/exporter/otlphttpexporter v0.149.0/go.mod h1:ZWwB3ErCJoUVez185j7kt5Eb7+l1PBclHtRTnT0kX6I=
 go.opentelemetry.io/collector/exporter/xexporter v0.149.0 h1:4uR3VnSxUVeV8igM7H3YkfKoQtndW8ZshWPjpGQIFUA=
 go.opentelemetry.io/collector/exporter/xexporter v0.149.0/go.mod h1:My5S6QPUDggCdQ4tNbUHb7/GAk5t5CoTDY1wvCqUnTs=
 go.opentelemetry.io/collector/extension v1.55.0 h1:B+1lH6sBHJPq0AX+WAtHsteqbeHQuRhHFtnjSDwSjKs=

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -2,6 +2,8 @@ package collector
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
@@ -14,31 +16,36 @@ var version = "dev"
 
 // Config holds runtime-configurable collector settings.
 type Config struct {
-	GRPCEndpoint string
-	HTTPEndpoint string
-	LogLevel     string
+	GRPCEndpoint  string
+	HTTPEndpoint  string
+	ProxyURL      string
+	ProxyProtocol string
+	LogLevel      string
 }
 
 func buildConfig(cfg Config) string {
+	exporterConfig, pipelineExporters := buildProxyExporterConfig(cfg)
+
 	return fmt.Sprintf(`
 receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: %s
+        endpoint: %q
       http:
-        endpoint: %s
+        endpoint: %q
         cors:
           allowed_origins:
             - "*"
 
 exporters:
   otelop: {}
+%s
 
 service:
   telemetry:
     logs:
-      level: %s
+      level: %q
     # Disable the Collector's own Prometheus self-metrics listener on :8888.
     # otelop doesn't consume it anywhere and the listener would conflict with
     # a second otelop instance on the same host.
@@ -47,14 +54,49 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otelop]
+      exporters: [%s]
     metrics:
       receivers: [otlp]
-      exporters: [otelop]
+      exporters: [%s]
     logs:
       receivers: [otlp]
-      exporters: [otelop]
-`, cfg.GRPCEndpoint, cfg.HTTPEndpoint, cfg.LogLevel)
+      exporters: [%s]
+`, cfg.GRPCEndpoint, cfg.HTTPEndpoint, exporterConfig, cfg.LogLevel, pipelineExporters, pipelineExporters, pipelineExporters)
+}
+
+func buildProxyExporterConfig(cfg Config) (string, string) {
+	if cfg.ProxyURL == "" || cfg.ProxyProtocol == "" {
+		return "", "otelop"
+	}
+
+	switch cfg.ProxyProtocol {
+	case "grpc":
+		endpoint, insecure := normalizeGRPCProxyURL(cfg.ProxyURL)
+		tlsConfig := ""
+		if insecure {
+			tlsConfig = "\n    tls:\n      insecure: true"
+		}
+		return fmt.Sprintf("  otlp_grpc/proxy:\n    endpoint: %q%s", endpoint, tlsConfig), "otelop, otlp_grpc/proxy"
+	case "http":
+		return fmt.Sprintf("  otlphttp/proxy:\n    endpoint: %q", cfg.ProxyURL), "otelop, otlphttp/proxy"
+	default:
+		return "", "otelop"
+	}
+}
+
+func normalizeGRPCProxyURL(raw string) (endpoint string, insecure bool) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" {
+		return raw, true
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http":
+		return u.Host, true
+	case "https":
+		return u.Host, false
+	default:
+		return raw, true
+	}
 }
 
 // New creates a new OTel Collector configured with an OTLP receiver

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 
 	"go.opentelemetry.io/collector/component"
@@ -20,6 +21,7 @@ type Config struct {
 	HTTPEndpoint  string
 	ProxyURL      string
 	ProxyProtocol string
+	ProxyHeaders  map[string]string
 	LogLevel      string
 }
 
@@ -76,12 +78,29 @@ func buildProxyExporterConfig(cfg Config) (string, string) {
 		if insecure {
 			tlsConfig = "\n    tls:\n      insecure: true"
 		}
-		return fmt.Sprintf("  otlp_grpc/proxy:\n    endpoint: %q%s", endpoint, tlsConfig), "otelop, otlp_grpc/proxy"
+		return fmt.Sprintf("  otlp_grpc/proxy:\n    endpoint: %q%s%s", endpoint, tlsConfig, renderHeaders(cfg.ProxyHeaders)), "otelop, otlp_grpc/proxy"
 	case "http":
-		return fmt.Sprintf("  otlphttp/proxy:\n    endpoint: %q", cfg.ProxyURL), "otelop, otlphttp/proxy"
+		return fmt.Sprintf("  otlphttp/proxy:\n    endpoint: %q%s", cfg.ProxyURL, renderHeaders(cfg.ProxyHeaders)), "otelop, otlphttp/proxy"
 	default:
 		return "", "otelop"
 	}
+}
+
+func renderHeaders(headers map[string]string) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(headers))
+	for k := range headers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("\n    headers:")
+	for _, k := range keys {
+		fmt.Fprintf(&b, "\n      %q: %q", k, headers[k])
+	}
+	return b.String()
 }
 
 func normalizeGRPCProxyURL(raw string) (endpoint string, insecure bool) {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -56,14 +56,14 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [%s]
+      exporters: [%[5]s]
     metrics:
       receivers: [otlp]
-      exporters: [%s]
+      exporters: [%[5]s]
     logs:
       receivers: [otlp]
-      exporters: [%s]
-`, cfg.GRPCEndpoint, cfg.HTTPEndpoint, exporterConfig, cfg.LogLevel, pipelineExporters, pipelineExporters, pipelineExporters)
+      exporters: [%[5]s]
+`, cfg.GRPCEndpoint, cfg.HTTPEndpoint, exporterConfig, cfg.LogLevel, pipelineExporters)
 }
 
 func buildProxyExporterConfig(cfg Config) (string, string) {

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1,0 +1,61 @@
+package collector
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildConfig_WithoutProxy(t *testing.T) {
+	cfg := buildConfig(Config{
+		GRPCEndpoint: "0.0.0.0:4317",
+		HTTPEndpoint: "0.0.0.0:4318",
+		LogLevel:     "warn",
+	})
+	if strings.Contains(cfg, "otlp_grpc/proxy") || strings.Contains(cfg, "otlphttp/proxy") {
+		t.Fatalf("buildConfig unexpectedly included proxy exporter:\n%s", cfg)
+	}
+	if strings.Count(cfg, "exporters: [otelop]") != 3 {
+		t.Fatalf("buildConfig should keep otelop-only pipelines:\n%s", cfg)
+	}
+}
+
+func TestBuildConfig_WithGRPCProxy(t *testing.T) {
+	cfg := buildConfig(Config{
+		GRPCEndpoint:  "0.0.0.0:4317",
+		HTTPEndpoint:  "0.0.0.0:4318",
+		ProxyURL:      "http://upstream.example.com:4317",
+		ProxyProtocol: "grpc",
+		LogLevel:      "info",
+	})
+	if !strings.Contains(cfg, `otlp_grpc/proxy:`) {
+		t.Fatalf("buildConfig missing grpc proxy exporter:\n%s", cfg)
+	}
+	if !strings.Contains(cfg, `endpoint: "upstream.example.com:4317"`) {
+		t.Fatalf("buildConfig missing normalized grpc endpoint:\n%s", cfg)
+	}
+	if !strings.Contains(cfg, "insecure: true") {
+		t.Fatalf("buildConfig missing insecure grpc tls config:\n%s", cfg)
+	}
+	if strings.Count(cfg, "exporters: [otelop, otlp_grpc/proxy]") != 3 {
+		t.Fatalf("buildConfig should fan out all pipelines to grpc proxy:\n%s", cfg)
+	}
+}
+
+func TestBuildConfig_WithHTTPProxy(t *testing.T) {
+	cfg := buildConfig(Config{
+		GRPCEndpoint:  "0.0.0.0:4317",
+		HTTPEndpoint:  "0.0.0.0:4318",
+		ProxyURL:      "http://upstream.example.com:4318",
+		ProxyProtocol: "http",
+		LogLevel:      "debug",
+	})
+	if !strings.Contains(cfg, `otlphttp/proxy:`) {
+		t.Fatalf("buildConfig missing http proxy exporter:\n%s", cfg)
+	}
+	if !strings.Contains(cfg, `endpoint: "http://upstream.example.com:4318"`) {
+		t.Fatalf("buildConfig missing http proxy endpoint:\n%s", cfg)
+	}
+	if strings.Count(cfg, "exporters: [otelop, otlphttp/proxy]") != 3 {
+		t.Fatalf("buildConfig should fan out all pipelines to http proxy:\n%s", cfg)
+	}
+}

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -25,7 +25,10 @@ func TestBuildConfig_WithGRPCProxy(t *testing.T) {
 		HTTPEndpoint:  "0.0.0.0:4318",
 		ProxyURL:      "http://upstream.example.com:4317",
 		ProxyProtocol: "grpc",
-		LogLevel:      "info",
+		ProxyHeaders: map[string]string{
+			"Authorization": "Bearer token",
+		},
+		LogLevel: "info",
 	})
 	if !strings.Contains(cfg, `otlp_grpc/proxy:`) {
 		t.Fatalf("buildConfig missing grpc proxy exporter:\n%s", cfg)
@@ -35,6 +38,9 @@ func TestBuildConfig_WithGRPCProxy(t *testing.T) {
 	}
 	if !strings.Contains(cfg, "insecure: true") {
 		t.Fatalf("buildConfig missing insecure grpc tls config:\n%s", cfg)
+	}
+	if !strings.Contains(cfg, `"Authorization": "Bearer token"`) {
+		t.Fatalf("buildConfig missing grpc proxy headers:\n%s", cfg)
 	}
 	if strings.Count(cfg, "exporters: [otelop, otlp_grpc/proxy]") != 3 {
 		t.Fatalf("buildConfig should fan out all pipelines to grpc proxy:\n%s", cfg)
@@ -47,13 +53,19 @@ func TestBuildConfig_WithHTTPProxy(t *testing.T) {
 		HTTPEndpoint:  "0.0.0.0:4318",
 		ProxyURL:      "http://upstream.example.com:4318",
 		ProxyProtocol: "http",
-		LogLevel:      "debug",
+		ProxyHeaders: map[string]string{
+			"x-api-key": "secret",
+		},
+		LogLevel: "debug",
 	})
 	if !strings.Contains(cfg, `otlphttp/proxy:`) {
 		t.Fatalf("buildConfig missing http proxy exporter:\n%s", cfg)
 	}
 	if !strings.Contains(cfg, `endpoint: "http://upstream.example.com:4318"`) {
 		t.Fatalf("buildConfig missing http proxy endpoint:\n%s", cfg)
+	}
+	if !strings.Contains(cfg, `"x-api-key": "secret"`) {
+		t.Fatalf("buildConfig missing http proxy headers:\n%s", cfg)
 	}
 	if strings.Count(cfg, "exporters: [otelop, otlphttp/proxy]") != 3 {
 		t.Fatalf("buildConfig should fan out all pipelines to http proxy:\n%s", cfg)

--- a/internal/collector/components.go
+++ b/internal/collector/components.go
@@ -3,6 +3,8 @@ package collector
 import (
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.opentelemetry.io/collector/processor"
@@ -21,6 +23,8 @@ func components(exporterFactory exporter.Factory) (otelcol.Factories, error) {
 
 	exporters, err := otelcol.MakeFactoryMap[exporter.Factory](
 		exporterFactory,
+		otlpexporter.NewFactory(),
+		otlphttpexporter.NewFactory(),
 	)
 	if err != nil {
 		return otelcol.Factories{}, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,8 @@ const (
 	DefaultHTTPAddr      = ":4319"
 	DefaultOTLPGRPCAddr  = "0.0.0.0:4317"
 	DefaultOTLPHTTPAddr  = "0.0.0.0:4318"
+	DefaultProxyURL      = ""
+	DefaultProxyProtocol = ""
 	DefaultTraceCap      = 1000
 	DefaultMetricCap     = 3000
 	DefaultLogCap        = 1000
@@ -44,6 +46,8 @@ type Config struct {
 	HTTPAddr      string `toml:"http"`
 	OTLPGRPCAddr  string `toml:"otlp_grpc"`
 	OTLPHTTPAddr  string `toml:"otlp_http"`
+	ProxyURL      string `toml:"proxy_url"`
+	ProxyProtocol string `toml:"proxy_protocol"`
 	TraceCap      int    `toml:"trace_cap"`
 	MetricCap     int    `toml:"metric_cap"`
 	LogCap        int    `toml:"log_cap"`
@@ -60,6 +64,8 @@ func Defaults() Config {
 		HTTPAddr:      DefaultHTTPAddr,
 		OTLPGRPCAddr:  DefaultOTLPGRPCAddr,
 		OTLPHTTPAddr:  DefaultOTLPHTTPAddr,
+		ProxyURL:      DefaultProxyURL,
+		ProxyProtocol: DefaultProxyProtocol,
 		TraceCap:      DefaultTraceCap,
 		MetricCap:     DefaultMetricCap,
 		LogCap:        DefaultLogCap,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ const (
 	DefaultOTLPHTTPAddr  = "0.0.0.0:4318"
 	DefaultProxyURL      = ""
 	DefaultProxyProtocol = ""
+	DefaultProxyAuthType = ""
 	DefaultTraceCap      = 1000
 	DefaultMetricCap     = 3000
 	DefaultLogCap        = 1000
@@ -39,21 +40,34 @@ const (
 	DefaultLogLevel      = "warn"
 )
 
+type ProxyAuthConfig struct {
+	Type     string            `toml:"type"`
+	Token    string            `toml:"token"`
+	Username string            `toml:"username"`
+	Password string            `toml:"password"`
+	Headers  map[string]string `toml:"headers"`
+}
+
+type ProxyConfig struct {
+	URL      string          `toml:"url"`
+	Protocol string          `toml:"protocol"`
+	Auth     ProxyAuthConfig `toml:"auth"`
+}
+
 // Config is the on-disk shape of the TOML config file. Fields use snake_case
 // keys to match TOML conventions (CLI flags are kebab-case, env vars are
 // SCREAMING_SNAKE — pick whichever surface is most ergonomic).
 type Config struct {
-	HTTPAddr      string `toml:"http"`
-	OTLPGRPCAddr  string `toml:"otlp_grpc"`
-	OTLPHTTPAddr  string `toml:"otlp_http"`
-	ProxyURL      string `toml:"proxy_url"`
-	ProxyProtocol string `toml:"proxy_protocol"`
-	TraceCap      int    `toml:"trace_cap"`
-	MetricCap     int    `toml:"metric_cap"`
-	LogCap        int    `toml:"log_cap"`
-	MaxDataPoints int    `toml:"max_data_points"`
-	LogLevel      string `toml:"log_level"`
-	Debug         bool   `toml:"debug"`
+	HTTPAddr      string      `toml:"http"`
+	OTLPGRPCAddr  string      `toml:"otlp_grpc"`
+	OTLPHTTPAddr  string      `toml:"otlp_http"`
+	Proxy         ProxyConfig `toml:"proxy"`
+	TraceCap      int         `toml:"trace_cap"`
+	MetricCap     int         `toml:"metric_cap"`
+	LogCap        int         `toml:"log_cap"`
+	MaxDataPoints int         `toml:"max_data_points"`
+	LogLevel      string      `toml:"log_level"`
+	Debug         bool        `toml:"debug"`
 }
 
 // Defaults returns a Config populated with the built-in fallback values.
@@ -61,11 +75,16 @@ type Config struct {
 // values.
 func Defaults() Config {
 	return Config{
-		HTTPAddr:      DefaultHTTPAddr,
-		OTLPGRPCAddr:  DefaultOTLPGRPCAddr,
-		OTLPHTTPAddr:  DefaultOTLPHTTPAddr,
-		ProxyURL:      DefaultProxyURL,
-		ProxyProtocol: DefaultProxyProtocol,
+		HTTPAddr:     DefaultHTTPAddr,
+		OTLPGRPCAddr: DefaultOTLPGRPCAddr,
+		OTLPHTTPAddr: DefaultOTLPHTTPAddr,
+		Proxy: ProxyConfig{
+			URL:      DefaultProxyURL,
+			Protocol: DefaultProxyProtocol,
+			Auth: ProxyAuthConfig{
+				Type: DefaultProxyAuthType,
+			},
+		},
 		TraceCap:      DefaultTraceCap,
 		MetricCap:     DefaultMetricCap,
 		LogCap:        DefaultLogCap,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,9 +30,6 @@ const (
 	DefaultHTTPAddr      = ":4319"
 	DefaultOTLPGRPCAddr  = "0.0.0.0:4317"
 	DefaultOTLPHTTPAddr  = "0.0.0.0:4318"
-	DefaultProxyURL      = ""
-	DefaultProxyProtocol = ""
-	DefaultProxyAuthType = ""
 	DefaultTraceCap      = 1000
 	DefaultMetricCap     = 3000
 	DefaultLogCap        = 1000
@@ -75,16 +72,9 @@ type Config struct {
 // values.
 func Defaults() Config {
 	return Config{
-		HTTPAddr:     DefaultHTTPAddr,
-		OTLPGRPCAddr: DefaultOTLPGRPCAddr,
-		OTLPHTTPAddr: DefaultOTLPHTTPAddr,
-		Proxy: ProxyConfig{
-			URL:      DefaultProxyURL,
-			Protocol: DefaultProxyProtocol,
-			Auth: ProxyAuthConfig{
-				Type: DefaultProxyAuthType,
-			},
-		},
+		HTTPAddr:      DefaultHTTPAddr,
+		OTLPGRPCAddr:  DefaultOTLPGRPCAddr,
+		OTLPHTTPAddr:  DefaultOTLPHTTPAddr,
 		TraceCap:      DefaultTraceCap,
 		MetricCap:     DefaultMetricCap,
 		LogCap:        DefaultLogCap,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,8 +57,8 @@ debug = true
 	if cfg.OTLPGRPCAddr != DefaultOTLPGRPCAddr {
 		t.Errorf("OTLPGRPCAddr = %q, want default %q", cfg.OTLPGRPCAddr, DefaultOTLPGRPCAddr)
 	}
-	if cfg.ProxyURL != DefaultProxyURL {
-		t.Errorf("ProxyURL = %q, want default %q", cfg.ProxyURL, DefaultProxyURL)
+	if cfg.Proxy.URL != DefaultProxyURL {
+		t.Errorf("Proxy.URL = %q, want default %q", cfg.Proxy.URL, DefaultProxyURL)
 	}
 	if cfg.LogLevel != DefaultLogLevel {
 		t.Errorf("LogLevel = %q, want default %q", cfg.LogLevel, DefaultLogLevel)
@@ -69,8 +69,16 @@ func TestLoad_ProxySettings(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	body := `
-proxy_url = "https://upstream.example.com:4317"
-proxy_protocol = "grpc"
+[proxy]
+url = "https://upstream.example.com:4317"
+protocol = "grpc"
+
+[proxy.auth]
+type = "headers"
+
+[proxy.auth.headers]
+Authorization = "Bearer abc"
+X-Api-Key = "secret"
 `
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -81,11 +89,17 @@ proxy_protocol = "grpc"
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.ProxyURL != "https://upstream.example.com:4317" {
-		t.Errorf("ProxyURL = %q", cfg.ProxyURL)
+	if cfg.Proxy.URL != "https://upstream.example.com:4317" {
+		t.Errorf("Proxy.URL = %q", cfg.Proxy.URL)
 	}
-	if cfg.ProxyProtocol != "grpc" {
-		t.Errorf("ProxyProtocol = %q", cfg.ProxyProtocol)
+	if cfg.Proxy.Protocol != "grpc" {
+		t.Errorf("Proxy.Protocol = %q", cfg.Proxy.Protocol)
+	}
+	if cfg.Proxy.Auth.Type != "headers" {
+		t.Errorf("Proxy.Auth.Type = %q", cfg.Proxy.Auth.Type)
+	}
+	if got := cfg.Proxy.Auth.Headers["Authorization"]; got != "Bearer abc" {
+		t.Errorf("Proxy.Auth.Headers[Authorization] = %q", got)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,8 +57,8 @@ debug = true
 	if cfg.OTLPGRPCAddr != DefaultOTLPGRPCAddr {
 		t.Errorf("OTLPGRPCAddr = %q, want default %q", cfg.OTLPGRPCAddr, DefaultOTLPGRPCAddr)
 	}
-	if cfg.Proxy.URL != DefaultProxyURL {
-		t.Errorf("Proxy.URL = %q, want default %q", cfg.Proxy.URL, DefaultProxyURL)
+	if cfg.Proxy.URL != "" {
+		t.Errorf("Proxy.URL = %q, want empty default", cfg.Proxy.URL)
 	}
 	if cfg.LogLevel != DefaultLogLevel {
 		t.Errorf("LogLevel = %q, want default %q", cfg.LogLevel, DefaultLogLevel)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,8 +57,35 @@ debug = true
 	if cfg.OTLPGRPCAddr != DefaultOTLPGRPCAddr {
 		t.Errorf("OTLPGRPCAddr = %q, want default %q", cfg.OTLPGRPCAddr, DefaultOTLPGRPCAddr)
 	}
+	if cfg.ProxyURL != DefaultProxyURL {
+		t.Errorf("ProxyURL = %q, want default %q", cfg.ProxyURL, DefaultProxyURL)
+	}
 	if cfg.LogLevel != DefaultLogLevel {
 		t.Errorf("LogLevel = %q, want default %q", cfg.LogLevel, DefaultLogLevel)
+	}
+}
+
+func TestLoad_ProxySettings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := `
+proxy_url = "https://upstream.example.com:4317"
+proxy_protocol = "grpc"
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv(EnvConfigFile, path)
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.ProxyURL != "https://upstream.example.com:4317" {
+		t.Errorf("ProxyURL = %q", cfg.ProxyURL)
+	}
+	if cfg.ProxyProtocol != "grpc" {
+		t.Errorf("ProxyProtocol = %q", cfg.ProxyProtocol)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -86,12 +86,14 @@ func MetadataFile() (string, error) {
 // intentionally kept out of this file — they come from the GraphQL status
 // query so we have a single source of truth.
 type Metadata struct {
-	PID          int       `json:"pid"`
-	StartedAt    time.Time `json:"startedAt"`
-	HTTPAddr     string    `json:"httpAddr"`
-	OTLPGRPCAddr string    `json:"otlpGrpcAddr"`
-	OTLPHTTPAddr string    `json:"otlpHttpAddr"`
-	Version      string    `json:"version"`
+	PID           int       `json:"pid"`
+	StartedAt     time.Time `json:"startedAt"`
+	HTTPAddr      string    `json:"httpAddr"`
+	OTLPGRPCAddr  string    `json:"otlpGrpcAddr"`
+	OTLPHTTPAddr  string    `json:"otlpHttpAddr"`
+	ProxyURL      string    `json:"proxyUrl"`
+	ProxyProtocol string    `json:"proxyProtocol"`
+	Version       string    `json:"version"`
 }
 
 // WriteMetadata atomically writes the metadata file via temp + rename so

--- a/internal/graphql/resolver.go
+++ b/internal/graphql/resolver.go
@@ -42,6 +42,8 @@ func (s *StatusResolver) UptimeMs() float64 {
 func (s *StatusResolver) HTTPAddr() string        { return s.parent.runtime.HTTPAddr }
 func (s *StatusResolver) OTLPGrpcAddr() string    { return s.parent.runtime.OTLPGRPCAddr }
 func (s *StatusResolver) OTLPHTTPAddr() string    { return s.parent.runtime.OTLPHTTPAddr }
+func (s *StatusResolver) ProxyURL() string        { return s.parent.runtime.ProxyURL }
+func (s *StatusResolver) ProxyProtocol() string   { return s.parent.runtime.ProxyProtocol }
 func (s *StatusResolver) Debug() bool             { return s.parent.runtime.Debug }
 func (s *StatusResolver) Config() *ConfigResolver { return s.parent.Config() }
 

--- a/internal/graphql/schema.go
+++ b/internal/graphql/schema.go
@@ -27,12 +27,14 @@ var schemaSource string
 // `status` query can report process-level state without reaching into
 // package globals.
 type RuntimeInfo struct {
-	Version      string
-	StartedAt    time.Time
-	HTTPAddr     string
-	OTLPGRPCAddr string
-	OTLPHTTPAddr string
-	Debug        bool
+	Version       string
+	StartedAt     time.Time
+	HTTPAddr      string
+	OTLPGRPCAddr  string
+	OTLPHTTPAddr  string
+	ProxyURL      string
+	ProxyProtocol string
+	Debug         bool
 }
 
 // MustNewSchema parses the embedded schema and binds it to a resolver backed

--- a/internal/graphql/schema.graphql
+++ b/internal/graphql/schema.graphql
@@ -56,6 +56,10 @@ type Status {
   otlpGrpcAddr: String!
   "OTLP HTTP receiver listen address."
   otlpHttpAddr: String!
+  "Upstream OTLP forwarding target, or empty when forwarding is disabled."
+  proxyUrl: String!
+  "Upstream OTLP forwarding protocol (`grpc` or `http`), or empty when disabled."
+  proxyProtocol: String!
   "True when self-telemetry is enabled via --debug."
   debug: Boolean!
   "Ring buffer capacity and current counts."

--- a/internal/graphql/schema_test.go
+++ b/internal/graphql/schema_test.go
@@ -118,12 +118,14 @@ func TestStatusQuery(t *testing.T) {
 	s := seedStore(t)
 	started := time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC)
 	runtime := otelopgraphql.RuntimeInfo{
-		Version:      "v1.2.3",
-		StartedAt:    started,
-		HTTPAddr:     ":4319",
-		OTLPGRPCAddr: "0.0.0.0:4317",
-		OTLPHTTPAddr: "0.0.0.0:4318",
-		Debug:        true,
+		Version:       "v1.2.3",
+		StartedAt:     started,
+		HTTPAddr:      ":4319",
+		OTLPGRPCAddr:  "0.0.0.0:4317",
+		OTLPHTTPAddr:  "0.0.0.0:4318",
+		ProxyURL:      "https://upstream.example.com:4317",
+		ProxyProtocol: "grpc",
+		Debug:         true,
 	}
 	schema := otelopgraphql.MustNewSchema(s, runtime)
 	resp := schema.Exec(context.Background(), `{
@@ -133,6 +135,8 @@ func TestStatusQuery(t *testing.T) {
 			httpAddr
 			otlpGrpcAddr
 			otlpHttpAddr
+			proxyUrl
+			proxyProtocol
 			debug
 			config { traceCount metricCount logCount traceCap }
 		}
@@ -153,6 +157,12 @@ func TestStatusQuery(t *testing.T) {
 	}
 	if st["otlpGrpcAddr"] != "0.0.0.0:4317" {
 		t.Errorf("otlpGrpcAddr = %v", st["otlpGrpcAddr"])
+	}
+	if st["proxyUrl"] != "https://upstream.example.com:4317" {
+		t.Errorf("proxyUrl = %v", st["proxyUrl"])
+	}
+	if st["proxyProtocol"] != "grpc" {
+		t.Errorf("proxyProtocol = %v", st["proxyProtocol"])
 	}
 	if st["debug"] != true {
 		t.Errorf("debug = %v", st["debug"])


### PR DESCRIPTION
## Summary

- add single-upstream OTLP proxy forwarding for gRPC and HTTP
- add proxy auth support for bearer, basic, and custom headers
- reject self-proxy configurations and URLs with embedded credentials
- redact proxy URLs in status and daemon metadata
- add config, collector, and CLI tests for proxy behavior

## Verification

- mise run check
- mise run test

## Notes

- keeps TOML proxy config under [proxy] and [proxy.auth]
- follows up on the review findings around self-recursion and credential leakage
