### PR TITLE
perf(store): cache HasError and add parent/log lookup indexes

### DIFF
--- a/internal/graphql/trace_resolver.go
+++ b/internal/graphql/trace_resolver.go
@@ -20,7 +20,7 @@ func (r *TraceResolver) ServiceName() string { return r.t.ServiceName }
 func (r *TraceResolver) SpanCount() int32    { return int32(r.t.SpanCount) }
 func (r *TraceResolver) StartTime() gql.Time { return gql.Time{Time: r.t.StartTime} }
 func (r *TraceResolver) DurationMs() float64 { return durationMs(r.t.Duration) }
-func (r *TraceResolver) HasError() bool      { return traceHasError(r.t) }
+func (r *TraceResolver) HasError() bool      { return r.t.HasError }
 
 func (r *TraceResolver) RootSpan() *SpanResolver {
 	if r.t.RootSpan == nil {
@@ -86,15 +86,11 @@ func (r *SpanResolver) Trace() *TraceResolver {
 // for root spans (ParentSpanID empty) or when the parent has not been
 // buffered under the same trace.
 func (r *SpanResolver) Parent() *SpanResolver {
-	if r.s.ParentSpanID == "" {
+	parent := r.trace.SpanByID(r.s.ParentSpanID)
+	if parent == nil {
 		return nil
 	}
-	for _, sibling := range r.trace.Spans {
-		if sibling.SpanID == r.s.ParentSpanID {
-			return &SpanResolver{store: r.store, trace: r.trace, s: sibling}
-		}
-	}
-	return nil
+	return &SpanResolver{store: r.store, trace: r.trace, s: parent}
 }
 
 type SpanEventResolver struct {
@@ -104,19 +100,6 @@ type SpanEventResolver struct {
 func (r *SpanEventResolver) Name() string        { return r.ev.Name }
 func (r *SpanEventResolver) Timestamp() gql.Time { return gql.Time{Time: r.ev.Timestamp} }
 func (r *SpanEventResolver) Attributes() JSONMap { return attrsToJSON(r.ev.Attributes) }
-
-// spanStatusError mirrors ptrace.StatusCodeError.String(). It is duplicated
-// here to avoid pulling pdata into the resolver package.
-const spanStatusError = "Error"
-
-func traceHasError(t *store.TraceData) bool {
-	for _, s := range t.Spans {
-		if s.StatusCode == spanStatusError {
-			return true
-		}
-	}
-	return false
-}
 
 func durationMs(d time.Duration) float64 {
 	return float64(d) / float64(time.Millisecond)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -24,12 +24,17 @@ type OnAddFunc func(signalType SignalType, data any)
 
 // Store holds telemetry data in bounded ring buffers keyed for O(1) upsert.
 type Store struct {
-	mu            sync.RWMutex
-	traces        *RingBuffer[*TraceData]
-	metrics       *RingBuffer[*MetricData]
-	logs          *RingBuffer[*LogData]
-	traceIndex    map[string]int
-	metricIndex   map[string]int
+	mu          sync.RWMutex
+	traces      *RingBuffer[*TraceData]
+	metrics     *RingBuffer[*MetricData]
+	logs        *RingBuffer[*LogData]
+	traceIndex  map[string]int
+	metricIndex map[string]int
+	// logsByTraceID is a secondary index keyed by TraceID so the trace↔log
+	// correlation join in GetLogsPageByTraceID doesn't scan the full log
+	// buffer on every trace-detail query. Entries are appended on AddLogs
+	// (oldest first within each bucket) and pruned on eviction.
+	logsByTraceID map[string][]*LogData
 	series        *seriesStore
 	maxDataPoints int
 	onAdd         OnAddFunc
@@ -46,6 +51,7 @@ func NewStore(traceCap, metricCap, logCap, maxDataPoints int, onAdd OnAddFunc) *
 		logs:          NewRingBuffer[*LogData](logCap),
 		traceIndex:    make(map[string]int, traceCap),
 		metricIndex:   make(map[string]int, metricCap),
+		logsByTraceID: make(map[string][]*LogData),
 		series:        newSeriesStore(),
 		maxDataPoints: maxDataPoints,
 		onAdd:         onAdd,
@@ -151,7 +157,13 @@ func (s *Store) AddLogs(ld plog.Logs) {
 
 	s.mu.Lock()
 	for _, l := range converted {
-		s.logs.Add(l)
+		_, evicted, wasEvicted := s.logs.Add(l)
+		if wasEvicted && evicted != nil && evicted.TraceID != "" {
+			s.removeFromLogsByTraceID(evicted)
+		}
+		if l.TraceID != "" {
+			s.logsByTraceID[l.TraceID] = append(s.logsByTraceID[l.TraceID], l)
+		}
 	}
 	s.mu.Unlock()
 
@@ -159,6 +171,27 @@ func (s *Store) AddLogs(ld plog.Logs) {
 		for _, l := range converted {
 			s.onAdd(SignalLogs, l)
 		}
+	}
+}
+
+// removeFromLogsByTraceID drops the evicted log from its bucket. The bucket
+// is tiny relative to the whole buffer (all logs sharing one traceID), so the
+// linear scan to locate the pointer is acceptable.
+func (s *Store) removeFromLogsByTraceID(evicted *LogData) {
+	bucket, ok := s.logsByTraceID[evicted.TraceID]
+	if !ok {
+		return
+	}
+	for i, l := range bucket {
+		if l == evicted {
+			bucket = append(bucket[:i], bucket[i+1:]...)
+			break
+		}
+	}
+	if len(bucket) == 0 {
+		delete(s.logsByTraceID, evicted.TraceID)
+	} else {
+		s.logsByTraceID[evicted.TraceID] = bucket
 	}
 }
 
@@ -184,20 +217,14 @@ func (s *Store) GetLogsPage(offset, limit int) (items []*LogData, total int) {
 }
 
 // GetLogsPageByTraceID returns a newest-first page of logs whose TraceID
-// matches traceID, with offset/limit applied to the filtered set. There is no
-// traceID index on logs, so this scans the whole buffer under the read lock.
-// Callers rely on this for the trace↔log correlation join.
+// matches traceID, with offset/limit applied to the filtered set. Backed by
+// the logsByTraceID secondary index so lookups are O(matched) rather than
+// O(total) — important because trace-detail opens hit this on every resolve.
 func (s *Store) GetLogsPageByTraceID(traceID string, offset, limit int) (items []*LogData, total int) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	all, _ := s.logs.Page(0, 0)
-	filtered := make([]*LogData, 0, len(all))
-	for _, l := range all {
-		if l.TraceID == traceID {
-			filtered = append(filtered, l)
-		}
-	}
-	total = len(filtered)
+	bucket := s.logsByTraceID[traceID]
+	total = len(bucket)
 	if offset < 0 {
 		offset = 0
 	}
@@ -208,7 +235,13 @@ func (s *Store) GetLogsPageByTraceID(traceID string, offset, limit int) (items [
 	if limit > 0 && offset+limit < end {
 		end = offset + limit
 	}
-	return filtered[offset:end], total
+	// Bucket is append-ordered (oldest first); walk backwards for newest first.
+	n := end - offset
+	items = make([]*LogData, n)
+	for i := 0; i < n; i++ {
+		items[i] = bucket[total-1-offset-i]
+	}
+	return items, total
 }
 
 // GetTraces returns all stored traces, newest first.
@@ -266,6 +299,7 @@ func (s *Store) Clear() {
 	s.logs.Clear()
 	clear(s.traceIndex)
 	clear(s.metricIndex)
+	clear(s.logsByTraceID)
 	s.series.clear()
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -215,6 +215,72 @@ func TestStore_AddAndGetLogs(t *testing.T) {
 	}
 }
 
+func TestStore_GetLogsPageByTraceID(t *testing.T) {
+	s := NewStore(10, 10, 10, 100, nil)
+
+	addLog := func(traceIDByte byte, body string) {
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("service.name", "svc")
+		sl := rl.ScopeLogs().AppendEmpty()
+		lr := sl.LogRecords().AppendEmpty()
+		lr.SetTraceID(pcommon.TraceID([16]byte{traceIDByte}))
+		lr.Body().SetStr(body)
+		lr.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		s.AddLogs(ld)
+	}
+
+	addLog(1, "t1-first")
+	addLog(2, "t2-only")
+	addLog(1, "t1-second")
+	addLog(0, "no-trace") // TraceID zero: must not be indexed
+
+	targetID := pcommon.TraceID([16]byte{1}).String()
+	items, total := s.GetLogsPageByTraceID(targetID, 0, 0)
+	if total != 2 {
+		t.Fatalf("total = %d, want 2", total)
+	}
+	if items[0].Body != "t1-second" || items[1].Body != "t1-first" {
+		t.Errorf("newest-first order broken: got [%q, %q]", items[0].Body, items[1].Body)
+	}
+
+	// Unrelated traceID must not leak results from other buckets.
+	other := pcommon.TraceID([16]byte{9}).String()
+	if _, total := s.GetLogsPageByTraceID(other, 0, 0); total != 0 {
+		t.Errorf("unknown trace total = %d, want 0", total)
+	}
+}
+
+func TestStore_AddLogs_EvictionPrunesTraceIndex(t *testing.T) {
+	// logCap=2 so the 3rd log evicts the 1st.
+	s := NewStore(10, 10, 2, 100, nil)
+
+	addLog := func(traceIDByte byte) {
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		sl := rl.ScopeLogs().AppendEmpty()
+		lr := sl.LogRecords().AppendEmpty()
+		lr.SetTraceID(pcommon.TraceID([16]byte{traceIDByte}))
+		lr.Body().SetStr("x")
+		s.AddLogs(ld)
+	}
+
+	addLog(1)
+	addLog(1)
+	addLog(2) // evicts the first log with traceID=1
+
+	id1 := pcommon.TraceID([16]byte{1}).String()
+	items, total := s.GetLogsPageByTraceID(id1, 0, 0)
+	if total != 1 || len(items) != 1 {
+		t.Fatalf("traceID=1 after eviction: total=%d items=%d, want 1/1", total, len(items))
+	}
+
+	addLog(2) // evicts the remaining log with traceID=1
+	if _, total := s.GetLogsPageByTraceID(id1, 0, 0); total != 0 {
+		t.Errorf("traceID=1 after second eviction: total=%d, want 0", total)
+	}
+}
+
 func TestStore_AddMetrics_Merge(t *testing.T) {
 	s := NewStore(10, 10, 10, 100, nil)
 

--- a/internal/store/trace.go
+++ b/internal/store/trace.go
@@ -29,7 +29,7 @@ type TraceData struct {
 	// spanIDs tracks known spanIDs for O(1) deduplication on merge. Not serialized.
 	spanIDs map[string]struct{} `json:"-"`
 	// spanByID supports O(1) parent lookup from SpanResolver.Parent. Built lazily
-	// on first access and invalidated whenever Merge appends new spans.
+	// on first access; Merge keeps it fresh by inserting each newly-appended span.
 	spanByID map[string]*SpanData `json:"-"`
 }
 
@@ -53,6 +53,9 @@ func (t *TraceData) Merge(other *TraceData) {
 		}
 		t.spanIDs[s.SpanID] = struct{}{}
 		t.Spans = append(t.Spans, s)
+		if t.spanByID != nil {
+			t.spanByID[s.SpanID] = s
+		}
 		if s.StartTime.Before(t.StartTime) || t.StartTime.IsZero() {
 			t.StartTime = s.StartTime
 		}
@@ -63,9 +66,6 @@ func (t *TraceData) Merge(other *TraceData) {
 			t.HasError = true
 		}
 	}
-	// Parent map is invalidated because new spans may have arrived. It will be
-	// rebuilt lazily on the next SpanByID call.
-	t.spanByID = nil
 	t.SpanCount = len(t.Spans)
 	if other.RootSpan != nil && isBetterRoot(t.RootSpan, other.RootSpan) {
 		t.RootSpan = other.RootSpan
@@ -90,8 +90,8 @@ func isBetterRoot(current, candidate *SpanData) bool {
 const spanStatusErrorLiteral = "Error"
 
 // SpanByID returns the span with the given SpanID within this trace, or nil
-// when no such span has been buffered. The lookup map is built lazily on the
-// first call and reused until Merge appends new spans.
+// when no such span has been buffered. The lookup map is built lazily on
+// first access and kept in sync by Merge as new spans are appended.
 func (t *TraceData) SpanByID(id string) *SpanData {
 	if id == "" {
 		return nil

--- a/internal/store/trace.go
+++ b/internal/store/trace.go
@@ -19,11 +19,18 @@ type TraceData struct {
 	// multiple parentless spans or disconnected parent/child relationships;
 	// anchoring Duration to a single root misreports the real trace length.
 	Duration time.Duration `json:"duration"`
+	// HasError is true when any span under this trace has StatusCode=="Error".
+	// Maintained incrementally in ConvertTraces/Merge so HasError GraphQL
+	// resolutions don't rescan Spans on every query.
+	HasError bool `json:"hasError"`
 
 	// Cached so Merge can extend Duration incrementally without rescanning spans.
 	endTime time.Time
 	// spanIDs tracks known spanIDs for O(1) deduplication on merge. Not serialized.
 	spanIDs map[string]struct{} `json:"-"`
+	// spanByID supports O(1) parent lookup from SpanResolver.Parent. Built lazily
+	// on first access and invalidated whenever Merge appends new spans.
+	spanByID map[string]*SpanData `json:"-"`
 }
 
 // Merge incorporates another TraceData sharing the same TraceID, deduplicating spans.
@@ -34,6 +41,9 @@ func (t *TraceData) Merge(other *TraceData) {
 			t.spanIDs[s.SpanID] = struct{}{}
 			if s.EndTime.After(t.endTime) {
 				t.endTime = s.EndTime
+			}
+			if s.StatusCode == spanStatusErrorLiteral {
+				t.HasError = true
 			}
 		}
 	}
@@ -49,7 +59,13 @@ func (t *TraceData) Merge(other *TraceData) {
 		if s.EndTime.After(t.endTime) {
 			t.endTime = s.EndTime
 		}
+		if s.StatusCode == spanStatusErrorLiteral {
+			t.HasError = true
+		}
 	}
+	// Parent map is invalidated because new spans may have arrived. It will be
+	// rebuilt lazily on the next SpanByID call.
+	t.spanByID = nil
 	t.SpanCount = len(t.Spans)
 	if other.RootSpan != nil && isBetterRoot(t.RootSpan, other.RootSpan) {
 		t.RootSpan = other.RootSpan
@@ -67,6 +83,26 @@ func isBetterRoot(current, candidate *SpanData) bool {
 		return true
 	}
 	return candidate.Duration > current.Duration
+}
+
+// spanStatusErrorLiteral mirrors ptrace.StatusCodeError.String() so HasError
+// bookkeeping inside the store package doesn't need to import pdata.
+const spanStatusErrorLiteral = "Error"
+
+// SpanByID returns the span with the given SpanID within this trace, or nil
+// when no such span has been buffered. The lookup map is built lazily on the
+// first call and reused until Merge appends new spans.
+func (t *TraceData) SpanByID(id string) *SpanData {
+	if id == "" {
+		return nil
+	}
+	if t.spanByID == nil {
+		t.spanByID = make(map[string]*SpanData, len(t.Spans))
+		for _, s := range t.Spans {
+			t.spanByID[s.SpanID] = s
+		}
+	}
+	return t.spanByID[id]
 }
 
 // SpanData represents a single span.
@@ -155,6 +191,9 @@ func ConvertTraces(td ptrace.Traces) []*TraceData {
 				}
 				if sd.EndTime.After(trace.endTime) {
 					trace.endTime = sd.EndTime
+				}
+				if sd.StatusCode == spanStatusErrorLiteral {
+					trace.HasError = true
 				}
 
 				if span.ParentSpanID().IsEmpty() && isBetterRoot(trace.RootSpan, sd) {

--- a/internal/store/trace_test.go
+++ b/internal/store/trace_test.go
@@ -319,6 +319,95 @@ func TestConvertTraces_OrphanSpansOnly(t *testing.T) {
 	}
 }
 
+// TestConvertTraces_HasError_SetWhenAnySpanErrors verifies HasError is
+// computed during conversion so GraphQL resolvers don't need to rescan spans.
+func TestConvertTraces_HasError_SetWhenAnySpanErrors(t *testing.T) {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "svc")
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	traceID := pcommon.TraceID([16]byte{0xE1})
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	ok := ss.Spans().AppendEmpty()
+	ok.SetTraceID(traceID)
+	ok.SetSpanID(pcommon.SpanID([8]byte{0x01}))
+	ok.SetStartTimestamp(pcommon.NewTimestampFromTime(base))
+	ok.SetEndTimestamp(pcommon.NewTimestampFromTime(base.Add(time.Millisecond)))
+
+	bad := ss.Spans().AppendEmpty()
+	bad.SetTraceID(traceID)
+	bad.SetSpanID(pcommon.SpanID([8]byte{0x02}))
+	bad.Status().SetCode(ptrace.StatusCodeError)
+	bad.SetStartTimestamp(pcommon.NewTimestampFromTime(base))
+	bad.SetEndTimestamp(pcommon.NewTimestampFromTime(base.Add(time.Millisecond)))
+
+	traces := ConvertTraces(td)
+	if len(traces) != 1 {
+		t.Fatalf("ConvertTraces returned %d traces, want 1", len(traces))
+	}
+	if !traces[0].HasError {
+		t.Error("HasError = false, want true when any span has StatusCode=Error")
+	}
+}
+
+func TestTraceData_Merge_PropagatesHasError(t *testing.T) {
+	t0 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	base := &TraceData{
+		TraceID:   "abc",
+		Spans:     []*SpanData{{SpanID: "a", StartTime: t0, StatusCode: "Unset"}},
+		SpanCount: 1,
+		StartTime: t0,
+	}
+	incoming := &TraceData{
+		TraceID:   "abc",
+		Spans:     []*SpanData{{SpanID: "b", StartTime: t0, StatusCode: "Error"}},
+		StartTime: t0,
+	}
+
+	base.Merge(incoming)
+
+	if !base.HasError {
+		t.Error("HasError should flip to true when a merged span has StatusCode=Error")
+	}
+}
+
+func TestTraceData_SpanByID_LookupAndInvalidation(t *testing.T) {
+	t0 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	spanA := &SpanData{SpanID: "a", StartTime: t0}
+	trace := &TraceData{
+		TraceID:   "abc",
+		Spans:     []*SpanData{spanA},
+		SpanCount: 1,
+		StartTime: t0,
+	}
+
+	if got := trace.SpanByID("a"); got != spanA {
+		t.Errorf("SpanByID(a) = %v, want spanA", got)
+	}
+	if got := trace.SpanByID("missing"); got != nil {
+		t.Errorf("SpanByID(missing) = %v, want nil", got)
+	}
+	if got := trace.SpanByID(""); got != nil {
+		t.Errorf("SpanByID(empty) = %v, want nil", got)
+	}
+
+	spanB := &SpanData{SpanID: "b", StartTime: t0}
+	trace.Merge(&TraceData{
+		TraceID:   "abc",
+		Spans:     []*SpanData{spanB},
+		StartTime: t0,
+	})
+
+	if got := trace.SpanByID("b"); got != spanB {
+		t.Errorf("SpanByID(b) after Merge = %v, want spanB (lookup must rebuild)", got)
+	}
+	if got := trace.SpanByID("a"); got != spanA {
+		t.Errorf("SpanByID(a) after Merge = %v, want spanA", got)
+	}
+}
+
 // TestConvertTraces_RootlessMultiServiceUsesEarliestStart ensures that when a
 // rootless trace spans multiple services, ConvertTraces labels it by the
 // earliest-started span's service rather than by resource iteration order.


### PR DESCRIPTION
## Summary

GraphQL resolvers were rescanning full span/log slices on every query. This PR replaces the hot-path scans with caches and secondary indexes.

- **Cache `TraceData.HasError`**: computed incrementally in `ConvertTraces` / `Merge` so the `Trace.hasError` resolver is O(1) instead of walking every span per query.
- **Lazy `TraceData.SpanByID()` map**: `Span.parent` was doing a linear search over siblings; now backed by a spanID→SpanData map built on first access. `Merge` inserts newly-appended spans directly so a duplicate-only merge never triggers a rescan.
- **`Store.logsByTraceID` secondary index**: `GetLogsPageByTraceID` was scanning the full log buffer (up to logCap, default 5000) on every trace-detail open. Now O(matched), with eviction pruning so the index stays in sync with the ring buffer.

## Test plan

- [x] `mise run check` (Go lint + frontend lint/type/format)
- [x] `mise run test` (Go tests + 70 frontend tests)
- [x] New tests:
  - `TestConvertTraces_HasError_SetWhenAnySpanErrors`
  - `TestTraceData_Merge_PropagatesHasError`
  - `TestTraceData_SpanByID_LookupAndInvalidation`
  - `TestStore_GetLogsPageByTraceID`
  - `TestStore_AddLogs_EvictionPrunesTraceIndex`