### PR TITLE
refactor(graphql): unify connection resolvers behind a generic type

### DIFF
--- a/internal/graphql/resolver.go
+++ b/internal/graphql/resolver.go
@@ -52,11 +52,14 @@ type TracesArgs struct {
 	Offset int32
 }
 
-func (r *Resolver) Traces(args TracesArgs) *TraceConnectionResolver {
+func (r *Resolver) Traces(args TracesArgs) *ConnectionResolver[*TraceResolver] {
 	items, total := r.store.GetTracesPage(int(args.Offset), int(args.Limit))
-	return &TraceConnectionResolver{
-		store:  r.store,
-		items:  items,
+	out := make([]*TraceResolver, len(items))
+	for i, t := range items {
+		out[i] = &TraceResolver{store: r.store, t: t}
+	}
+	return &ConnectionResolver[*TraceResolver]{
+		items:  out,
 		total:  int32(total),
 		limit:  args.Limit,
 		offset: args.Offset,
@@ -80,10 +83,14 @@ type MetricsArgs struct {
 	Offset int32
 }
 
-func (r *Resolver) Metrics(args MetricsArgs) *MetricConnectionResolver {
+func (r *Resolver) Metrics(args MetricsArgs) *ConnectionResolver[*MetricResolver] {
 	items, total := r.store.GetMetricsPage(int(args.Offset), int(args.Limit))
-	return &MetricConnectionResolver{
-		items:  items,
+	out := make([]*MetricResolver, len(items))
+	for i, m := range items {
+		out[i] = &MetricResolver{m: m}
+	}
+	return &ConnectionResolver[*MetricResolver]{
+		items:  out,
 		total:  int32(total),
 		limit:  args.Limit,
 		offset: args.Offset,
@@ -96,7 +103,7 @@ type LogsArgs struct {
 	TraceID *string
 }
 
-func (r *Resolver) Logs(args LogsArgs) *LogConnectionResolver {
+func (r *Resolver) Logs(args LogsArgs) *ConnectionResolver[*LogResolver] {
 	var (
 		items []*store.LogData
 		total int
@@ -106,9 +113,12 @@ func (r *Resolver) Logs(args LogsArgs) *LogConnectionResolver {
 	} else {
 		items, total = r.store.GetLogsPage(int(args.Offset), int(args.Limit))
 	}
-	return &LogConnectionResolver{
-		store:  r.store,
-		items:  items,
+	out := make([]*LogResolver, len(items))
+	for i, l := range items {
+		out[i] = &LogResolver{store: r.store, l: l}
+	}
+	return &ConnectionResolver[*LogResolver]{
+		items:  out,
 		total:  int32(total),
 		limit:  args.Limit,
 		offset: args.Offset,
@@ -136,61 +146,17 @@ func (c *ConfigResolver) TraceCount() int32    { return c.traceCount }
 func (c *ConfigResolver) MetricCount() int32   { return c.metricCount }
 func (c *ConfigResolver) LogCount() int32      { return c.logCount }
 
-type TraceConnectionResolver struct {
-	store  *store.Store
-	items  []*store.TraceData
+// ConnectionResolver is the generic paginated-list response used for traces,
+// metrics, and logs. Instantiated once per resolver type so the identical
+// items/total/limit/offset surface isn't duplicated across three structs.
+type ConnectionResolver[T any] struct {
+	items  []T
 	total  int32
 	limit  int32
 	offset int32
 }
 
-func (c *TraceConnectionResolver) Items() []*TraceResolver {
-	out := make([]*TraceResolver, len(c.items))
-	for i, t := range c.items {
-		out[i] = &TraceResolver{store: c.store, t: t}
-	}
-	return out
-}
-
-func (c *TraceConnectionResolver) Total() int32  { return c.total }
-func (c *TraceConnectionResolver) Limit() int32  { return c.limit }
-func (c *TraceConnectionResolver) Offset() int32 { return c.offset }
-
-type MetricConnectionResolver struct {
-	items  []*store.MetricData
-	total  int32
-	limit  int32
-	offset int32
-}
-
-func (c *MetricConnectionResolver) Items() []*MetricResolver {
-	out := make([]*MetricResolver, len(c.items))
-	for i, m := range c.items {
-		out[i] = &MetricResolver{m: m}
-	}
-	return out
-}
-
-func (c *MetricConnectionResolver) Total() int32  { return c.total }
-func (c *MetricConnectionResolver) Limit() int32  { return c.limit }
-func (c *MetricConnectionResolver) Offset() int32 { return c.offset }
-
-type LogConnectionResolver struct {
-	store  *store.Store
-	items  []*store.LogData
-	total  int32
-	limit  int32
-	offset int32
-}
-
-func (c *LogConnectionResolver) Items() []*LogResolver {
-	out := make([]*LogResolver, len(c.items))
-	for i, l := range c.items {
-		out[i] = &LogResolver{store: c.store, l: l}
-	}
-	return out
-}
-
-func (c *LogConnectionResolver) Total() int32  { return c.total }
-func (c *LogConnectionResolver) Limit() int32  { return c.limit }
-func (c *LogConnectionResolver) Offset() int32 { return c.offset }
+func (c *ConnectionResolver[T]) Items() []T    { return c.items }
+func (c *ConnectionResolver[T]) Total() int32  { return c.total }
+func (c *ConnectionResolver[T]) Limit() int32  { return c.limit }
+func (c *ConnectionResolver[T]) Offset() int32 { return c.offset }

--- a/internal/graphql/resolver.go
+++ b/internal/graphql/resolver.go
@@ -54,16 +54,9 @@ type TracesArgs struct {
 
 func (r *Resolver) Traces(args TracesArgs) *ConnectionResolver[*TraceResolver] {
 	items, total := r.store.GetTracesPage(int(args.Offset), int(args.Limit))
-	out := make([]*TraceResolver, len(items))
-	for i, t := range items {
-		out[i] = &TraceResolver{store: r.store, t: t}
-	}
-	return &ConnectionResolver[*TraceResolver]{
-		items:  out,
-		total:  int32(total),
-		limit:  args.Limit,
-		offset: args.Offset,
-	}
+	return newConnection(items, total, args.Limit, args.Offset, func(t *store.TraceData) *TraceResolver {
+		return &TraceResolver{store: r.store, t: t}
+	})
 }
 
 type TraceArgs struct {
@@ -85,16 +78,9 @@ type MetricsArgs struct {
 
 func (r *Resolver) Metrics(args MetricsArgs) *ConnectionResolver[*MetricResolver] {
 	items, total := r.store.GetMetricsPage(int(args.Offset), int(args.Limit))
-	out := make([]*MetricResolver, len(items))
-	for i, m := range items {
-		out[i] = &MetricResolver{m: m}
-	}
-	return &ConnectionResolver[*MetricResolver]{
-		items:  out,
-		total:  int32(total),
-		limit:  args.Limit,
-		offset: args.Offset,
-	}
+	return newConnection(items, total, args.Limit, args.Offset, func(m *store.MetricData) *MetricResolver {
+		return &MetricResolver{m: m}
+	})
 }
 
 type LogsArgs struct {
@@ -113,16 +99,9 @@ func (r *Resolver) Logs(args LogsArgs) *ConnectionResolver[*LogResolver] {
 	} else {
 		items, total = r.store.GetLogsPage(int(args.Offset), int(args.Limit))
 	}
-	out := make([]*LogResolver, len(items))
-	for i, l := range items {
-		out[i] = &LogResolver{store: r.store, l: l}
-	}
-	return &ConnectionResolver[*LogResolver]{
-		items:  out,
-		total:  int32(total),
-		limit:  args.Limit,
-		offset: args.Offset,
-	}
+	return newConnection(items, total, args.Limit, args.Offset, func(l *store.LogData) *LogResolver {
+		return &LogResolver{store: r.store, l: l}
+	})
 }
 
 func (r *Resolver) ClearSignals() bool {
@@ -146,9 +125,8 @@ func (c *ConfigResolver) TraceCount() int32    { return c.traceCount }
 func (c *ConfigResolver) MetricCount() int32   { return c.metricCount }
 func (c *ConfigResolver) LogCount() int32      { return c.logCount }
 
-// ConnectionResolver is the generic paginated-list response used for traces,
-// metrics, and logs. Instantiated once per resolver type so the identical
-// items/total/limit/offset surface isn't duplicated across three structs.
+// ConnectionResolver is the generic paginated-list response shared by
+// traces/metrics/logs. Instantiated per element type via newConnection.
 type ConnectionResolver[T any] struct {
 	items  []T
 	total  int32
@@ -160,3 +138,18 @@ func (c *ConnectionResolver[T]) Items() []T    { return c.items }
 func (c *ConnectionResolver[T]) Total() int32  { return c.total }
 func (c *ConnectionResolver[T]) Limit() int32  { return c.limit }
 func (c *ConnectionResolver[T]) Offset() int32 { return c.offset }
+
+// newConnection wraps a store page into a ConnectionResolver, mapping each
+// store record into its per-type resolver via convert.
+func newConnection[T, R any](items []T, total int, limit, offset int32, convert func(T) R) *ConnectionResolver[R] {
+	out := make([]R, len(items))
+	for i, v := range items {
+		out[i] = convert(v)
+	}
+	return &ConnectionResolver[R]{
+		items:  out,
+		total:  int32(total),
+		limit:  limit,
+		offset: offset,
+	}
+}


### PR DESCRIPTION
## Summary

Collapse the three near-identical connection resolver structs (`TraceConnectionResolver`, `MetricConnectionResolver`, `LogConnectionResolver`) into a single `ConnectionResolver[T]` generic, plus a `newConnection` helper that wraps a store page with a per-type converter. The identical `items`/`total`/`limit`/`offset` surface — and the per-query `make+for` resolver-wrapping loop — now each live in one place.

Net -37 lines in `internal/graphql/resolver.go`.

## Test plan

- [x] `mise run check` (Go lint + frontend lint/type/format)
- [x] `mise run test` — all existing GraphQL schema tests (`TestSchemaParses`, `TestTraces_FieldSelection`, `TestLogs_TraceIDFilter`, `TestMetrics_PointCountWithoutFetchingPoints`, etc.) pass unchanged, confirming graph-gophers/graphql-go reflection handles the instantiated generic types correctly