### PR TITLE
fix(cli): show wall-clock uptime across system sleep

### DIFF
--- a/cmd/otelop/start.go
+++ b/cmd/otelop/start.go
@@ -246,8 +246,9 @@ func bootstrap(ctx context.Context, opts startOptions) (*runtime, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	rt := &runtime{
-		cancel:    cancel,
-		startedAt: time.Now(),
+		cancel: cancel,
+		// Round(0) drops the monotonic reading so uptime spans system sleep.
+		startedAt: time.Now().Round(0),
 	}
 
 	rt.hub = ws.NewHub()


### PR DESCRIPTION
## Summary

`otelop status` reported uptime that lagged real elapsed time after the laptop had been closed overnight — e.g. a process running for 26 hours across an 8-hour sleep showed `up 18h`.

`runtime.startedAt` was captured via `time.Now()`, which carries both a wall-clock value and a monotonic reading. When two `time.Time` values both have monotonic readings, Go's `time.Since` / `Sub` uses the monotonic clock alone, and that clock pauses while the host is suspended.

Strip the monotonic reading at init with `Round(0)` so `time.Since` falls back to wall-clock subtraction.

## Test plan

- [x] `mise run check`
- [x] `mise run test`