### PR TITLE
chore: update skill symlinks after otelop-api → otelop-inspect rename

### DIFF
--- a/.agents/skills/otelop-api
+++ b/.agents/skills/otelop-api
@@ -1,1 +1,0 @@
-../../skills/otelop-api

--- a/.agents/skills/otelop-inspect
+++ b/.agents/skills/otelop-inspect
@@ -1,0 +1,1 @@
+../../skills/otelop-inspect

--- a/.claude/skills/otelop-api
+++ b/.claude/skills/otelop-api
@@ -1,1 +1,0 @@
-../../.agents/skills/otelop-api

--- a/.claude/skills/otelop-inspect
+++ b/.claude/skills/otelop-inspect
@@ -1,0 +1,1 @@
+../../.agents/skills/otelop-inspect


### PR DESCRIPTION
## Summary

- `.agents/skills/otelop-api` and `.claude/skills/otelop-api` symlinks were broken after the skill was renamed to `otelop-inspect` in #43
- Updated both symlinks to point to `otelop-inspect`

## Test plan

- [x] `file .claude/skills/otelop-inspect` resolves to a directory
- [x] `file .agents/skills/otelop-inspect` resolves to a directory
- [x] `ls .claude/skills/otelop-inspect/` shows `SKILL.md`