### PR TITLE
fix(store): skip empty metrics to avoid null dataPoints over WebSocket

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -105,6 +105,14 @@ func (s *Store) AddMetrics(md pmetric.Metrics) {
 	notify := make([]*MetricData, 0, len(converted))
 	s.mu.Lock()
 	for _, m := range converted {
+		// Cumulative baselines (and scrapes where every point was filtered as
+		// non-finite) leave DataPoints as a nil slice. Go marshals that as
+		// JSON null, which crashes the WebSocket consumer reading
+		// `dataPoints.length`. The series store already captured the baseline,
+		// so the next scrape will emit a real delta — drop the empty metric.
+		if len(m.DataPoints) == 0 {
+			continue
+		}
 		key := metricKey(m.ServiceName, m.Name)
 		if idx, ok := s.metricIndex[key]; ok {
 			if existing := s.metrics.Get(idx); existing != nil && existing.Name == m.Name && existing.ServiceName == m.ServiceName {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -338,6 +338,73 @@ func TestAttributesToMap_NonFiniteDoubles(t *testing.T) {
 	}
 }
 
+func TestStore_AddMetrics_SkipsEmptyMetrics(t *testing.T) {
+	var notified []*MetricData
+	s := NewStore(10, 10, 10, 100, func(sig SignalType, data any) {
+		if sig == SignalMetrics {
+			notified = append(notified, data.(*MetricData))
+		}
+	})
+
+	// First scrape of a cumulative monotonic Sum: delta baseline, no points emitted.
+	md1 := pmetric.NewMetrics()
+	rm1 := md1.ResourceMetrics().AppendEmpty()
+	rm1.Resource().Attributes().PutStr("service.name", "svc")
+	sm1 := rm1.ScopeMetrics().AppendEmpty()
+	m1 := sm1.Metrics().AppendEmpty()
+	m1.SetName("requests.total")
+	sum1 := m1.SetEmptySum()
+	sum1.SetIsMonotonic(true)
+	sum1.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	sum1.DataPoints().AppendEmpty().SetIntValue(100)
+
+	s.AddMetrics(md1)
+
+	if got := s.GetMetrics(); len(got) != 0 {
+		t.Fatalf("baseline scrape should not be stored, got %d metrics", len(got))
+	}
+	if len(notified) != 0 {
+		t.Fatalf("baseline scrape should not notify subscribers, got %d", len(notified))
+	}
+
+	// Second scrape produces a real delta — metric should now appear.
+	md2 := pmetric.NewMetrics()
+	rm2 := md2.ResourceMetrics().AppendEmpty()
+	rm2.Resource().Attributes().PutStr("service.name", "svc")
+	sm2 := rm2.ScopeMetrics().AppendEmpty()
+	m2 := sm2.Metrics().AppendEmpty()
+	m2.SetName("requests.total")
+	sum2 := m2.SetEmptySum()
+	sum2.SetIsMonotonic(true)
+	sum2.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	sum2.DataPoints().AppendEmpty().SetIntValue(150)
+
+	s.AddMetrics(md2)
+
+	metrics := s.GetMetrics()
+	if len(metrics) != 1 || len(metrics[0].DataPoints) != 1 {
+		t.Fatalf("expected 1 metric with 1 delta point, got %+v", metrics)
+	}
+	if len(notified) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(notified))
+	}
+
+	// The broadcast payload must serialize dataPoints as a real array, never null.
+	payload, err := json.Marshal(notified[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded struct {
+		DataPoints []map[string]any `json:"dataPoints"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.DataPoints == nil {
+		t.Fatalf("dataPoints must not serialize as null: %s", payload)
+	}
+}
+
 func TestStore_AddMetrics_DifferentNames(t *testing.T) {
 	s := NewStore(10, 10, 10, 100, nil)
 


### PR DESCRIPTION
## Summary

- The first scrape of cumulative Sum/Histogram metrics cannot compute a delta, so `extractDataPoints` returns a nil slice. Go marshals that as JSON `null`, and the frontend crashes at `metric-list.tsx:66` with `TypeError: Cannot read properties of null (reading 'length')` when reading `metric.dataPoints.length`.
- Skip metrics with `len(m.DataPoints) == 0` in `Store.AddMetrics`. The series store has already captured the baseline, so the next scrape surfaces the metric for the first time with a real delta point — no ghost rows, no crash.
- Add `TestStore_AddMetrics_SkipsEmptyMetrics` to cover: baseline is neither stored nor notified, the second scrape is, and the broadcast payload serializes `dataPoints` as a JSON array rather than null.

## Test plan

- [x] `mise run test`
- [x] `mise run check`
- [x] Verified in the dev server that the Metrics tab opens without error when cumulative metrics first arrive over the WebSocket