### PR TITLE
fix(collector): normalize confmap values for static provider

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -188,12 +188,12 @@ func New(exporterFactory exporter.Factory, cfg Config) (*otelcol.Collector, erro
 
 func newStaticProviderFactory(cfg obj) confmap.ProviderFactory {
 	return confmap.NewProviderFactory(func(confmap.ProviderSettings) confmap.Provider {
-		return &staticProvider{cfg: cfg}
+		return &staticProvider{cfg: normalizeValue(cfg).(map[string]any)}
 	})
 }
 
 type staticProvider struct {
-	cfg obj
+	cfg map[string]any
 }
 
 func (p *staticProvider) Retrieve(_ context.Context, _ string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
@@ -206,4 +206,29 @@ func (p *staticProvider) Scheme() string {
 
 func (p *staticProvider) Shutdown(context.Context) error {
 	return nil
+}
+
+func normalizeValue(v any) any {
+	switch x := v.(type) {
+	case obj:
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			out[k] = normalizeValue(vv)
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			out[k] = normalizeValue(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, vv := range x {
+			out[i] = normalizeValue(vv)
+		}
+		return out
+	default:
+		return v
+	}
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1,8 +1,11 @@
 package collector
 
 import (
+	"context"
 	"reflect"
 	"testing"
+
+	"go.opentelemetry.io/collector/confmap"
 )
 
 func TestBuildConfigMap_WithoutProxy(t *testing.T) {
@@ -91,5 +94,32 @@ func TestBuildConfigMap_WithHTTPProxy(t *testing.T) {
 		if !reflect.DeepEqual(got, []any{"otelop", "otlphttp/proxy"}) {
 			t.Fatalf("%s exporters = %#v", name, got)
 		}
+	}
+}
+
+func TestStaticProviderNormalizesLocalObjTypes(t *testing.T) {
+	factory := newStaticProviderFactory(buildConfigMap(Config{
+		GRPCEndpoint: "0.0.0.0:4317",
+		HTTPEndpoint: "0.0.0.0:4318",
+		LogLevel:     "info",
+	}))
+	provider := factory.Create(confmap.ProviderSettings{})
+
+	retrieved, err := provider.Retrieve(context.Background(), "otelop:config", nil)
+	if err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	defer func() {
+		if err := retrieved.Close(context.Background()); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}()
+
+	conf, err := retrieved.AsConf()
+	if err != nil {
+		t.Fatalf("AsConf: %v", err)
+	}
+	if got, ok := conf.ToStringMap()["exporters"].(map[string]any); !ok || got["otelop"] == nil {
+		t.Fatalf("exporters.otelop missing in conf: %#v", conf.ToStringMap())
 	}
 }


### PR DESCRIPTION
## Summary

- normalize local collector obj values into plain map[string]any and []any before handing them to confmap.NewRetrieved
- fix startup failure caused by passing the local alias type through the static confmap provider
- add a regression test that exercises the static provider and AsConf path directly

## Verification

- mise run test
