### PR TITLE
refactor(store): factor resource attrs + service.name into resourceInfo

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"ad34ebea-5478-41da-814b-4fb6142cd880","pid":7210,"acquiredAt":1776357185673}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"ad34ebea-5478-41da-814b-4fb6142cd880","pid":7210,"acquiredAt":1776357185673}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ frontend/node_modules/
 # Build
 /dist/
 /tmp/
+
+# Claude Code local state
+/.claude/scheduled_tasks.lock

--- a/internal/store/attrs.go
+++ b/internal/store/attrs.go
@@ -17,10 +17,9 @@ func attributesToMap(attrs pcommon.Map) map[string]any {
 	return result
 }
 
-// resourceInfo flattens OTLP resource attributes into a plain map and
-// surfaces service.name alongside it. The three signal converters (trace,
-// metric, log) always want these two values in lockstep; pulling them in a
-// single Range pass avoids a second O(n) scan for the service.name lookup.
+// resourceInfo returns the flattened resource map plus service.name. Both
+// are computed in a single Range pass so the service.name lookup doesn't
+// need a second O(n) scan over the same attributes.
 func resourceInfo(attrs pcommon.Map) (map[string]any, string) {
 	result := make(map[string]any, attrs.Len())
 	var svcName string

--- a/internal/store/attrs.go
+++ b/internal/store/attrs.go
@@ -17,6 +17,23 @@ func attributesToMap(attrs pcommon.Map) map[string]any {
 	return result
 }
 
+// resourceInfo flattens OTLP resource attributes into a plain map and
+// surfaces service.name alongside it. The three signal converters (trace,
+// metric, log) always want these two values in lockstep; pulling them in a
+// single Range pass avoids a second O(n) scan for the service.name lookup.
+func resourceInfo(attrs pcommon.Map) (map[string]any, string) {
+	result := make(map[string]any, attrs.Len())
+	var svcName string
+	attrs.Range(func(k string, v pcommon.Value) bool {
+		if k == "service.name" {
+			svcName = v.AsString()
+		}
+		result[k] = valueToAny(v)
+		return true
+	})
+	return result, svcName
+}
+
 func valueToAny(v pcommon.Value) any {
 	switch v.Type() {
 	case pcommon.ValueTypeStr:

--- a/internal/store/log.go
+++ b/internal/store/log.go
@@ -26,11 +26,7 @@ func ConvertLogs(ld plog.Logs) []*LogData {
 
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		rl := ld.ResourceLogs().At(i)
-		resource := attributesToMap(rl.Resource().Attributes())
-		var svcName string
-		if serviceName, ok := rl.Resource().Attributes().Get("service.name"); ok {
-			svcName = serviceName.AsString()
-		}
+		resource, svcName := resourceInfo(rl.Resource().Attributes())
 
 		for j := 0; j < rl.ScopeLogs().Len(); j++ {
 			sl := rl.ScopeLogs().At(j)

--- a/internal/store/metric.go
+++ b/internal/store/metric.go
@@ -47,11 +47,7 @@ func convertMetrics(md pmetric.Metrics, series *seriesStore) []*MetricData {
 
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {
 		rm := md.ResourceMetrics().At(i)
-		resource := attributesToMap(rm.Resource().Attributes())
-		var svcName string
-		if serviceName, ok := rm.Resource().Attributes().Get("service.name"); ok {
-			svcName = serviceName.AsString()
-		}
+		resource, svcName := resourceInfo(rm.Resource().Attributes())
 
 		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
 			sm := rm.ScopeMetrics().At(j)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -404,6 +404,47 @@ func TestAttributesToMap_NonFiniteDoubles(t *testing.T) {
 	}
 }
 
+func TestResourceInfo(t *testing.T) {
+	t.Run("extracts service.name and flattens attributes", func(t *testing.T) {
+		attrs := pcommon.NewMap()
+		attrs.PutStr("service.name", "svc-a")
+		attrs.PutStr("deployment.env", "prod")
+		attrs.PutInt("pid", 42)
+
+		got, svc := resourceInfo(attrs)
+
+		if svc != "svc-a" {
+			t.Errorf("svc = %q, want svc-a", svc)
+		}
+		if got["service.name"] != "svc-a" {
+			t.Errorf("attrs[service.name] = %v, want svc-a", got["service.name"])
+		}
+		if got["deployment.env"] != "prod" {
+			t.Errorf("attrs[deployment.env] = %v, want prod", got["deployment.env"])
+		}
+		if got["pid"] != int64(42) {
+			t.Errorf("attrs[pid] = %v, want 42", got["pid"])
+		}
+	})
+
+	t.Run("returns empty service.name when missing", func(t *testing.T) {
+		attrs := pcommon.NewMap()
+		attrs.PutStr("deployment.env", "prod")
+
+		got, svc := resourceInfo(attrs)
+
+		if svc != "" {
+			t.Errorf("svc = %q, want empty", svc)
+		}
+		if _, ok := got["service.name"]; ok {
+			t.Errorf("attrs should not contain service.name, got %v", got)
+		}
+		if got["deployment.env"] != "prod" {
+			t.Errorf("attrs[deployment.env] = %v, want prod", got["deployment.env"])
+		}
+	})
+}
+
 func TestStore_AddMetrics_SkipsEmptyMetrics(t *testing.T) {
 	var notified []*MetricData
 	s := NewStore(10, 10, 10, 100, func(sig SignalType, data any) {

--- a/internal/store/trace.go
+++ b/internal/store/trace.go
@@ -140,11 +140,7 @@ func ConvertTraces(td ptrace.Traces) []*TraceData {
 	resourceSpans := td.ResourceSpans()
 	for i := 0; i < resourceSpans.Len(); i++ {
 		rs := resourceSpans.At(i)
-		resource := attributesToMap(rs.Resource().Attributes())
-		var svcName string
-		if serviceName, ok := rs.Resource().Attributes().Get("service.name"); ok {
-			svcName = serviceName.AsString()
-		}
+		resource, svcName := resourceInfo(rs.Resource().Attributes())
 
 		scopeSpans := rs.ScopeSpans()
 		for j := 0; j < scopeSpans.Len(); j++ {


### PR DESCRIPTION
## Summary

`ConvertTraces`, `ConvertLogs`, and `convertMetrics` each repeated the same two lines at the resource boundary:

```go
resource := attributesToMap(rs.Resource().Attributes())
var svcName string
if serviceName, ok := rs.Resource().Attributes().Get("service.name"); ok {
    svcName = serviceName.AsString()
}
```

Pull this into a single `resourceInfo` helper in `internal/store/attrs.go` that flattens the map and surfaces `service.name` in one `Range` pass — saving the separate O(n) `Get` lookup and removing the duplication across the three signal converters.

Also ships a tiny `.gitignore` fix for the Claude Code scheduler lock file that leaked into the test commit.

## Test plan

- [x] `mise run check` (Go lint + frontend lint/type/format)
- [x] `mise run test` (Go + 70 frontend tests)
- [x] New `TestResourceInfo` covers the present and absent `service.name` paths