### PR TITLE
refactor(graphql): preserve argument types on field spans

### DIFF
--- a/internal/graphql/tracer.go
+++ b/internal/graphql/tracer.go
@@ -93,13 +93,38 @@ func (slogTracer) TraceField(
 	}
 	spanCtx, span := otelTracer().Start(ctx, typeName+"."+fieldName)
 	for name, value := range args {
-		span.SetAttributes(attribute.String("graphql.args."+name, fmt.Sprintf("%v", value)))
+		span.SetAttributes(argAttribute("graphql.args."+name, value))
 	}
 	return spanCtx, func(err *errors.QueryError) {
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 		}
 		span.End()
+	}
+}
+
+// argAttribute preserves the argument's underlying type on the span so
+// integer / boolean arguments aren't flattened into strings in the trace
+// viewer. Compound values fall back to Sprintf because OTel attributes are
+// scalar-only.
+func argAttribute(key string, v any) attribute.KeyValue {
+	switch x := v.(type) {
+	case nil:
+		return attribute.String(key, "")
+	case bool:
+		return attribute.Bool(key, x)
+	case int32:
+		return attribute.Int64(key, int64(x))
+	case int64:
+		return attribute.Int64(key, x)
+	case int:
+		return attribute.Int(key, x)
+	case float64:
+		return attribute.Float64(key, x)
+	case string:
+		return attribute.String(key, x)
+	default:
+		return attribute.String(key, fmt.Sprintf("%v", v))
 	}
 }
 

--- a/internal/graphql/tracer_test.go
+++ b/internal/graphql/tracer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
@@ -76,20 +77,38 @@ func TestTracer_EmitsOtelSpans(t *testing.T) {
 		names[i] = s.Name()
 	}
 
-	var seenQuery, seenTracesField bool
-	for _, n := range names {
+	var seenQuery bool
+	var tracesSpan sdktrace.ReadOnlySpan
+	for i, n := range names {
 		if n == "graphql.query" {
 			seenQuery = true
 		}
 		if n == "Query.traces" {
-			seenTracesField = true
+			tracesSpan = spans[i]
 		}
 	}
 	if !seenQuery {
 		t.Errorf("expected graphql.query span, got %v", names)
 	}
-	if !seenTracesField {
-		t.Errorf("expected Query.traces span, got %v", names)
+	if tracesSpan == nil {
+		t.Fatalf("expected Query.traces span, got %v", names)
+	}
+
+	var limitAttr attribute.KeyValue
+	for _, attr := range tracesSpan.Attributes() {
+		if string(attr.Key) == "graphql.args.limit" {
+			limitAttr = attr
+			break
+		}
+	}
+	if limitAttr.Key == "" {
+		t.Fatalf("expected graphql.args.limit on Query.traces span, got attrs %v", tracesSpan.Attributes())
+	}
+	if limitAttr.Value.Type() != attribute.INT64 {
+		t.Errorf("graphql.args.limit type = %v, want INT64", limitAttr.Value.Type())
+	}
+	if got := limitAttr.Value.AsInt64(); got != 1 {
+		t.Errorf("graphql.args.limit = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Inspecting otelop's own self-telemetry surfaced field spans like `Query.traces` carrying `graphql.args.limit` as the string `"0"`, even though limit is an `int32` in the schema. The field tracer was stringifying every arg via `fmt.Sprintf("%v", value)` regardless of the underlying type.

Switch on the runtime type and use the appropriate OTel attribute constructor (`attribute.Int64`, `attribute.Bool`, `attribute.Float64`, `attribute.String`) so the trace viewer keeps the type information the OTel attribute API already supports. Compound types fall back to `Sprintf` because OTel attributes are scalar-only.

## Test plan

- [x] `mise run check`
- [x] `mise run test`
- [x] Extended `TestTracer_EmitsOtelSpans` to assert `graphql.args.limit` on `Query.traces` is stored as `INT64` with value `1`