### PR TITLE
feat(server): enable WebSocket per-message compression

### DIFF
--- a/internal/server/handler_ws.go
+++ b/internal/server/handler_ws.go
@@ -12,7 +12,8 @@ import (
 
 func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		OriginPatterns: []string{"*"},
+		OriginPatterns:  []string{"*"},
+		CompressionMode: websocket.CompressionNoContextTakeover,
 	})
 	if err != nil {
 		slog.Error("websocket: accept error", "error", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,7 +47,6 @@ func New(s *store.Store, hub *ws.Hub, frontendFS fs.FS, runtime otelopgraphql.Ru
 	// startup.
 	mux.Handle("/mcp", mcp.NewHandler(srv.schema, runtime.Version))
 
-	// WebSocket (no compression — it has its own framing)
 	mux.HandleFunc("GET /ws", srv.handleWebSocket)
 
 	// Static files with SPA fallback


### PR DESCRIPTION
## Summary

- Turn on `CompressionNoContextTakeover` in the telemetry WebSocket's `AcceptOptions`. Frames above the library threshold are now deflated per message, cutting bandwidth for repetitive JSON payloads without holding a per-connection sliding window (memory stays flat).
- Drop the now-misleading `// WebSocket (no compression — it has its own framing)` annotation on the `/ws` route. The HTTP compression middleware's skip-WebSocket reasoning is already explained in the block just below.

## Test plan

- [x] `mise run test`
- [x] `mise run check`
- [x] Verified in the dev server that the upgrade response negotiates `Sec-Websocket-Extensions: permessage-deflate; client_no_context_takeover; server_no_context_takeover` and telemetry continues to stream normally