### PR TITLE
chore(observability): export collector self-metrics in --debug mode

### DIFF
--- a/cmd/otelop/start.go
+++ b/cmd/otelop/start.go
@@ -282,14 +282,25 @@ func bootstrap(ctx context.Context, opts startOptions) (*runtime, error) {
 		}
 	}()
 
+	selfTelemetryEndpoint := ""
+	if opts.Debug {
+		ep, err := resolveLoopback(opts.OTLPGRPCAddr)
+		if err != nil {
+			rt.shutdown()
+			return nil, fmt.Errorf("invalid otlp-grpc address: %w", err)
+		}
+		selfTelemetryEndpoint = ep
+	}
+
 	slog.Debug("starting collector", "grpc", opts.OTLPGRPCAddr, "http", opts.OTLPHTTPAddr)
 	col, err := collector.New(otelopexporter.NewFactory(rt.store), collector.Config{
-		GRPCEndpoint:  opts.OTLPGRPCAddr,
-		HTTPEndpoint:  opts.OTLPHTTPAddr,
-		ProxyURL:      opts.ProxyURL,
-		ProxyProtocol: opts.ProxyProtocol,
-		ProxyHeaders:  buildProxyHeaders(opts.ProxyAuth),
-		LogLevel:      opts.LogLevel,
+		GRPCEndpoint:          opts.OTLPGRPCAddr,
+		HTTPEndpoint:          opts.OTLPHTTPAddr,
+		ProxyURL:              opts.ProxyURL,
+		ProxyProtocol:         opts.ProxyProtocol,
+		ProxyHeaders:          buildProxyHeaders(opts.ProxyAuth),
+		LogLevel:              opts.LogLevel,
+		SelfTelemetryEndpoint: selfTelemetryEndpoint,
 	})
 	if err != nil {
 		rt.shutdown()
@@ -311,13 +322,8 @@ func bootstrap(ctx context.Context, opts startOptions) (*runtime, error) {
 	}
 
 	if opts.Debug {
-		endpoint, err := resolveLoopback(opts.OTLPGRPCAddr)
-		if err != nil {
-			rt.shutdown()
-			return nil, fmt.Errorf("invalid otlp-grpc address: %w", err)
-		}
-		slog.Debug("starting self-telemetry", "endpoint", endpoint)
-		result, err := selftelemetry.Setup(ctx, endpoint)
+		slog.Debug("starting self-telemetry", "endpoint", selfTelemetryEndpoint)
+		result, err := selftelemetry.Setup(ctx, selfTelemetryEndpoint)
 		if err != nil {
 			rt.shutdown()
 			return nil, fmt.Errorf("failed to setup self-telemetry: %w", err)

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -16,6 +16,11 @@ var version = "dev"
 
 type obj map[string]any
 
+// selfTelemetryIntervalMs is the periodic OTLP reader interval for the
+// Collector's own component metrics. Mirrors the SDK-side cadence in
+// internal/selftelemetry so both data sources tick together.
+const selfTelemetryIntervalMs = 10_000
+
 // Config holds runtime-configurable collector settings.
 type Config struct {
 	GRPCEndpoint  string
@@ -24,6 +29,12 @@ type Config struct {
 	ProxyProtocol string
 	ProxyHeaders  map[string]string
 	LogLevel      string
+	// SelfTelemetryEndpoint, when non-empty (host:port), makes the
+	// Collector export its own component metrics
+	// (otelcol_receiver_accepted_*, otelcol_exporter_sent_*, ...) via OTLP
+	// gRPC to that endpoint. Empty disables self-telemetry and the default
+	// Prometheus :8888 listener too.
+	SelfTelemetryEndpoint string
 }
 
 func buildConfigMap(cfg Config) map[string]any {
@@ -67,14 +78,38 @@ func buildServiceConfig(cfg Config, pipelineExporters []any) obj {
 
 func buildTelemetryConfig(cfg Config) obj {
 	return obj{
-		"logs": obj{
-			"level": cfg.LogLevel,
-		},
-		// Disable the Collector's own Prometheus self-metrics listener on :8888.
-		// otelop doesn't consume it anywhere and the listener would conflict with
-		// a second otelop instance on the same host.
-		"metrics": obj{
-			"level": "none",
+		"logs":    obj{"level": cfg.LogLevel},
+		"metrics": buildTelemetryMetricsConfig(cfg),
+	}
+}
+
+// buildTelemetryMetricsConfig configures the Collector's self-telemetry. In
+// both branches the Prometheus :8888 listener stays off — otelop never reads
+// it and a second instance on the same host would collide. When an endpoint
+// is provided, a periodic OTLP reader ships component metrics straight to
+// otelop's own receiver instead.
+func buildTelemetryMetricsConfig(cfg Config) obj {
+	if cfg.SelfTelemetryEndpoint == "" {
+		return obj{"level": "none"}
+	}
+	endpoint := (&url.URL{Scheme: "http", Host: cfg.SelfTelemetryEndpoint}).String()
+	return obj{
+		// "normal" omits per-RPC histograms that "detailed" enables; those
+		// would dominate the bounded in-memory store at default capacity.
+		"level": "normal",
+		"readers": []any{
+			obj{
+				"periodic": obj{
+					"interval": selfTelemetryIntervalMs,
+					"exporter": obj{
+						"otlp": obj{
+							"protocol": "grpc",
+							"endpoint": endpoint,
+							"insecure": true,
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -97,6 +97,66 @@ func TestBuildConfigMap_WithHTTPProxy(t *testing.T) {
 	}
 }
 
+func TestBuildConfigMap_SelfTelemetryDisabled(t *testing.T) {
+	cfg := buildConfigMap(Config{
+		GRPCEndpoint: "0.0.0.0:4317",
+		HTTPEndpoint: "0.0.0.0:4318",
+		LogLevel:     "info",
+	})
+	metrics := cfg["service"].(obj)["telemetry"].(obj)["metrics"].(obj)
+	if metrics["level"] != "none" {
+		t.Fatalf("metrics level = %#v, want none", metrics["level"])
+	}
+	if _, ok := metrics["readers"]; ok {
+		t.Fatalf("metrics readers must be absent when endpoint is empty, got %#v", metrics["readers"])
+	}
+}
+
+func TestBuildConfigMap_SelfTelemetryEnabled(t *testing.T) {
+	cfg := buildConfigMap(Config{
+		GRPCEndpoint:          "0.0.0.0:4317",
+		HTTPEndpoint:          "0.0.0.0:4318",
+		LogLevel:              "info",
+		SelfTelemetryEndpoint: "localhost:4317",
+	})
+	metrics := cfg["service"].(obj)["telemetry"].(obj)["metrics"].(obj)
+	if metrics["level"] != "normal" {
+		t.Fatalf("metrics level = %#v, want normal", metrics["level"])
+	}
+	readers, ok := metrics["readers"].([]any)
+	if !ok || len(readers) != 1 {
+		t.Fatalf("metrics readers = %#v, want one entry", metrics["readers"])
+	}
+	periodic := readers[0].(obj)["periodic"].(obj)
+	if periodic["interval"] != selfTelemetryIntervalMs {
+		t.Fatalf("interval = %#v, want %d", periodic["interval"], selfTelemetryIntervalMs)
+	}
+	otlp := periodic["exporter"].(obj)["otlp"].(obj)
+	if otlp["endpoint"] != "http://localhost:4317" {
+		t.Fatalf("otlp endpoint = %#v", otlp["endpoint"])
+	}
+	if otlp["protocol"] != "grpc" {
+		t.Fatalf("otlp protocol = %#v", otlp["protocol"])
+	}
+	if otlp["insecure"] != true {
+		t.Fatalf("otlp insecure = %#v", otlp["insecure"])
+	}
+}
+
+func TestBuildConfigMap_SelfTelemetryEndpointURLEncoded(t *testing.T) {
+	cfg := buildConfigMap(Config{
+		GRPCEndpoint:          "0.0.0.0:4317",
+		HTTPEndpoint:          "0.0.0.0:4318",
+		LogLevel:              "info",
+		SelfTelemetryEndpoint: "[::1]:4317",
+	})
+	metrics := cfg["service"].(obj)["telemetry"].(obj)["metrics"].(obj)
+	otlp := metrics["readers"].([]any)[0].(obj)["periodic"].(obj)["exporter"].(obj)["otlp"].(obj)
+	if otlp["endpoint"] != "http://[::1]:4317" {
+		t.Fatalf("otlp endpoint = %#v, want http://[::1]:4317", otlp["endpoint"])
+	}
+}
+
 func TestStaticProviderNormalizesLocalObjTypes(t *testing.T) {
 	factory := newStaticProviderFactory(buildConfigMap(Config{
 		GRPCEndpoint: "0.0.0.0:4317",


### PR DESCRIPTION
## Summary
- Configure the embedded Collector's `service.telemetry.metrics.readers` so component metrics (`otelcol_receiver_accepted_*`, `otelcol_exporter_sent_*`, …) flow back to otelop's own OTLP receiver when `--debug` is on
- Single opt-in field `collector.Config.SelfTelemetryEndpoint` — empty disables both the readers and the default Prometheus `:8888` listener (no port collision between instances)
- `level=normal` keeps histograms off so detailed-level cardinality doesn't dominate the bounded in-memory store

## Test plan
- [x] `mise run check`
- [x] `mise run test`
- [x] `otelop start --debug -f` → `otelcol_receiver_accepted_spans` etc. appear in the metrics view
- [x] `otelop start -f` (no debug) → metrics view contains no `otelcol_*` series and `:8888` is not bound (`lsof -iTCP:8888 -sTCP:LISTEN` is empty)
- [x] Two `--debug` instances on different ports start successfully (no `:8888` conflict)