### PR TITLE
chore(release): publish multi-arch container images to ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
         type: string
 permissions:
   contents: write
+  packages: write
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -17,6 +18,12 @@ jobs:
           ref: ${{ inputs.tag }}
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - run: mise run install
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         with:
           args: release --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,25 @@ archives:
         formats:
           - zip
 
+dockers_v2:
+  - id: otelop
+    dockerfile: Dockerfile
+    images:
+      - ghcr.io/mashiro/otelop
+    tags:
+      - "{{.Version}}"
+      - "{{ if not .Prerelease }}latest{{ end }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.source: https://github.com/mashiro/otelop
+      org.opencontainers.image.description: Local OpenTelemetry viewer for traces, metrics, and logs
+      org.opencontainers.image.licenses: MIT
+      org.opencontainers.image.version: "{{.Version}}"
+      org.opencontainers.image.revision: "{{.FullCommit}}"
+      org.opencontainers.image.created: "{{.Date}}"
+
 changelog:
   disable: true
 

--- a/.mise/tasks/image
+++ b/.mise/tasks/image
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#MISE description="Build the container image via goreleaser snapshot and tag it as otelop:local"
+#MISE depends=["release-snapshot"]
+set -euo pipefail
+
+case "$(uname -m)" in
+  arm64|aarch64) arch=arm64 ;;
+  x86_64|amd64)  arch=amd64 ;;
+  *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+docker tag "ghcr.io/mashiro/otelop:latest-${arch}" otelop:local

--- a/.mise/tasks/publish-image
+++ b/.mise/tasks/publish-image
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#MISE description="Build and push the container image to ghcr.io for the given (or latest) tag"
+set -euo pipefail
+
+tag="${1:-$(git describe --tags --abbrev=0)}"
+
+: "${GITHUB_TOKEN:=$(gh auth token 2>/dev/null || true)}"
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "GITHUB_TOKEN unset and 'gh auth token' returned nothing — run 'gh auth login' or set GITHUB_TOKEN" >&2
+  exit 1
+fi
+
+if ! gh auth status 2>&1 | grep -q 'write:packages'; then
+  echo "gh token missing 'write:packages' scope." >&2
+  echo "Run: gh auth refresh -h github.com -s write:packages" >&2
+  exit 1
+fi
+
+gh_user="$(gh api user --jq .login)"
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$gh_user" --password-stdin >/dev/null
+
+export GITHUB_TOKEN
+export GORELEASER_CURRENT_TAG="$tag"
+
+goreleaser release --clean --skip=archive,announce,sbom,sign,validate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM gcr.io/distroless/static-debian13:nonroot
+
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/otelop /usr/local/bin/otelop
+
+EXPOSE 4317 4318 4319
+
+ENTRYPOINT ["/usr/local/bin/otelop"]
+CMD ["start", "--foreground"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ With mise:
 mise use -g github:mashiro/otelop
 ```
 
+With Docker:
+
+```bash
+docker run --rm -p 4317:4317 -p 4318:4318 -p 4319:4319 ghcr.io/mashiro/otelop:latest
+```
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a minimal `Dockerfile` (distroless static debian13, non-root) and a goreleaser `dockers_v2` block so each release tag publishes a multi-arch container image (linux/amd64 + linux/arm64) to `ghcr.io/mashiro/otelop` with full OCI metadata. Default `CMD` is `start --foreground` so `docker run ghcr.io/mashiro/otelop:latest` works with no extra args. `latest` is suppressed for prereleases.
- Adds `mise run image` to build a host-arch test image as `otelop:local` via the same goreleaser snapshot (so local testing exercises the exact same artifact).
- Adds `mise run publish-image [tag]` to publish the image on demand for an existing release tag, for chore/refactor changes that touch the image but do not warrant a new version bump. Includes a preflight check for the `write:packages` scope so the task fails fast with a clear remediation hint.
- Updates `.github/workflows/release.yml` with `packages: write`, buildx setup, and `docker/login-action` so future release-please cuts publish images automatically.

## Test plan

- [x] `goreleaser check` passes
- [x] `goreleaser release --snapshot --clean` builds linux/amd64 + linux/arm64 images with correct labels (`org.opencontainers.image.{source,version,revision,created,description,licenses}`) and `CMD=["start","--foreground"]`
- [x] `mise run image` produces `otelop:local` and serves UI / OTLP HTTP (200) on the expected ports
- [x] `mise run publish-image` (with `write:packages` scope) pushes a multi-arch manifest to ghcr.io, and `docker pull` by digest then `docker run` against the published image returns the expected version and 200s