### PR TITLE
feat(server): emit spa.stat and spa.serve spans

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,12 +10,19 @@ import (
 	gqlgo "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
 
 	otelopgraphql "github.com/mashiro/otelop/internal/graphql"
 	"github.com/mashiro/otelop/internal/mcp"
 	"github.com/mashiro/otelop/internal/store"
 	ws "github.com/mashiro/otelop/internal/websocket"
 )
+
+// tracer resolves the server tracer lazily so tests that swap the global
+// provider still see their own span recorder.
+func tracer() oteltrace.Tracer { return otel.Tracer("otelop/server") }
 
 // Server serves the GraphQL endpoint, MCP endpoint, WebSocket stream, and
 // embedded frontend.
@@ -123,8 +130,10 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return s.httpServer.Shutdown(ctx)
 }
 
-// spaHandler serves static files from the given filesystem, falling back to index.html
-// for paths that don't match a real file (SPA routing).
+// spaHandler serves static files from the given filesystem, falling back to
+// index.html for paths that don't match a real file (SPA routing). Emits
+// child spans (spa.stat, spa.serve) so the otelhttp root span's duration can
+// be split into existence-check vs file-serving vs wrapping middleware.
 func spaHandler(fsys fs.FS) http.Handler {
 	fileServer := http.FileServerFS(fsys)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -135,10 +144,19 @@ func spaHandler(fsys fs.FS) http.Handler {
 			path = path[1:]
 		}
 
+		ctx := r.Context()
+		statCtx, statSpan := tracer().Start(ctx, "spa.stat")
+		statSpan.SetAttributes(attribute.String("spa.path", path))
 		_, err := fs.Stat(fsys, path)
+		statSpan.SetAttributes(attribute.Bool("spa.found", err == nil))
+		statSpan.End()
+		_ = statCtx
+
 		if err != nil {
 			r.URL.Path = "/"
 		}
-		fileServer.ServeHTTP(w, r)
+		serveCtx, serveSpan := tracer().Start(ctx, "spa.serve")
+		defer serveSpan.End()
+		fileServer.ServeHTTP(w, r.WithContext(serveCtx))
 	})
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestSpaHandler_EmitsStatAndServeSpans(t *testing.T) {
+	orig := otel.GetTracerProvider()
+	t.Cleanup(func() { otel.SetTracerProvider(orig) })
+
+	fsys := fstest.MapFS{
+		"index.html": {Data: []byte("<html></html>")},
+		"app.js":     {Data: []byte("console.log(0)")},
+	}
+
+	h := spaHandler(fsys)
+
+	tests := []struct {
+		name      string
+		path      string
+		wantFound bool
+	}{
+		{name: "existing asset", path: "/app.js", wantFound: true},
+		{name: "spa fallback", path: "/nonexistent/route", wantFound: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := tracetest.NewSpanRecorder()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+			otel.SetTracerProvider(tp)
+
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
+			h.ServeHTTP(rr, req)
+
+			var sawStat, sawServe bool
+			for _, span := range rec.Ended() {
+				switch span.Name() {
+				case "spa.stat":
+					sawStat = true
+					var found *bool
+					for _, a := range span.Attributes() {
+						if string(a.Key) == "spa.found" {
+							v := a.Value.AsBool()
+							found = &v
+						}
+					}
+					if found == nil {
+						t.Errorf("spa.stat missing spa.found attribute")
+					} else if *found != tc.wantFound {
+						t.Errorf("spa.found = %v, want %v", *found, tc.wantFound)
+					}
+				case "spa.serve":
+					sawServe = true
+				}
+			}
+			if !sawStat {
+				t.Errorf("expected spa.stat span")
+			}
+			if !sawServe {
+				t.Errorf("expected spa.serve span")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Drilling into the static-file `GET /assets/*.js` trace in otelop's own self-telemetry surfaced only the `otelhttp` root span — the 16 ms handler was opaque. With brotli/gzip compression, `fs.Stat`, `http.FileServerFS`, and mux dispatch all stacked under one span, there was no way to tell where the time actually went from the trace viewer alone.

Split `spaHandler` into explicit child spans:

- **`spa.stat`** — existence probe against the embedded FS, with `spa.path` and `spa.found` attributes
- **`spa.serve`** — `http.FileServerFS.ServeHTTP` work

When a trace shows the root ≫ `spa.stat + spa.serve`, the remainder is the compression middleware.

## Test plan

- [x] `mise run check`
- [x] `mise run test`
- [x] New `TestSpaHandler_EmitsStatAndServeSpans` covers both the asset-found and SPA-fallback paths