### PR TITLE
chore(config): bump default log cap to 5000

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ otelop version
   --proxy-header     upstream header                 (repeatable key=value)
   --trace-cap        max traces in memory            (default 1000)
   --metric-cap       max metric series in memory     (default 3000)
-  --log-cap          max log entries in memory       (default 1000)
+  --log-cap          max log entries in memory       (default 5000)
   --max-data-points  max data points per series      (default 1000)
   --log-level        debug|info|warn|error           (default warn)
 ```
@@ -134,7 +134,7 @@ token = "replace-me"
 
 trace_cap = 1000
 metric_cap = 3000
-log_cap = 1000
+log_cap = 5000
 max_data_points = 1000
 log_level = "warn"
 debug = false

--- a/frontend/src/stores/telemetry.ts
+++ b/frontend/src/stores/telemetry.ts
@@ -13,7 +13,7 @@ export interface ServerConfig {
 const DEFAULT_CONFIG: ServerConfig = {
   traceCap: 1000,
   metricCap: 3000,
-  logCap: 1000,
+  logCap: 5000,
   maxDataPoints: 1000,
 };
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,7 @@ const (
 	DefaultOTLPHTTPAddr  = "0.0.0.0:4318"
 	DefaultTraceCap      = 1000
 	DefaultMetricCap     = 3000
-	DefaultLogCap        = 1000
+	DefaultLogCap        = 5000
 	DefaultMaxDataPoints = 1000
 	DefaultLogLevel      = "warn"
 )


### PR DESCRIPTION
## Summary

- Raise `DefaultLogCap` from 1000 to 5000. Logs are atomic (1 record = 1 entry) whereas traces hold hundreds of spans each and metric series carry up to 1000 data points, so the previous default left the log tab truncating much sooner than the other signals in chatty dev workflows.
- Mirror the new default in `frontend/src/stores/telemetry.ts` (`DEFAULT_CONFIG`) so the pre-fetch fallback matches the server.
- Update the `--log-cap` flag help and the sample TOML config in `README.md`.

Other caps (`TraceCap=1000`, `MetricCap=3000`, `MaxDataPoints=1000`) were reviewed and left as-is: traces are memory-dominant, metric cardinality is already generous relative to typical dev workloads, and `MaxDataPoints × 60s` default export interval already covers multi-hour sessions.

## Test plan

- [x] `mise run check` — green
- [x] `mise run test` — Go + frontend suites pass