### PR TITLE
fix(store): derive trace duration from full span range

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,10 @@ mise run build    # Build
 - Extract duplicated patterns into factory functions or components (e.g. `createSearchAtom`, `CopyJsonButton`)
 - Before creating a new UI component, check whether shadcn already provides one
 
+### Timestamps
+
+- Use `Temporal.Instant.from(...)` (from `temporal-polyfill`) for parsing/comparing OTel timestamps. `Date.parse` truncates to milliseconds and loses the nanosecond precision that OTel emits
+
 ### Comments
 
 - WHAT comments (`{/* Bar */}`, `{/* Operation name */}`) are unnecessary — the code is self-evident

--- a/frontend/src/components/traces/span-waterfall.tsx
+++ b/frontend/src/components/traces/span-waterfall.tsx
@@ -165,16 +165,10 @@ function WaterfallInner({
   }, [flatSpans]);
 
   const { baseNs, totalNs } = useMemo(() => {
-    if (trace.rootSpan) {
-      try {
-        const start = Temporal.Instant.from(trace.rootSpan.startTime).epochNanoseconds;
-        const end = Temporal.Instant.from(trace.rootSpan.endTime).epochNanoseconds;
-        const dur = Number(end - start);
-        if (dur > 0) return { baseNs: start, totalNs: dur };
-      } catch {
-        /* fall through */
-      }
-    }
+    // Prefer trace.startTime + trace.duration: the server reports these as the
+    // full trace range (min start → max end) even for multi-root Codex traces.
+    // Anchoring the waterfall to trace.rootSpan would truncate long-running
+    // sibling branches when the representative root is short.
     try {
       const start = Temporal.Instant.from(trace.startTime).epochNanoseconds;
       if (trace.duration > 0) return { baseNs: start, totalNs: trace.duration };
@@ -197,7 +191,7 @@ function WaterfallInner({
       return { baseNs: minNs, totalNs: Number(maxNs - minNs) };
     }
     return { baseNs: 0n, totalNs: 1 };
-  }, [trace.rootSpan, trace.startTime, trace.duration, flatSpans]);
+  }, [trace.startTime, trace.duration, flatSpans]);
 
   const barWidth = width - LABEL_WIDTH;
   const xScale = useMemo(

--- a/frontend/src/hooks/use-initial-load.ts
+++ b/frontend/src/hooks/use-initial-load.ts
@@ -117,9 +117,15 @@ export function useInitialLoad() {
             return {
               ...rest,
               duration: durationMs * MS_TO_NS,
-              // Mirror the Go resolver: rootSpan is the first span with no parent.
-              // The query omits rootSpan to avoid shipping the same span twice.
-              rootSpan: spans.find((s) => s.parentSpanId === ""),
+              // Mirror the Go resolver: pick the longest parentless span as the
+              // representative root so multi-root Codex traces don't surface the
+              // short turn/start span. The query omits rootSpan to avoid shipping
+              // the same span twice.
+              rootSpan: spans.reduce<SpanData | undefined>(
+                (best, s) =>
+                  s.parentSpanId === "" && (!best || s.duration > best.duration) ? s : best,
+                undefined,
+              ),
               spans,
             };
           },

--- a/frontend/src/stores/telemetry.ts
+++ b/frontend/src/stores/telemetry.ts
@@ -1,5 +1,6 @@
 import { atom } from "jotai";
-import type { TraceData, MetricData, LogData } from "@/types/telemetry";
+import { Temporal } from "temporal-polyfill";
+import type { TraceData, MetricData, LogData, SpanData } from "@/types/telemetry";
 
 // Server-side capacity config, fetched at startup.
 export interface ServerConfig {
@@ -36,16 +37,32 @@ export const addTraceAtom = atom(null, (get, set, newTrace: TraceData) => {
     const existing = current[idx];
     const seen = new Set(existing.spans.map((s) => s.spanId));
     const deduped = newTrace.spans.filter((s) => !seen.has(s.spanId));
-    if (deduped.length === 0 && !newTrace.rootSpan) return;
+    const rootChanged = isBetterRoot(existing.rootSpan, newTrace.rootSpan);
+    // OTel timestamps are nanosecond-precision ISO strings; compare via
+    // Temporal.Instant to avoid Date's millisecond truncation.
+    const newStart = Temporal.Instant.from(newTrace.startTime).epochNanoseconds;
+    const existingStart = Temporal.Instant.from(existing.startTime).epochNanoseconds;
+    if (
+      deduped.length === 0 &&
+      !rootChanged &&
+      newTrace.duration <= existing.duration &&
+      newStart >= existingStart
+    ) {
+      return;
+    }
     const mergedSpans = [...existing.spans, ...deduped];
     const updated = [...current];
     updated[idx] = {
       ...existing,
       spans: mergedSpans,
       spanCount: mergedSpans.length,
-      rootSpan: newTrace.rootSpan ?? existing.rootSpan,
-      serviceName: newTrace.rootSpan ? newTrace.serviceName : existing.serviceName,
-      duration: newTrace.rootSpan ? newTrace.duration : existing.duration,
+      rootSpan: rootChanged ? newTrace.rootSpan : existing.rootSpan,
+      serviceName: rootChanged ? newTrace.serviceName : existing.serviceName,
+      // Multi-root Codex traces can grow past the originally-reported root
+      // span duration. Always take the larger range so the list/detail
+      // header reflect the full trace length.
+      startTime: newStart < existingStart ? newTrace.startTime : existing.startTime,
+      duration: Math.max(existing.duration, newTrace.duration),
     };
     set(tracesAtom, updated);
   } else {
@@ -53,6 +70,13 @@ export const addTraceAtom = atom(null, (get, set, newTrace: TraceData) => {
     set(tracesAtom, next.length > maxTraces ? next.slice(0, maxTraces) : next);
   }
 });
+
+// Picks the longest parentless span as the representative root for display.
+function isBetterRoot(current: SpanData | undefined, candidate: SpanData | undefined): boolean {
+  if (!candidate) return false;
+  if (!current) return true;
+  return candidate.duration > current.duration;
+}
 
 export const addMetricAtom = atom(null, (get, set, newMetric: MetricData) => {
   const current = get(metricsAtom);

--- a/internal/store/trace.go
+++ b/internal/store/trace.go
@@ -8,14 +8,20 @@ import (
 
 // TraceData represents a group of spans sharing the same trace ID.
 type TraceData struct {
-	TraceID     string        `json:"traceId"`
-	RootSpan    *SpanData     `json:"rootSpan,omitempty"`
-	Spans       []*SpanData   `json:"spans"`
-	ServiceName string        `json:"serviceName"`
-	SpanCount   int           `json:"spanCount"`
-	StartTime   time.Time     `json:"startTime"`
-	Duration    time.Duration `json:"duration"`
+	TraceID     string      `json:"traceId"`
+	RootSpan    *SpanData   `json:"rootSpan,omitempty"`
+	Spans       []*SpanData `json:"spans"`
+	ServiceName string      `json:"serviceName"`
+	SpanCount   int         `json:"spanCount"`
+	StartTime   time.Time   `json:"startTime"`
+	// Duration is the full trace range (max end - min start) across every span,
+	// never just the root span's duration. Codex-style traces can contain
+	// multiple parentless spans or disconnected parent/child relationships;
+	// anchoring Duration to a single root misreports the real trace length.
+	Duration time.Duration `json:"duration"`
 
+	// Cached so Merge can extend Duration incrementally without rescanning spans.
+	endTime time.Time
 	// spanIDs tracks known spanIDs for O(1) deduplication on merge. Not serialized.
 	spanIDs map[string]struct{} `json:"-"`
 }
@@ -26,6 +32,9 @@ func (t *TraceData) Merge(other *TraceData) {
 		t.spanIDs = make(map[string]struct{}, len(t.Spans)+len(other.Spans))
 		for _, s := range t.Spans {
 			t.spanIDs[s.SpanID] = struct{}{}
+			if s.EndTime.After(t.endTime) {
+				t.endTime = s.EndTime
+			}
 		}
 	}
 	for _, s := range other.Spans {
@@ -34,16 +43,30 @@ func (t *TraceData) Merge(other *TraceData) {
 		}
 		t.spanIDs[s.SpanID] = struct{}{}
 		t.Spans = append(t.Spans, s)
+		if s.StartTime.Before(t.StartTime) || t.StartTime.IsZero() {
+			t.StartTime = s.StartTime
+		}
+		if s.EndTime.After(t.endTime) {
+			t.endTime = s.EndTime
+		}
 	}
 	t.SpanCount = len(t.Spans)
-	if other.RootSpan != nil {
+	if other.RootSpan != nil && isBetterRoot(t.RootSpan, other.RootSpan) {
 		t.RootSpan = other.RootSpan
 		t.ServiceName = other.ServiceName
-		t.Duration = other.Duration
 	}
-	if !other.StartTime.IsZero() && other.StartTime.Before(t.StartTime) {
-		t.StartTime = other.StartTime
+	if t.endTime.After(t.StartTime) {
+		t.Duration = t.endTime.Sub(t.StartTime)
 	}
+}
+
+// When a trace has multiple parentless spans we pick the longest one so the
+// displayed span name/status roughly reflects the dominant operation.
+func isBetterRoot(current, candidate *SpanData) bool {
+	if current == nil {
+		return true
+	}
+	return candidate.Duration > current.Duration
 }
 
 // SpanData represents a single span.
@@ -118,6 +141,7 @@ func ConvertTraces(td ptrace.Traces) []*TraceData {
 					trace = &TraceData{
 						TraceID:   traceID,
 						StartTime: sd.StartTime,
+						endTime:   sd.EndTime,
 					}
 					index[traceID] = trace
 					result = append(result, trace)
@@ -129,34 +153,37 @@ func ConvertTraces(td ptrace.Traces) []*TraceData {
 				if sd.StartTime.Before(trace.StartTime) {
 					trace.StartTime = sd.StartTime
 				}
+				if sd.EndTime.After(trace.endTime) {
+					trace.endTime = sd.EndTime
+				}
 
-				if span.ParentSpanID().IsEmpty() {
+				if span.ParentSpanID().IsEmpty() && isBetterRoot(trace.RootSpan, sd) {
 					trace.RootSpan = sd
 					trace.ServiceName = svcName
-					trace.Duration = sd.Duration
 				}
 			}
 		}
 	}
 
-	// For traces without an explicit root span, derive service name and duration
-	// from the earliest/latest span in a single pass.
 	for _, trace := range result {
-		if trace.RootSpan != nil || len(trace.Spans) == 0 {
+		if len(trace.Spans) == 0 {
 			continue
 		}
-		earliest := trace.Spans[0]
-		latestEnd := earliest.EndTime
-		for _, s := range trace.Spans[1:] {
-			if s.StartTime.Before(earliest.StartTime) {
-				earliest = s
-			}
-			if s.EndTime.After(latestEnd) {
-				latestEnd = s.EndTime
-			}
+		if trace.endTime.After(trace.StartTime) {
+			trace.Duration = trace.endTime.Sub(trace.StartTime)
 		}
-		trace.ServiceName = earliest.ServiceName
-		trace.Duration = latestEnd.Sub(earliest.StartTime)
+		if trace.ServiceName == "" {
+			// For rootless traces, derive the label from the earliest-started
+			// span rather than ingestion order so out-of-order resource batches
+			// don't mislabel the trace.
+			earliest := trace.Spans[0]
+			for _, s := range trace.Spans[1:] {
+				if s.StartTime.Before(earliest.StartTime) {
+					earliest = s
+				}
+			}
+			trace.ServiceName = earliest.ServiceName
+		}
 	}
 
 	return result

--- a/internal/store/trace_test.go
+++ b/internal/store/trace_test.go
@@ -3,6 +3,9 @@ package store
 import (
 	"testing"
 	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
 func TestTraceData_Merge_DeduplicatesSpansAndPromotesRoot(t *testing.T) {
@@ -50,8 +53,11 @@ func TestTraceData_Merge_DeduplicatesSpansAndPromotesRoot(t *testing.T) {
 	if !base.StartTime.Equal(t0) {
 		t.Errorf("StartTime = %v, want %v (base is earlier)", base.StartTime, t0)
 	}
-	if base.Duration != t1.Sub(t2) {
-		t.Errorf("Duration = %v, want %v", base.Duration, t1.Sub(t2))
+	// Duration covers the full trace range (t0 → t1), not the new root span's
+	// own 5ms duration. The merged trace spans 10ms from earliest start to
+	// latest end.
+	if want := t1.Sub(t0); base.Duration != want {
+		t.Errorf("Duration = %v, want %v (full range)", base.Duration, want)
 	}
 }
 
@@ -115,6 +121,68 @@ func TestTraceData_Merge_AdvancesStartTimeBackwards(t *testing.T) {
 	}
 }
 
+// TestTraceData_Merge_MultiRootDurationUsesFullRange mirrors Codex-style
+// traces where a short turn/start root span coexists with a long-running
+// sibling branch (e.g. session_task.turn). Merge must report the full trace
+// range and surface the longest parentless span as the representative root.
+func TestTraceData_Merge_MultiRootDurationUsesFullRange(t *testing.T) {
+	t0 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	shortRoot := &SpanData{
+		SpanID:    "turn-start",
+		Name:      "turn/start",
+		StartTime: t0,
+		EndTime:   t0.Add(2 * time.Millisecond),
+		Duration:  2 * time.Millisecond,
+	}
+	longRoot := &SpanData{
+		SpanID:    "session-task-turn",
+		Name:      "session_task.turn",
+		StartTime: t0.Add(1 * time.Millisecond),
+		EndTime:   t0.Add(900 * time.Millisecond),
+		Duration:  899 * time.Millisecond,
+	}
+	childOfLongRoot := &SpanData{
+		SpanID:       "receiving-stream",
+		Name:         "receiving_stream",
+		ParentSpanID: "session-task-turn",
+		StartTime:    t0.Add(10 * time.Millisecond),
+		EndTime:      t0.Add(950 * time.Millisecond),
+		Duration:     940 * time.Millisecond,
+	}
+
+	base := &TraceData{
+		TraceID:   "codex",
+		Spans:     []*SpanData{shortRoot},
+		RootSpan:  shortRoot,
+		SpanCount: 1,
+		StartTime: shortRoot.StartTime,
+		Duration:  shortRoot.Duration,
+	}
+	incoming := &TraceData{
+		TraceID:   "codex",
+		Spans:     []*SpanData{longRoot, childOfLongRoot},
+		RootSpan:  longRoot,
+		SpanCount: 2,
+		StartTime: longRoot.StartTime,
+		Duration:  longRoot.Duration,
+	}
+
+	base.Merge(incoming)
+
+	if base.SpanCount != 3 {
+		t.Fatalf("SpanCount = %d, want 3", base.SpanCount)
+	}
+	if base.RootSpan == nil || base.RootSpan.SpanID != longRoot.SpanID {
+		t.Errorf("RootSpan = %+v, want longest parentless span %q", base.RootSpan, longRoot.SpanID)
+	}
+	if want := 950 * time.Millisecond; base.Duration != want {
+		t.Errorf("Duration = %v, want %v (full trace range)", base.Duration, want)
+	}
+	if !base.StartTime.Equal(t0) {
+		t.Errorf("StartTime = %v, want %v", base.StartTime, t0)
+	}
+}
+
 func TestTraceData_Merge_IsIdempotentOnRepeatedCalls(t *testing.T) {
 	t0 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	base := &TraceData{
@@ -142,5 +210,155 @@ func TestTraceData_Merge_IsIdempotentOnRepeatedCalls(t *testing.T) {
 	}
 	if base.SpanCount != 2 {
 		t.Errorf("SpanCount = %d, want 2", base.SpanCount)
+	}
+}
+
+// TestConvertTraces_MultiRoot verifies that a Codex-style trace with a short
+// turn/start root and a long session_task.turn root reports the full trace
+// range for Duration and picks the longest parentless span as RootSpan.
+func TestConvertTraces_MultiRoot(t *testing.T) {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "codex")
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	traceID := pcommon.TraceID([16]byte{0xC0, 0xDE})
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	shortRoot := ss.Spans().AppendEmpty()
+	shortRoot.SetTraceID(traceID)
+	shortRoot.SetSpanID(pcommon.SpanID([8]byte{0x01}))
+	shortRoot.SetName("turn/start")
+	shortRoot.SetStartTimestamp(pcommon.NewTimestampFromTime(base))
+	shortRoot.SetEndTimestamp(pcommon.NewTimestampFromTime(base.Add(2 * time.Millisecond)))
+
+	longRoot := ss.Spans().AppendEmpty()
+	longRoot.SetTraceID(traceID)
+	longRoot.SetSpanID(pcommon.SpanID([8]byte{0x02}))
+	longRoot.SetName("session_task.turn")
+	longRoot.SetStartTimestamp(pcommon.NewTimestampFromTime(base.Add(1 * time.Millisecond)))
+	longRoot.SetEndTimestamp(pcommon.NewTimestampFromTime(base.Add(800 * time.Millisecond)))
+
+	child := ss.Spans().AppendEmpty()
+	child.SetTraceID(traceID)
+	child.SetSpanID(pcommon.SpanID([8]byte{0x03}))
+	child.SetParentSpanID(pcommon.SpanID([8]byte{0x02}))
+	child.SetName("receiving_stream")
+	child.SetStartTimestamp(pcommon.NewTimestampFromTime(base.Add(50 * time.Millisecond)))
+	child.SetEndTimestamp(pcommon.NewTimestampFromTime(base.Add(950 * time.Millisecond)))
+
+	traces := ConvertTraces(td)
+	if len(traces) != 1 {
+		t.Fatalf("ConvertTraces returned %d traces, want 1", len(traces))
+	}
+	got := traces[0]
+
+	if got.SpanCount != 3 {
+		t.Errorf("SpanCount = %d, want 3", got.SpanCount)
+	}
+	if got.RootSpan == nil {
+		t.Fatalf("RootSpan is nil")
+	}
+	if got.RootSpan.Name != "session_task.turn" {
+		t.Errorf("RootSpan.Name = %q, want session_task.turn (longest parentless span)", got.RootSpan.Name)
+	}
+	if want := 950 * time.Millisecond; got.Duration != want {
+		t.Errorf("Duration = %v, want %v (full range from earliest start to latest end)", got.Duration, want)
+	}
+	if !got.StartTime.Equal(base) {
+		t.Errorf("StartTime = %v, want %v", got.StartTime, base)
+	}
+	if got.ServiceName != "codex" {
+		t.Errorf("ServiceName = %q, want codex", got.ServiceName)
+	}
+}
+
+// TestConvertTraces_OrphanSpansOnly covers the fully disconnected case:
+// every span has a ParentSpanID but none of them match a span in the same
+// trace. Duration still comes from the full range and ServiceName falls
+// back to the first seen span's service.
+func TestConvertTraces_OrphanSpansOnly(t *testing.T) {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "codex")
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	traceID := pcommon.TraceID([16]byte{0xAB})
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	a := ss.Spans().AppendEmpty()
+	a.SetTraceID(traceID)
+	a.SetSpanID(pcommon.SpanID([8]byte{0x0A}))
+	a.SetParentSpanID(pcommon.SpanID([8]byte{0xFF}))
+	a.SetName("orphan-a")
+	a.SetStartTimestamp(pcommon.NewTimestampFromTime(base))
+	a.SetEndTimestamp(pcommon.NewTimestampFromTime(base.Add(30 * time.Millisecond)))
+
+	b := ss.Spans().AppendEmpty()
+	b.SetTraceID(traceID)
+	b.SetSpanID(pcommon.SpanID([8]byte{0x0B}))
+	b.SetParentSpanID(pcommon.SpanID([8]byte{0xEE}))
+	b.SetName("orphan-b")
+	b.SetStartTimestamp(pcommon.NewTimestampFromTime(base.Add(5 * time.Millisecond)))
+	b.SetEndTimestamp(pcommon.NewTimestampFromTime(base.Add(100 * time.Millisecond)))
+
+	traces := ConvertTraces(td)
+	if len(traces) != 1 {
+		t.Fatalf("ConvertTraces returned %d traces, want 1", len(traces))
+	}
+	got := traces[0]
+
+	if got.RootSpan != nil {
+		t.Errorf("RootSpan = %+v, want nil (no parentless spans)", got.RootSpan)
+	}
+	if want := 100 * time.Millisecond; got.Duration != want {
+		t.Errorf("Duration = %v, want %v", got.Duration, want)
+	}
+	if got.ServiceName != "codex" {
+		t.Errorf("ServiceName = %q, want codex", got.ServiceName)
+	}
+}
+
+// TestConvertTraces_RootlessMultiServiceUsesEarliestStart ensures that when a
+// rootless trace spans multiple services, ConvertTraces labels it by the
+// earliest-started span's service rather than by resource iteration order.
+func TestConvertTraces_RootlessMultiServiceUsesEarliestStart(t *testing.T) {
+	td := ptrace.NewTraces()
+	traceID := pcommon.TraceID([16]byte{0xCD})
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// First resource batch (iteration order 0) is a later-started service.
+	rsLate := td.ResourceSpans().AppendEmpty()
+	rsLate.Resource().Attributes().PutStr("service.name", "late-service")
+	late := rsLate.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	late.SetTraceID(traceID)
+	late.SetSpanID(pcommon.SpanID([8]byte{0x01}))
+	late.SetParentSpanID(pcommon.SpanID([8]byte{0xAA}))
+	late.SetName("late-span")
+	late.SetStartTimestamp(pcommon.NewTimestampFromTime(base.Add(20 * time.Millisecond)))
+	late.SetEndTimestamp(pcommon.NewTimestampFromTime(base.Add(40 * time.Millisecond)))
+
+	// Second resource batch (iteration order 1) started earlier in wall time.
+	rsEarly := td.ResourceSpans().AppendEmpty()
+	rsEarly.Resource().Attributes().PutStr("service.name", "early-service")
+	early := rsEarly.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	early.SetTraceID(traceID)
+	early.SetSpanID(pcommon.SpanID([8]byte{0x02}))
+	early.SetParentSpanID(pcommon.SpanID([8]byte{0xBB}))
+	early.SetName("early-span")
+	early.SetStartTimestamp(pcommon.NewTimestampFromTime(base))
+	early.SetEndTimestamp(pcommon.NewTimestampFromTime(base.Add(10 * time.Millisecond)))
+
+	traces := ConvertTraces(td)
+	if len(traces) != 1 {
+		t.Fatalf("ConvertTraces returned %d traces, want 1", len(traces))
+	}
+	got := traces[0]
+
+	if got.RootSpan != nil {
+		t.Errorf("RootSpan = %+v, want nil (no parentless spans)", got.RootSpan)
+	}
+	if got.ServiceName != "early-service" {
+		t.Errorf("ServiceName = %q, want early-service (earliest start)", got.ServiceName)
 	}
 }


### PR DESCRIPTION
## Summary

- Always derive `trace.Duration` from the full span range (`min(StartTime) → max(EndTime)`) instead of anchoring it to whichever parentless span happened to arrive last. Codex-style multi-root traces were previously misreporting total time and truncating long-running siblings in the waterfall.
- Pick the longest parentless span as the representative `RootSpan`, consistently across the backend, the WebSocket merge, and the initial GraphQL bootstrap.
- For fully rootless traces, keep deriving `ServiceName` from the earliest-started span rather than collector iteration order.
- Frontend: merge WebSocket updates using the larger range, parse timestamps via `Temporal.Instant` (nanosecond precision) instead of `Date.parse`, and anchor the waterfall to `trace.startTime + trace.duration`.
- Document the `Temporal.Instant` rule in `CLAUDE.md`.

Fixes #31

## Test plan

- [x] `mise run check` — green
- [x] `mise run test` — Go + frontend suites pass (70 frontend tests, all Go packages)
- [x] New Go coverage added and passing: `TestTraceData_Merge_MultiRootDurationUsesFullRange`, `TestConvertTraces_MultiRoot`, `TestConvertTraces_OrphanSpansOnly`, `TestConvertTraces_RootlessMultiServiceUsesEarliestStart`
- [x] Manual UI verification with a real Codex multi-root trace — not yet performed