### PR TITLE
fix(ci): grant packages:write to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

`release.yml` started requesting `packages: write` in #67 to push container images to ghcr.io, but it is invoked as a reusable workflow from `release-please.yml`. Reusable workflows can only use permissions the caller has explicitly granted, so the called workflow fails at startup (`startup_failure`) once it requests a scope the caller does not have. Fix by adding `packages: write` to `release-please.yml`'s top-level permissions.

Failing run: https://github.com/mashiro/otelop/actions/runs/25065828558

## Test plan

- [ ] After merge, the next push to `main` triggers `Release Please` and the run starts successfully (no `startup_failure`)