### PR TITLE
feat(store): emit ingest spans with batch counts

### DIFF
--- a/cmd/otelop/start.go
+++ b/cmd/otelop/start.go
@@ -254,7 +254,7 @@ func bootstrap(ctx context.Context, opts startOptions) (*runtime, error) {
 	rt.hub = ws.NewHub()
 	go rt.hub.Run(ctx)
 
-	rt.store = store.NewStore(opts.TraceCap, opts.MetricCap, opts.LogCap, opts.MaxDataPoints, func(sig store.SignalType, data any) {
+	rt.store = store.NewStore(opts.TraceCap, opts.MetricCap, opts.LogCap, opts.MaxDataPoints, func(_ context.Context, sig store.SignalType, data any) {
 		rt.hub.Broadcast(ws.Message{Type: sig, Data: data})
 	})
 

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -19,17 +19,17 @@ func newExporter(s *store.Store) *otelopExporter {
 	return &otelopExporter{store: s}
 }
 
-func (e *otelopExporter) pushTraces(_ context.Context, td ptrace.Traces) error {
-	e.store.AddTraces(td)
+func (e *otelopExporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
+	e.store.AddTraces(ctx, td)
 	return nil
 }
 
-func (e *otelopExporter) pushMetrics(_ context.Context, md pmetric.Metrics) error {
-	e.store.AddMetrics(md)
+func (e *otelopExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) error {
+	e.store.AddMetrics(ctx, md)
 	return nil
 }
 
-func (e *otelopExporter) pushLogs(_ context.Context, ld plog.Logs) error {
-	e.store.AddLogs(ld)
+func (e *otelopExporter) pushLogs(ctx context.Context, ld plog.Logs) error {
+	e.store.AddLogs(ctx, ld)
 	return nil
 }

--- a/internal/graphql/schema_test.go
+++ b/internal/graphql/schema_test.go
@@ -54,7 +54,7 @@ func seedStore(t *testing.T) *store.Store {
 	sp2child.Status().SetCode(ptrace.StatusCodeError)
 	sp2child.Status().SetMessage("db down")
 
-	s.AddTraces(td)
+	s.AddTraces(context.Background(), td)
 
 	// A metric
 	md := pmetric.NewMetrics()
@@ -71,7 +71,7 @@ func seedStore(t *testing.T) *store.Store {
 		dp.SetDoubleValue(float64(i) + 0.5)
 		dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
 	}
-	s.AddMetrics(md)
+	s.AddMetrics(context.Background(), md)
 
 	// Logs: 1 correlated with trace 2, 1 orphan
 	ld := plog.NewLogs()
@@ -90,7 +90,7 @@ func seedStore(t *testing.T) *store.Store {
 	lr2.Body().SetStr("unrelated")
 	lr2.SetTimestamp(pcommon.NewTimestampFromTime(now))
 
-	s.AddLogs(ld)
+	s.AddLogs(context.Background(), ld)
 
 	return s
 }
@@ -311,7 +311,7 @@ func TestLogEdge_TraceNullWhenEvicted(t *testing.T) {
 	lr := sl.LogRecords().AppendEmpty()
 	lr.SetTraceID(pcommon.TraceID([16]byte{9}))
 	lr.Body().SetStr("orphan")
-	s.AddLogs(ld)
+	s.AddLogs(context.Background(), ld)
 
 	data := exec(t, s, `{ logs { items { body trace { traceId } } } }`, nil)
 	items := data["logs"].(map[string]any)["items"].([]any)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,12 +1,20 @@
 package store
 
 import (
+	"context"
 	"sync"
 
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
+
+// tracer resolves lazily so tests that swap the global provider still see
+// their own span recorder.
+func tracer() oteltrace.Tracer { return otel.Tracer("otelop/store") }
 
 // SignalType identifies the type of telemetry signal.
 type SignalType string
@@ -19,8 +27,9 @@ const (
 
 // OnAddFunc is called when new data is added to the store. It runs outside the
 // store's write lock so implementations may take their time (e.g. serialize
-// and broadcast over a WebSocket).
-type OnAddFunc func(signalType SignalType, data any)
+// and broadcast over a WebSocket). The ctx carries the ingest span so
+// broadcast work shows up as a child in the trace.
+type OnAddFunc func(ctx context.Context, signalType SignalType, data any)
 
 // Store holds telemetry data in bounded ring buffers keyed for O(1) upsert.
 type Store struct {
@@ -67,8 +76,13 @@ func metricKey(serviceName, name string) string {
 }
 
 // AddTraces converts and stores trace data. Broadcasts fire outside the lock.
-func (s *Store) AddTraces(td ptrace.Traces) {
+func (s *Store) AddTraces(ctx context.Context, td ptrace.Traces) {
+	ctx, span := tracer().Start(ctx, "store.add_traces")
+	defer span.End()
+	span.SetAttributes(attribute.Int("store.resource_spans", td.ResourceSpans().Len()))
+
 	converted := ConvertTraces(td)
+	span.SetAttributes(attribute.Int("store.traces.converted", len(converted)))
 	if len(converted) == 0 {
 		return
 	}
@@ -94,16 +108,22 @@ func (s *Store) AddTraces(td ptrace.Traces) {
 	}
 	s.mu.Unlock()
 
+	span.SetAttributes(attribute.Int("store.traces.notified", len(notify)))
 	if s.onAdd != nil {
 		for _, trace := range notify {
-			s.onAdd(SignalTraces, trace)
+			s.onAdd(ctx, SignalTraces, trace)
 		}
 	}
 }
 
 // AddMetrics converts and stores metric data, merging data points for the same metric.
-func (s *Store) AddMetrics(md pmetric.Metrics) {
+func (s *Store) AddMetrics(ctx context.Context, md pmetric.Metrics) {
+	ctx, span := tracer().Start(ctx, "store.add_metrics")
+	defer span.End()
+	span.SetAttributes(attribute.Int("store.resource_metrics", md.ResourceMetrics().Len()))
+
 	converted := convertMetrics(md, s.series)
+	span.SetAttributes(attribute.Int("store.metrics.converted", len(converted)))
 	if len(converted) == 0 {
 		return
 	}
@@ -141,16 +161,22 @@ func (s *Store) AddMetrics(md pmetric.Metrics) {
 	}
 	s.mu.Unlock()
 
+	span.SetAttributes(attribute.Int("store.metrics.notified", len(notify)))
 	if s.onAdd != nil {
 		for _, m := range notify {
-			s.onAdd(SignalMetrics, m)
+			s.onAdd(ctx, SignalMetrics, m)
 		}
 	}
 }
 
 // AddLogs converts and stores log data.
-func (s *Store) AddLogs(ld plog.Logs) {
+func (s *Store) AddLogs(ctx context.Context, ld plog.Logs) {
+	ctx, span := tracer().Start(ctx, "store.add_logs")
+	defer span.End()
+	span.SetAttributes(attribute.Int("store.resource_logs", ld.ResourceLogs().Len()))
+
 	converted := ConvertLogs(ld)
+	span.SetAttributes(attribute.Int("store.logs.converted", len(converted)))
 	if len(converted) == 0 {
 		return
 	}
@@ -169,7 +195,7 @@ func (s *Store) AddLogs(ld plog.Logs) {
 
 	if s.onAdd != nil {
 		for _, l := range converted {
-			s.onAdd(SignalLogs, l)
+			s.onAdd(ctx, SignalLogs, l)
 		}
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"encoding/json"
 	"math"
 	"testing"
@@ -10,7 +11,59 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
+
+func TestStore_AddTraces_EmitsSpan(t *testing.T) {
+	orig := otel.GetTracerProvider()
+	t.Cleanup(func() { otel.SetTracerProvider(orig) })
+
+	rec := tracetest.NewSpanRecorder()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec)))
+
+	s := NewStore(10, 10, 10, 100, nil)
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "svc")
+	ss := rs.ScopeSpans().AppendEmpty()
+	sp := ss.Spans().AppendEmpty()
+	sp.SetTraceID(pcommon.TraceID([16]byte{1}))
+	sp.SetSpanID(pcommon.SpanID([8]byte{1}))
+	sp.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	sp.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	s.AddTraces(context.Background(), td)
+
+	var seen bool
+	for _, span := range rec.Ended() {
+		if span.Name() != "store.add_traces" {
+			continue
+		}
+		seen = true
+		var converted, notified *int64
+		for _, a := range span.Attributes() {
+			switch string(a.Key) {
+			case "store.traces.converted":
+				v := a.Value.AsInt64()
+				converted = &v
+			case "store.traces.notified":
+				v := a.Value.AsInt64()
+				notified = &v
+			}
+		}
+		if converted == nil || *converted != 1 {
+			t.Errorf("store.traces.converted = %v, want 1", converted)
+		}
+		if notified == nil || *notified != 1 {
+			t.Errorf("store.traces.notified = %v, want 1", notified)
+		}
+	}
+	if !seen {
+		t.Errorf("expected store.add_traces span in %v", rec.Ended())
+	}
+}
 
 func TestRingBuffer_Add(t *testing.T) {
 	rb := NewRingBuffer[int](3)
@@ -70,7 +123,7 @@ func TestRingBuffer_Clear(t *testing.T) {
 
 func TestStore_AddAndGetTraces(t *testing.T) {
 	var called int
-	s := NewStore(10, 10, 10, 100, func(sig SignalType, data any) {
+	s := NewStore(10, 10, 10, 100, func(_ context.Context, sig SignalType, data any) {
 		called++
 		if sig != SignalTraces {
 			t.Errorf("expected SignalTraces, got %s", sig)
@@ -89,7 +142,7 @@ func TestStore_AddAndGetTraces(t *testing.T) {
 	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(100 * time.Millisecond)))
 
-	s.AddTraces(td)
+	s.AddTraces(context.Background(), td)
 
 	traces := s.GetTraces()
 	if len(traces) != 1 {
@@ -125,7 +178,7 @@ func TestStore_AddTraces_DeduplicateSpans(t *testing.T) {
 	span1.SetStartTimestamp(pcommon.NewTimestampFromTime(now))
 	span1.SetEndTimestamp(pcommon.NewTimestampFromTime(now.Add(100 * time.Millisecond)))
 
-	s.AddTraces(td1)
+	s.AddTraces(context.Background(), td1)
 
 	// Second batch: same traceID and same spanID (duplicate).
 	td2 := ptrace.NewTraces()
@@ -146,7 +199,7 @@ func TestStore_AddTraces_DeduplicateSpans(t *testing.T) {
 	span3.SetStartTimestamp(pcommon.NewTimestampFromTime(now))
 	span3.SetEndTimestamp(pcommon.NewTimestampFromTime(now.Add(50 * time.Millisecond)))
 
-	s.AddTraces(td2)
+	s.AddTraces(context.Background(), td2)
 
 	traces := s.GetTraces()
 	if len(traces) != 1 {
@@ -173,7 +226,7 @@ func TestStore_GetTraceByID(t *testing.T) {
 	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(50 * time.Millisecond)))
 
-	s.AddTraces(td)
+	s.AddTraces(context.Background(), td)
 
 	trace, ok := s.GetTraceByID(traceID.String())
 	if !ok {
@@ -201,7 +254,7 @@ func TestStore_AddAndGetLogs(t *testing.T) {
 	lr.Body().SetStr("test log message")
 	lr.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 
-	s.AddLogs(ld)
+	s.AddLogs(context.Background(), ld)
 
 	logs := s.GetLogs()
 	if len(logs) != 1 {
@@ -227,7 +280,7 @@ func TestStore_GetLogsPageByTraceID(t *testing.T) {
 		lr.SetTraceID(pcommon.TraceID([16]byte{traceIDByte}))
 		lr.Body().SetStr(body)
 		lr.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
-		s.AddLogs(ld)
+		s.AddLogs(context.Background(), ld)
 	}
 
 	addLog(1, "t1-first")
@@ -262,7 +315,7 @@ func TestStore_AddLogs_EvictionPrunesTraceIndex(t *testing.T) {
 		lr := sl.LogRecords().AppendEmpty()
 		lr.SetTraceID(pcommon.TraceID([16]byte{traceIDByte}))
 		lr.Body().SetStr("x")
-		s.AddLogs(ld)
+		s.AddLogs(context.Background(), ld)
 	}
 
 	addLog(1)
@@ -297,7 +350,7 @@ func TestStore_AddMetrics_Merge(t *testing.T) {
 	dp1.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	dp1.SetDoubleValue(42.0)
 
-	s.AddMetrics(md1)
+	s.AddMetrics(context.Background(), md1)
 
 	metrics := s.GetMetrics()
 	if len(metrics) != 1 {
@@ -320,7 +373,7 @@ func TestStore_AddMetrics_Merge(t *testing.T) {
 	dp2.SetTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Second)))
 	dp2.SetDoubleValue(55.0)
 
-	s.AddMetrics(md2)
+	s.AddMetrics(context.Background(), md2)
 
 	metrics = s.GetMetrics()
 	if len(metrics) != 1 {
@@ -447,7 +500,7 @@ func TestResourceInfo(t *testing.T) {
 
 func TestStore_AddMetrics_SkipsEmptyMetrics(t *testing.T) {
 	var notified []*MetricData
-	s := NewStore(10, 10, 10, 100, func(sig SignalType, data any) {
+	s := NewStore(10, 10, 10, 100, func(_ context.Context, sig SignalType, data any) {
 		if sig == SignalMetrics {
 			notified = append(notified, data.(*MetricData))
 		}
@@ -465,7 +518,7 @@ func TestStore_AddMetrics_SkipsEmptyMetrics(t *testing.T) {
 	sum1.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	sum1.DataPoints().AppendEmpty().SetIntValue(100)
 
-	s.AddMetrics(md1)
+	s.AddMetrics(context.Background(), md1)
 
 	if got := s.GetMetrics(); len(got) != 0 {
 		t.Fatalf("baseline scrape should not be stored, got %d metrics", len(got))
@@ -486,7 +539,7 @@ func TestStore_AddMetrics_SkipsEmptyMetrics(t *testing.T) {
 	sum2.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	sum2.DataPoints().AppendEmpty().SetIntValue(150)
 
-	s.AddMetrics(md2)
+	s.AddMetrics(context.Background(), md2)
 
 	metrics := s.GetMetrics()
 	if len(metrics) != 1 || len(metrics[0].DataPoints) != 1 {
@@ -530,7 +583,7 @@ func TestStore_AddMetrics_DifferentNames(t *testing.T) {
 	m2.SetEmptyGauge()
 	m2.Gauge().DataPoints().AppendEmpty().SetDoubleValue(2.0)
 
-	s.AddMetrics(md)
+	s.AddMetrics(context.Background(), md)
 
 	metrics := s.GetMetrics()
 	if len(metrics) != 2 {
@@ -550,7 +603,7 @@ func TestStore_Clear(t *testing.T) {
 	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 
-	s.AddTraces(td)
+	s.AddTraces(context.Background(), td)
 	s.Clear()
 
 	if len(s.GetTraces()) != 0 {
@@ -572,7 +625,7 @@ func TestStore_AddTraces_EvictionClearsIndex(t *testing.T) {
 		sp.SetSpanID(pcommon.SpanID([8]byte{traceByte}))
 		sp.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 		sp.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now()))
-		s.AddTraces(td)
+		s.AddTraces(context.Background(), td)
 	}
 
 	add(1)
@@ -612,7 +665,7 @@ func TestStore_GetTracesPage(t *testing.T) {
 		sp.SetSpanID(pcommon.SpanID([8]byte{byte(i)}))
 		sp.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Duration(i) * time.Millisecond)))
 		sp.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Duration(i) * time.Millisecond)))
-		s.AddTraces(td)
+		s.AddTraces(context.Background(), td)
 	}
 
 	page, total := s.GetTracesPage(1, 2)
@@ -646,7 +699,7 @@ func TestStore_NewestFirst(t *testing.T) {
 		now := time.Now().Add(time.Duration(i) * time.Second)
 		span.SetStartTimestamp(pcommon.NewTimestampFromTime(now))
 		span.SetEndTimestamp(pcommon.NewTimestampFromTime(now.Add(time.Millisecond)))
-		s.AddTraces(td)
+		s.AddTraces(context.Background(), td)
 	}
 
 	traces := s.GetTraces()


### PR DESCRIPTION
## Summary

`Store.AddTraces` / `AddMetrics` / `AddLogs` had no instrumentation, so OTLP ingest work was invisible in otelop's own trace view. Any time a metric or log batch was slow to land, the only visible span was the collector's receiver span — the store's convert → upsert → broadcast work stacked under it opaquely.

- Thread `context.Context` through the exporter into the three ingest methods and through `OnAddFunc`
- Emit `store.add_traces` / `store.add_metrics` / `store.add_logs` spans with batch-size attributes (`store.resource_*`, `store.*.converted`, `store.*.notified`)
- Broadcast callbacks run under the ingest span, so WebSocket fan-out latency shows up as a child when self-telemetry is on

## Test plan

- [x] `mise run check`
- [x] `mise run test`
- [x] New `TestStore_AddTraces_EmitsSpan` verifies the span is emitted with correct converted/notified attrs