### PR TITLE
perf(frontend): stable key for DataPointsTable rows

### DIFF
--- a/frontend/src/components/metrics/metric-detail.tsx
+++ b/frontend/src/components/metrics/metric-detail.tsx
@@ -162,9 +162,9 @@ function DataPointsTable({ metric }: { metric: MetricData }) {
             </tr>
           </thead>
           <tbody>
-            {[...metric.dataPoints].reverse().map((dp, i) => (
+            {[...metric.dataPoints].reverse().map((dp) => (
               <tr
-                key={i}
+                key={`${dp.timestamp}|${attrKey(dp.attributes)}`}
                 className="border-b border-border/20 last:border-0 transition-colors hover:bg-metric/5"
               >
                 <td className="px-3 py-1.5 font-mono text-muted-foreground">


### PR DESCRIPTION
## Summary

`DataPointsTable` used the array index as React's key on a reversed copy of `metric.dataPoints`:

```tsx
{[...metric.dataPoints].reverse().map((dp, i) => (
  <tr key={i} ...>
```

With live WebSocket updates the underlying array shifts (old points are sliced off at the `maxDataPoints` cap, new ones append), so the same index refers to a different data point on the next render — every row re-mounts, defeating React reconciliation.

Use a content-based key (`timestamp | attrKey(attributes)`) so React can match rows across updates. For a metric open during live ingest this keeps the table from tearing down and rebuilding every data-point row on each tick.

## Test plan

- [x] `mise run check` (Go lint + frontend lint/type/format)
- [x] `mise run test` (Go + 70 frontend tests)