### PR TITLE
perf(store): hash series keys with maphash instead of allocating strings

### DIFF
--- a/internal/store/series.go
+++ b/internal/store/series.go
@@ -2,9 +2,9 @@ package store
 
 import (
 	"fmt"
+	"hash/maphash"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 )
@@ -42,7 +42,7 @@ type seriesState struct {
 // (Store) already hold their own lock during ingest.
 type seriesStore struct {
 	mu         sync.Mutex
-	entries    map[string]*seriesState
+	entries    map[uint64]*seriesState
 	ttl        time.Duration
 	maxEntries int
 	lastPrune  time.Time
@@ -50,20 +50,27 @@ type seriesStore struct {
 
 func newSeriesStore() *seriesStore {
 	return &seriesStore{
-		entries:    make(map[string]*seriesState),
+		entries:    make(map[uint64]*seriesState),
 		ttl:        defaultSeriesTTL,
 		maxEntries: defaultSeriesMaxEntries,
 	}
 }
 
-// seriesKey builds a stable lookup key for a metric series. Attributes are
-// sorted so callers don't have to think about insertion order.
-func seriesKey(serviceName, metricName string, attrs map[string]any) string {
-	var b strings.Builder
-	b.WriteString(serviceName)
-	b.WriteByte(0)
-	b.WriteString(metricName)
-	b.WriteByte(0)
+// seriesKeySeed is chosen once per process — the series store never leaves
+// memory, so a process-local keyspace is all we need.
+var seriesKeySeed = maphash.MakeSeed()
+
+// seriesKey builds a stable 64-bit hash key for a metric series. Attributes
+// are sorted before hashing so callers don't have to think about insertion
+// order. Returning a uint64 instead of a string avoids allocating a fresh
+// key string on every ingested data point.
+func seriesKey(serviceName, metricName string, attrs map[string]any) uint64 {
+	var h maphash.Hash
+	h.SetSeed(seriesKeySeed)
+	h.WriteString(serviceName)
+	h.WriteByte(0)
+	h.WriteString(metricName)
+	h.WriteByte(0)
 	if len(attrs) > 0 {
 		keys := make([]string, 0, len(attrs))
 		for k := range attrs {
@@ -71,31 +78,40 @@ func seriesKey(serviceName, metricName string, attrs map[string]any) string {
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			b.WriteString(k)
-			b.WriteByte('=')
-			b.WriteString(stringifyAttr(attrs[k]))
-			b.WriteByte(0)
+			h.WriteString(k)
+			h.WriteByte('=')
+			writeAttrValue(&h, attrs[k])
+			h.WriteByte(0)
 		}
 	}
-	return b.String()
+	return h.Sum64()
 }
 
-func stringifyAttr(v any) string {
+// writeAttrValue hashes the canonical bytes of an attribute value without
+// allocating an intermediate string for int/float/bool.
+func writeAttrValue(h *maphash.Hash, v any) {
 	switch x := v.(type) {
 	case string:
-		return x
+		h.WriteString(x)
 	case bool:
-		return strconv.FormatBool(x)
+		if x {
+			h.WriteString("true")
+		} else {
+			h.WriteString("false")
+		}
 	case int64:
-		return strconv.FormatInt(x, 10)
+		var buf [20]byte
+		_, _ = h.Write(strconv.AppendInt(buf[:0], x, 10))
 	case int:
-		return strconv.Itoa(x)
+		var buf [20]byte
+		_, _ = h.Write(strconv.AppendInt(buf[:0], int64(x), 10))
 	case float64:
-		return strconv.FormatFloat(x, 'g', -1, 64)
+		var buf [32]byte
+		_, _ = h.Write(strconv.AppendFloat(buf[:0], x, 'g', -1, 64))
 	case nil:
-		return ""
+		// nothing to hash
 	default:
-		return fmt.Sprintf("%v", x)
+		_, _ = fmt.Fprintf(h, "%v", x)
 	}
 }
 
@@ -103,7 +119,7 @@ func stringifyAttr(v any) string {
 // updates the stored snapshot. If there is no prior snapshot, or the new
 // value is smaller (counter reset), it records the baseline and returns
 // ok=false so the caller can drop the point.
-func (s *seriesStore) numberDelta(key string, rawValue float64, now time.Time) (delta float64, ok bool) {
+func (s *seriesStore) numberDelta(key uint64, rawValue float64, now time.Time) (delta float64, ok bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.pruneLocked(now)
@@ -125,7 +141,7 @@ func (s *seriesStore) numberDelta(key string, rawValue float64, now time.Time) (
 
 // histogramDelta returns (countDelta, sumDelta) and updates the stored
 // snapshot. Same reset semantics as numberDelta.
-func (s *seriesStore) histogramDelta(key string, rawCount uint64, rawSum float64, now time.Time) (countDelta uint64, sumDelta float64, ok bool) {
+func (s *seriesStore) histogramDelta(key uint64, rawCount uint64, rawSum float64, now time.Time) (countDelta uint64, sumDelta float64, ok bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.pruneLocked(now)
@@ -158,14 +174,18 @@ func (s *seriesStore) histogramDelta(key string, rawCount uint64, rawSum float64
 // admitLocked inserts a new entry, evicting the oldest-lastSeen entry when
 // the cap is hit. O(N) on eviction but only fires when the map is full, so
 // steady-state cost is O(1).
-func (s *seriesStore) admitLocked(key string, state *seriesState) {
+func (s *seriesStore) admitLocked(key uint64, state *seriesState) {
 	if s.maxEntries > 0 && len(s.entries) >= s.maxEntries {
-		var oldestKey string
-		var oldestSeen time.Time
+		var (
+			oldestKey  uint64
+			oldestSeen time.Time
+			haveOldest bool
+		)
 		for k, v := range s.entries {
-			if oldestKey == "" || v.lastSeen.Before(oldestSeen) {
+			if !haveOldest || v.lastSeen.Before(oldestSeen) {
 				oldestKey = k
 				oldestSeen = v.lastSeen
+				haveOldest = true
 			}
 		}
 		delete(s.entries, oldestKey)

--- a/internal/store/series_test.go
+++ b/internal/store/series_test.go
@@ -11,7 +11,7 @@ func TestSeriesKey_StableAcrossAttrOrder(t *testing.T) {
 	a := seriesKey("svc", "m", map[string]any{"http.route": "/a", "http.method": "GET"})
 	b := seriesKey("svc", "m", map[string]any{"http.method": "GET", "http.route": "/a"})
 	if a != b {
-		t.Fatalf("seriesKey should be order-independent, got %q vs %q", a, b)
+		t.Fatalf("seriesKey should be order-independent, got %d vs %d", a, b)
 	}
 }
 
@@ -23,23 +23,38 @@ func TestSeriesKey_DifferentAttrsCollideNot(t *testing.T) {
 	}
 }
 
+func BenchmarkSeriesKey(b *testing.B) {
+	attrs := map[string]any{
+		"http.method":      "GET",
+		"http.route":       "/api/v1/widgets/:id",
+		"http.status_code": int64(200),
+		"net.peer.name":    "backend.internal",
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = seriesKey("svc", "http.server.request.duration", attrs)
+	}
+}
+
 func TestNumberDelta_BaselineThenDelta(t *testing.T) {
 	s := newSeriesStore()
 	now := time.Unix(0, 0)
+	const k uint64 = 1
 
 	// First observation → baseline, emit nothing.
-	if _, ok := s.numberDelta("k", 10, now); ok {
+	if _, ok := s.numberDelta(k, 10, now); ok {
 		t.Fatalf("first observation should be a baseline (ok=false)")
 	}
 
 	// Second observation → delta = 5.
-	delta, ok := s.numberDelta("k", 15, now.Add(time.Second))
+	delta, ok := s.numberDelta(k, 15, now.Add(time.Second))
 	if !ok || delta != 5 {
 		t.Fatalf("expected delta=5, got delta=%v ok=%v", delta, ok)
 	}
 
 	// Third observation → delta = 3.
-	delta, ok = s.numberDelta("k", 18, now.Add(2*time.Second))
+	delta, ok = s.numberDelta(k, 18, now.Add(2*time.Second))
 	if !ok || delta != 3 {
 		t.Fatalf("expected delta=3, got delta=%v ok=%v", delta, ok)
 	}
@@ -48,14 +63,15 @@ func TestNumberDelta_BaselineThenDelta(t *testing.T) {
 func TestNumberDelta_ResetReestablishesBaseline(t *testing.T) {
 	s := newSeriesStore()
 	now := time.Unix(0, 0)
-	s.numberDelta("k", 100, now)
-	s.numberDelta("k", 120, now.Add(time.Second))
+	const k uint64 = 1
+	s.numberDelta(k, 100, now)
+	s.numberDelta(k, 120, now.Add(time.Second))
 	// Process restart / counter reset — raw value goes down.
-	if _, ok := s.numberDelta("k", 5, now.Add(2*time.Second)); ok {
+	if _, ok := s.numberDelta(k, 5, now.Add(2*time.Second)); ok {
 		t.Fatalf("reset should emit no delta")
 	}
 	// Next point is a delta against the new baseline.
-	delta, ok := s.numberDelta("k", 8, now.Add(3*time.Second))
+	delta, ok := s.numberDelta(k, 8, now.Add(3*time.Second))
 	if !ok || delta != 3 {
 		t.Fatalf("expected delta=3 after reset, got delta=%v ok=%v", delta, ok)
 	}
@@ -64,11 +80,12 @@ func TestNumberDelta_ResetReestablishesBaseline(t *testing.T) {
 func TestHistogramDelta_CountAndSum(t *testing.T) {
 	s := newSeriesStore()
 	now := time.Unix(0, 0)
+	const k uint64 = 1
 
-	if _, _, ok := s.histogramDelta("k", 10, 100, now); ok {
+	if _, _, ok := s.histogramDelta(k, 10, 100, now); ok {
 		t.Fatalf("first observation should be baseline")
 	}
-	c, sm, ok := s.histogramDelta("k", 13, 130, now.Add(time.Second))
+	c, sm, ok := s.histogramDelta(k, 13, 130, now.Add(time.Second))
 	if !ok || c != 3 || sm != 30 {
 		t.Fatalf("expected count=3 sum=30, got count=%d sum=%v ok=%v", c, sm, ok)
 	}
@@ -78,10 +95,10 @@ func TestSeriesStore_TTLPrune(t *testing.T) {
 	s := newSeriesStore()
 	s.ttl = time.Second
 	now := time.Unix(0, 0)
-	s.numberDelta("stale", 1, now)
-	s.numberDelta("fresh", 1, now.Add(10*time.Second))
-	// The "fresh" write prunes anything older than 10s - 1s = 9s, which
-	// includes "stale" (lastSeen=0s).
+	s.numberDelta(1, 1, now)
+	s.numberDelta(2, 1, now.Add(10*time.Second))
+	// The second write prunes anything older than 10s - 1s = 9s, which
+	// includes the first entry (lastSeen=0s).
 	if s.len() != 1 {
 		t.Fatalf("expected stale entry to be pruned, got len=%d", s.len())
 	}


### PR DESCRIPTION
## Summary

`seriesKey` ran on every ingested cumulative metric data point and built a fresh string via `strings.Builder` + `stringifyAttr`, churning ~560 B and 7 allocations per call. Switch it to a `uint64` hashed with `hash/maphash`, and inline the attribute formatting so `int`/`float`/`bool` cases hash directly into the buffer without an intermediate string.

- Change `seriesKey` return type: `string` → `uint64`
- Change `seriesStore.entries`: `map[string]*seriesState` → `map[uint64]*seriesState`
- Update `numberDelta`/`histogramDelta`/`admitLocked` signatures accordingly
- Remove the old `stringifyAttr` helper; replace with `writeAttrValue` that writes straight into the hash
- Add `BenchmarkSeriesKey` to document the target workload and catch regressions

## Benchmark

`BenchmarkSeriesKey` on darwin/arm64 with 4 attributes:

```
before: 258 ns/op  560 B/op  7 allocs/op
after:  203 ns/op  224 B/op  2 allocs/op
```

The remaining 2 allocations come from the keys slice used to canonicalize attribute order before hashing; stack-buffering that is possible but not worth the complexity at typical attribute counts.

## Notes

`hash/maphash`'s seed is process-local, so series keys are not stable across restarts — that's fine because the `seriesStore` is in-memory only. Collision probability at the 50k entry cap is ~1e-9, well within acceptable territory.

## Test plan

- [x] `mise run check` (Go lint + frontend lint/type/format)
- [x] `mise run test` (Go + 70 frontend tests)
- [x] Existing `TestSeriesKey_*`, `TestNumberDelta_*`, `TestHistogramDelta_*`, `TestSeriesStore_TTLPrune` pass with the new key type