### PR TITLE
chore: align renovate and pnpm minimumReleaseAge, exclude digest types

### DIFF
--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 allowBuilds:
   msw: false
+minimumReleaseAge: 4320
 catalog:
   vite: npm:@voidzero-dev/vite-plus-core@0.1.20
   vite-plus: 0.1.20

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,13 +9,16 @@
     ":disableRateLimiting",
   ],
   "timezone": "Asia/Tokyo",
-  "schedule": ["every weekend"],
   "minimumReleaseAge": "3 days",
   "labels": ["renovate"],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
+    },
+    {
+      "matchUpdateTypes": ["pinDigest", "digest"],
+      "minimumReleaseAge": "0 days",
     },
   ],
 }


### PR DESCRIPTION
## Background

PR #70 (`pinDigest` for `gcr.io/distroless/static-debian13`) has its `renovate/stability-days` status check stuck pending forever.

- Since Renovate 42, updates that have no release timestamp (`digest`, `pinDigest`) are treated as "not yet satisfying `minimumReleaseAge`".
- The Docker datasource never publishes a release timestamp for digests, so the check can never physically turn green.

We want to keep `minimumReleaseAge: 3 days` as supply-chain protection for real version bumps, but exempt digest-only updates since the gate provides no actual protection there.

## Changes

### `renovate.json5`
- Remove `schedule: ["every weekend"]` (revert to the default "at any time").
- Drop `digest` from the automerge rule — without a working timestamp gate, human review is the last line of defense.
- Add a dedicated rule setting `minimumReleaseAge: 0 days` for `pinDigest` / `digest`.

### `frontend/pnpm-workspace.yaml`
- Add `minimumReleaseAge: 4320` (in minutes = 3 days) so transitive dependencies that Renovate does not track are also gated on the pnpm side.

## Resulting behavior per updateType

| updateType  | minimumReleaseAge | automerge | Notes |
|-------------|-------------------|-----------|-------|
| `major`     | 3 days            | no        | Unchanged — manual review |
| `minor`     | 3 days            | yes       | Unchanged |
| `patch`     | 3 days            | yes       | Unchanged |
| `pinDigest` | **0 days**        | **no**    | Timestamp gate doesn't apply; require human review |
| `digest`    | **0 days**        | **no**    | Same as above; also removed from automerge |

## Impact

- Resolves the `renovate/stability-days` pending issue on PR #70 (after merge, ticking the rebase/retry checkbox on #70 will trigger an immediate re-evaluation).
- Digest updates will now always require manual merge (low operational cost given the volume).
- With the weekend-only schedule removed, Renovate PRs may also open on weekdays.

Refs #70