### PR TITLE
refactor(collector): build embedded collector config via confmap

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -14,6 +14,8 @@ import (
 
 var version = "dev"
 
+type obj map[string]any
+
 // Config holds runtime-configurable collector settings.
 type Config struct {
 	GRPCEndpoint  string
@@ -27,54 +29,66 @@ type Config struct {
 func buildConfigMap(cfg Config) map[string]any {
 	exporters, pipelineExporters := buildProxyExporterConfig(cfg)
 
-	return map[string]any{
-		"receivers": map[string]any{
-			"otlp": map[string]any{
-				"protocols": map[string]any{
-					"grpc": map[string]any{
-						"endpoint": cfg.GRPCEndpoint,
-					},
-					"http": map[string]any{
-						"endpoint": cfg.HTTPEndpoint,
-						"cors": map[string]any{
-							"allowed_origins": []any{"*"},
-						},
-					},
-				},
-			},
-		},
+	return obj{
+		"receivers": buildReceiversConfig(cfg),
 		"exporters": exporters,
-		"service": map[string]any{
-			"telemetry": map[string]any{
-				"logs": map[string]any{
-					"level": cfg.LogLevel,
+		"service":   buildServiceConfig(cfg, pipelineExporters),
+	}
+}
+
+func buildReceiversConfig(cfg Config) obj {
+	return obj{
+		"otlp": obj{
+			"protocols": obj{
+				"grpc": obj{
+					"endpoint": cfg.GRPCEndpoint,
 				},
-				// Disable the Collector's own Prometheus self-metrics listener on :8888.
-				// otelop doesn't consume it anywhere and the listener would conflict with
-				// a second otelop instance on the same host.
-				"metrics": map[string]any{
-					"level": "none",
+				"http": obj{
+					"endpoint": cfg.HTTPEndpoint,
+					"cors": obj{
+						"allowed_origins": []any{"*"},
+					},
 				},
-			},
-			"pipelines": map[string]any{
-				"traces":  buildPipelineConfig(pipelineExporters),
-				"metrics": buildPipelineConfig(pipelineExporters),
-				"logs":    buildPipelineConfig(pipelineExporters),
 			},
 		},
 	}
 }
 
-func buildPipelineConfig(exporters []any) map[string]any {
-	return map[string]any{
+func buildServiceConfig(cfg Config, pipelineExporters []any) obj {
+	return obj{
+		"telemetry": buildTelemetryConfig(cfg),
+		"pipelines": obj{
+			"traces":  buildPipelineConfig(pipelineExporters),
+			"metrics": buildPipelineConfig(pipelineExporters),
+			"logs":    buildPipelineConfig(pipelineExporters),
+		},
+	}
+}
+
+func buildTelemetryConfig(cfg Config) obj {
+	return obj{
+		"logs": obj{
+			"level": cfg.LogLevel,
+		},
+		// Disable the Collector's own Prometheus self-metrics listener on :8888.
+		// otelop doesn't consume it anywhere and the listener would conflict with
+		// a second otelop instance on the same host.
+		"metrics": obj{
+			"level": "none",
+		},
+	}
+}
+
+func buildPipelineConfig(exporters []any) obj {
+	return obj{
 		"receivers": []any{"otlp"},
 		"exporters": exporters,
 	}
 }
 
-func buildProxyExporterConfig(cfg Config) (map[string]any, []any) {
-	exporters := map[string]any{
-		"otelop": map[string]any{},
+func buildProxyExporterConfig(cfg Config) (obj, []any) {
+	exporters := obj{
+		"otelop": obj{},
 	}
 	pipelineExporters := []any{"otelop"}
 	if cfg.ProxyURL == "" || cfg.ProxyProtocol == "" {
@@ -84,11 +98,11 @@ func buildProxyExporterConfig(cfg Config) (map[string]any, []any) {
 	switch cfg.ProxyProtocol {
 	case "grpc":
 		endpoint, insecure := normalizeGRPCProxyURL(cfg.ProxyURL)
-		exp := map[string]any{
+		exp := obj{
 			"endpoint": endpoint,
 		}
 		if insecure {
-			exp["tls"] = map[string]any{"insecure": true}
+			exp["tls"] = obj{"insecure": true}
 		}
 		if headers := renderHeaders(cfg.ProxyHeaders); len(headers) > 0 {
 			exp["headers"] = headers
@@ -96,7 +110,7 @@ func buildProxyExporterConfig(cfg Config) (map[string]any, []any) {
 		exporters["otlp_grpc/proxy"] = exp
 		pipelineExporters = append(pipelineExporters, "otlp_grpc/proxy")
 	case "http":
-		exp := map[string]any{
+		exp := obj{
 			"endpoint": cfg.ProxyURL,
 		}
 		if headers := renderHeaders(cfg.ProxyHeaders); len(headers) > 0 {
@@ -108,7 +122,7 @@ func buildProxyExporterConfig(cfg Config) (map[string]any, []any) {
 	return exporters, pipelineExporters
 }
 
-func renderHeaders(headers map[string]string) map[string]any {
+func renderHeaders(headers map[string]string) obj {
 	if len(headers) == 0 {
 		return nil
 	}
@@ -117,7 +131,7 @@ func renderHeaders(headers map[string]string) map[string]any {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	out := make(map[string]any, len(headers))
+	out := make(obj, len(headers))
 	for _, k := range keys {
 		out[k] = headers[k]
 	}
@@ -172,14 +186,14 @@ func New(exporterFactory exporter.Factory, cfg Config) (*otelcol.Collector, erro
 	return otelcol.NewCollector(set)
 }
 
-func newStaticProviderFactory(cfg map[string]any) confmap.ProviderFactory {
+func newStaticProviderFactory(cfg obj) confmap.ProviderFactory {
 	return confmap.NewProviderFactory(func(confmap.ProviderSettings) confmap.Provider {
 		return &staticProvider{cfg: cfg}
 	})
 }
 
 type staticProvider struct {
-	cfg map[string]any
+	cfg obj
 }
 
 func (p *staticProvider) Retrieve(_ context.Context, _ string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -1,14 +1,13 @@
 package collector
 
 import (
-	"fmt"
+	"context"
 	"net/url"
 	"sort"
 	"strings"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
-	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/otelcol"
 )
@@ -25,82 +24,104 @@ type Config struct {
 	LogLevel      string
 }
 
-func buildConfig(cfg Config) string {
-	exporterConfig, pipelineExporters := buildProxyExporterConfig(cfg)
+func buildConfigMap(cfg Config) map[string]any {
+	exporters, pipelineExporters := buildProxyExporterConfig(cfg)
 
-	return fmt.Sprintf(`
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: %q
-      http:
-        endpoint: %q
-        cors:
-          allowed_origins:
-            - "*"
-
-exporters:
-  otelop: {}
-%s
-
-service:
-  telemetry:
-    logs:
-      level: %q
-    # Disable the Collector's own Prometheus self-metrics listener on :8888.
-    # otelop doesn't consume it anywhere and the listener would conflict with
-    # a second otelop instance on the same host.
-    metrics:
-      level: none
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [%[5]s]
-    metrics:
-      receivers: [otlp]
-      exporters: [%[5]s]
-    logs:
-      receivers: [otlp]
-      exporters: [%[5]s]
-`, cfg.GRPCEndpoint, cfg.HTTPEndpoint, exporterConfig, cfg.LogLevel, pipelineExporters)
+	return map[string]any{
+		"receivers": map[string]any{
+			"otlp": map[string]any{
+				"protocols": map[string]any{
+					"grpc": map[string]any{
+						"endpoint": cfg.GRPCEndpoint,
+					},
+					"http": map[string]any{
+						"endpoint": cfg.HTTPEndpoint,
+						"cors": map[string]any{
+							"allowed_origins": []any{"*"},
+						},
+					},
+				},
+			},
+		},
+		"exporters": exporters,
+		"service": map[string]any{
+			"telemetry": map[string]any{
+				"logs": map[string]any{
+					"level": cfg.LogLevel,
+				},
+				// Disable the Collector's own Prometheus self-metrics listener on :8888.
+				// otelop doesn't consume it anywhere and the listener would conflict with
+				// a second otelop instance on the same host.
+				"metrics": map[string]any{
+					"level": "none",
+				},
+			},
+			"pipelines": map[string]any{
+				"traces":  buildPipelineConfig(pipelineExporters),
+				"metrics": buildPipelineConfig(pipelineExporters),
+				"logs":    buildPipelineConfig(pipelineExporters),
+			},
+		},
+	}
 }
 
-func buildProxyExporterConfig(cfg Config) (string, string) {
+func buildPipelineConfig(exporters []any) map[string]any {
+	return map[string]any{
+		"receivers": []any{"otlp"},
+		"exporters": exporters,
+	}
+}
+
+func buildProxyExporterConfig(cfg Config) (map[string]any, []any) {
+	exporters := map[string]any{
+		"otelop": map[string]any{},
+	}
+	pipelineExporters := []any{"otelop"}
 	if cfg.ProxyURL == "" || cfg.ProxyProtocol == "" {
-		return "", "otelop"
+		return exporters, pipelineExporters
 	}
 
 	switch cfg.ProxyProtocol {
 	case "grpc":
 		endpoint, insecure := normalizeGRPCProxyURL(cfg.ProxyURL)
-		tlsConfig := ""
-		if insecure {
-			tlsConfig = "\n    tls:\n      insecure: true"
+		exp := map[string]any{
+			"endpoint": endpoint,
 		}
-		return fmt.Sprintf("  otlp_grpc/proxy:\n    endpoint: %q%s%s", endpoint, tlsConfig, renderHeaders(cfg.ProxyHeaders)), "otelop, otlp_grpc/proxy"
+		if insecure {
+			exp["tls"] = map[string]any{"insecure": true}
+		}
+		if headers := renderHeaders(cfg.ProxyHeaders); len(headers) > 0 {
+			exp["headers"] = headers
+		}
+		exporters["otlp_grpc/proxy"] = exp
+		pipelineExporters = append(pipelineExporters, "otlp_grpc/proxy")
 	case "http":
-		return fmt.Sprintf("  otlphttp/proxy:\n    endpoint: %q%s", cfg.ProxyURL, renderHeaders(cfg.ProxyHeaders)), "otelop, otlphttp/proxy"
-	default:
-		return "", "otelop"
+		exp := map[string]any{
+			"endpoint": cfg.ProxyURL,
+		}
+		if headers := renderHeaders(cfg.ProxyHeaders); len(headers) > 0 {
+			exp["headers"] = headers
+		}
+		exporters["otlphttp/proxy"] = exp
+		pipelineExporters = append(pipelineExporters, "otlphttp/proxy")
 	}
+	return exporters, pipelineExporters
 }
 
-func renderHeaders(headers map[string]string) string {
+func renderHeaders(headers map[string]string) map[string]any {
 	if len(headers) == 0 {
-		return ""
+		return nil
 	}
 	keys := make([]string, 0, len(headers))
 	for k := range headers {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	var b strings.Builder
-	b.WriteString("\n    headers:")
+	out := make(map[string]any, len(headers))
 	for _, k := range keys {
-		fmt.Fprintf(&b, "\n      %q: %q", k, headers[k])
+		out[k] = headers[k]
 	}
-	return b.String()
+	return out
 }
 
 func normalizeGRPCProxyURL(raw string) (endpoint string, insecure bool) {
@@ -126,7 +147,7 @@ func New(exporterFactory exporter.Factory, cfg Config) (*otelcol.Collector, erro
 		return nil, err
 	}
 
-	yamlConfig := buildConfig(cfg)
+	providerFactory := newStaticProviderFactory(buildConfigMap(cfg))
 
 	set := otelcol.CollectorSettings{
 		BuildInfo: component.BuildInfo{
@@ -139,9 +160,9 @@ func New(exporterFactory exporter.Factory, cfg Config) (*otelcol.Collector, erro
 		},
 		ConfigProviderSettings: otelcol.ConfigProviderSettings{
 			ResolverSettings: confmap.ResolverSettings{
-				URIs: []string{"yaml:" + yamlConfig},
+				URIs: []string{"otelop:config"},
 				ProviderFactories: []confmap.ProviderFactory{
-					yamlprovider.NewFactory(),
+					providerFactory,
 				},
 			},
 		},
@@ -149,4 +170,26 @@ func New(exporterFactory exporter.Factory, cfg Config) (*otelcol.Collector, erro
 	}
 
 	return otelcol.NewCollector(set)
+}
+
+func newStaticProviderFactory(cfg map[string]any) confmap.ProviderFactory {
+	return confmap.NewProviderFactory(func(confmap.ProviderSettings) confmap.Provider {
+		return &staticProvider{cfg: cfg}
+	})
+}
+
+type staticProvider struct {
+	cfg map[string]any
+}
+
+func (p *staticProvider) Retrieve(_ context.Context, _ string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
+	return confmap.NewRetrieved(p.cfg)
+}
+
+func (p *staticProvider) Scheme() string {
+	return "otelop"
+}
+
+func (p *staticProvider) Shutdown(context.Context) error {
+	return nil
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1,26 +1,34 @@
 package collector
 
 import (
-	"strings"
+	"reflect"
 	"testing"
 )
 
-func TestBuildConfig_WithoutProxy(t *testing.T) {
-	cfg := buildConfig(Config{
+func TestBuildConfigMap_WithoutProxy(t *testing.T) {
+	cfg := buildConfigMap(Config{
 		GRPCEndpoint: "0.0.0.0:4317",
 		HTTPEndpoint: "0.0.0.0:4318",
 		LogLevel:     "warn",
 	})
-	if strings.Contains(cfg, "otlp_grpc/proxy") || strings.Contains(cfg, "otlphttp/proxy") {
-		t.Fatalf("buildConfig unexpectedly included proxy exporter:\n%s", cfg)
+	exporters := cfg["exporters"].(map[string]any)
+	if _, ok := exporters["otlp_grpc/proxy"]; ok {
+		t.Fatalf("buildConfigMap unexpectedly included grpc proxy exporter")
 	}
-	if strings.Count(cfg, "exporters: [otelop]") != 3 {
-		t.Fatalf("buildConfig should keep otelop-only pipelines:\n%s", cfg)
+	if _, ok := exporters["otlphttp/proxy"]; ok {
+		t.Fatalf("buildConfigMap unexpectedly included http proxy exporter")
+	}
+	pipelines := cfg["service"].(map[string]any)["pipelines"].(map[string]any)
+	for _, name := range []string{"traces", "metrics", "logs"} {
+		got := pipelines[name].(map[string]any)["exporters"].([]any)
+		if !reflect.DeepEqual(got, []any{"otelop"}) {
+			t.Fatalf("%s exporters = %#v", name, got)
+		}
 	}
 }
 
-func TestBuildConfig_WithGRPCProxy(t *testing.T) {
-	cfg := buildConfig(Config{
+func TestBuildConfigMap_WithGRPCProxy(t *testing.T) {
+	cfg := buildConfigMap(Config{
 		GRPCEndpoint:  "0.0.0.0:4317",
 		HTTPEndpoint:  "0.0.0.0:4318",
 		ProxyURL:      "http://upstream.example.com:4317",
@@ -30,25 +38,32 @@ func TestBuildConfig_WithGRPCProxy(t *testing.T) {
 		},
 		LogLevel: "info",
 	})
-	if !strings.Contains(cfg, `otlp_grpc/proxy:`) {
-		t.Fatalf("buildConfig missing grpc proxy exporter:\n%s", cfg)
+	exporters := cfg["exporters"].(map[string]any)
+	exp, ok := exporters["otlp_grpc/proxy"].(map[string]any)
+	if !ok {
+		t.Fatalf("buildConfigMap missing grpc proxy exporter")
 	}
-	if !strings.Contains(cfg, `endpoint: "upstream.example.com:4317"`) {
-		t.Fatalf("buildConfig missing normalized grpc endpoint:\n%s", cfg)
+	if exp["endpoint"] != "upstream.example.com:4317" {
+		t.Fatalf("grpc endpoint = %#v", exp["endpoint"])
 	}
-	if !strings.Contains(cfg, "insecure: true") {
-		t.Fatalf("buildConfig missing insecure grpc tls config:\n%s", cfg)
+	if !reflect.DeepEqual(exp["tls"], map[string]any{"insecure": true}) {
+		t.Fatalf("grpc tls = %#v", exp["tls"])
 	}
-	if !strings.Contains(cfg, `"Authorization": "Bearer token"`) {
-		t.Fatalf("buildConfig missing grpc proxy headers:\n%s", cfg)
+	headers := exp["headers"].(map[string]any)
+	if headers["Authorization"] != "Bearer token" {
+		t.Fatalf("grpc headers = %#v", headers)
 	}
-	if strings.Count(cfg, "exporters: [otelop, otlp_grpc/proxy]") != 3 {
-		t.Fatalf("buildConfig should fan out all pipelines to grpc proxy:\n%s", cfg)
+	pipelines := cfg["service"].(map[string]any)["pipelines"].(map[string]any)
+	for _, name := range []string{"traces", "metrics", "logs"} {
+		got := pipelines[name].(map[string]any)["exporters"].([]any)
+		if !reflect.DeepEqual(got, []any{"otelop", "otlp_grpc/proxy"}) {
+			t.Fatalf("%s exporters = %#v", name, got)
+		}
 	}
 }
 
-func TestBuildConfig_WithHTTPProxy(t *testing.T) {
-	cfg := buildConfig(Config{
+func TestBuildConfigMap_WithHTTPProxy(t *testing.T) {
+	cfg := buildConfigMap(Config{
 		GRPCEndpoint:  "0.0.0.0:4317",
 		HTTPEndpoint:  "0.0.0.0:4318",
 		ProxyURL:      "http://upstream.example.com:4318",
@@ -58,16 +73,23 @@ func TestBuildConfig_WithHTTPProxy(t *testing.T) {
 		},
 		LogLevel: "debug",
 	})
-	if !strings.Contains(cfg, `otlphttp/proxy:`) {
-		t.Fatalf("buildConfig missing http proxy exporter:\n%s", cfg)
+	exporters := cfg["exporters"].(map[string]any)
+	exp, ok := exporters["otlphttp/proxy"].(map[string]any)
+	if !ok {
+		t.Fatalf("buildConfigMap missing http proxy exporter")
 	}
-	if !strings.Contains(cfg, `endpoint: "http://upstream.example.com:4318"`) {
-		t.Fatalf("buildConfig missing http proxy endpoint:\n%s", cfg)
+	if exp["endpoint"] != "http://upstream.example.com:4318" {
+		t.Fatalf("http endpoint = %#v", exp["endpoint"])
 	}
-	if !strings.Contains(cfg, `"x-api-key": "secret"`) {
-		t.Fatalf("buildConfig missing http proxy headers:\n%s", cfg)
+	headers := exp["headers"].(map[string]any)
+	if headers["x-api-key"] != "secret" {
+		t.Fatalf("http headers = %#v", headers)
 	}
-	if strings.Count(cfg, "exporters: [otelop, otlphttp/proxy]") != 3 {
-		t.Fatalf("buildConfig should fan out all pipelines to http proxy:\n%s", cfg)
+	pipelines := cfg["service"].(map[string]any)["pipelines"].(map[string]any)
+	for _, name := range []string{"traces", "metrics", "logs"} {
+		got := pipelines[name].(map[string]any)["exporters"].([]any)
+		if !reflect.DeepEqual(got, []any{"otelop", "otlphttp/proxy"}) {
+			t.Fatalf("%s exporters = %#v", name, got)
+		}
 	}
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -11,16 +11,16 @@ func TestBuildConfigMap_WithoutProxy(t *testing.T) {
 		HTTPEndpoint: "0.0.0.0:4318",
 		LogLevel:     "warn",
 	})
-	exporters := cfg["exporters"].(map[string]any)
+	exporters := cfg["exporters"].(obj)
 	if _, ok := exporters["otlp_grpc/proxy"]; ok {
 		t.Fatalf("buildConfigMap unexpectedly included grpc proxy exporter")
 	}
 	if _, ok := exporters["otlphttp/proxy"]; ok {
 		t.Fatalf("buildConfigMap unexpectedly included http proxy exporter")
 	}
-	pipelines := cfg["service"].(map[string]any)["pipelines"].(map[string]any)
+	pipelines := cfg["service"].(obj)["pipelines"].(obj)
 	for _, name := range []string{"traces", "metrics", "logs"} {
-		got := pipelines[name].(map[string]any)["exporters"].([]any)
+		got := pipelines[name].(obj)["exporters"].([]any)
 		if !reflect.DeepEqual(got, []any{"otelop"}) {
 			t.Fatalf("%s exporters = %#v", name, got)
 		}
@@ -38,24 +38,24 @@ func TestBuildConfigMap_WithGRPCProxy(t *testing.T) {
 		},
 		LogLevel: "info",
 	})
-	exporters := cfg["exporters"].(map[string]any)
-	exp, ok := exporters["otlp_grpc/proxy"].(map[string]any)
+	exporters := cfg["exporters"].(obj)
+	exp, ok := exporters["otlp_grpc/proxy"].(obj)
 	if !ok {
 		t.Fatalf("buildConfigMap missing grpc proxy exporter")
 	}
 	if exp["endpoint"] != "upstream.example.com:4317" {
 		t.Fatalf("grpc endpoint = %#v", exp["endpoint"])
 	}
-	if !reflect.DeepEqual(exp["tls"], map[string]any{"insecure": true}) {
+	if !reflect.DeepEqual(exp["tls"], obj{"insecure": true}) {
 		t.Fatalf("grpc tls = %#v", exp["tls"])
 	}
-	headers := exp["headers"].(map[string]any)
+	headers := exp["headers"].(obj)
 	if headers["Authorization"] != "Bearer token" {
 		t.Fatalf("grpc headers = %#v", headers)
 	}
-	pipelines := cfg["service"].(map[string]any)["pipelines"].(map[string]any)
+	pipelines := cfg["service"].(obj)["pipelines"].(obj)
 	for _, name := range []string{"traces", "metrics", "logs"} {
-		got := pipelines[name].(map[string]any)["exporters"].([]any)
+		got := pipelines[name].(obj)["exporters"].([]any)
 		if !reflect.DeepEqual(got, []any{"otelop", "otlp_grpc/proxy"}) {
 			t.Fatalf("%s exporters = %#v", name, got)
 		}
@@ -73,21 +73,21 @@ func TestBuildConfigMap_WithHTTPProxy(t *testing.T) {
 		},
 		LogLevel: "debug",
 	})
-	exporters := cfg["exporters"].(map[string]any)
-	exp, ok := exporters["otlphttp/proxy"].(map[string]any)
+	exporters := cfg["exporters"].(obj)
+	exp, ok := exporters["otlphttp/proxy"].(obj)
 	if !ok {
 		t.Fatalf("buildConfigMap missing http proxy exporter")
 	}
 	if exp["endpoint"] != "http://upstream.example.com:4318" {
 		t.Fatalf("http endpoint = %#v", exp["endpoint"])
 	}
-	headers := exp["headers"].(map[string]any)
+	headers := exp["headers"].(obj)
 	if headers["x-api-key"] != "secret" {
 		t.Fatalf("http headers = %#v", headers)
 	}
-	pipelines := cfg["service"].(map[string]any)["pipelines"].(map[string]any)
+	pipelines := cfg["service"].(obj)["pipelines"].(obj)
 	for _, name := range []string{"traces", "metrics", "logs"} {
-		got := pipelines[name].(map[string]any)["exporters"].([]any)
+		got := pipelines[name].(obj)["exporters"].([]any)
 		if !reflect.DeepEqual(got, []any{"otelop", "otlphttp/proxy"}) {
 			t.Fatalf("%s exporters = %#v", name, got)
 		}


### PR DESCRIPTION
## Summary

- replace embedded collector YAML string generation with a static confmap provider
- build receiver, exporter, telemetry, and pipeline config as Go maps instead of YAML text
- simplify the collector config assembly with small builder helpers and a local obj alias
- keep existing proxy behavior while removing string-based config assembly risks

## Verification

- mise run check
- mise run test
