### PR TITLE
chore(renovate): split github-actions and vite-plus into separate groups

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -20,5 +20,22 @@
       "matchUpdateTypes": ["pinDigest", "digest"],
       "minimumReleaseAge": "0 days",
     },
+    // Split GitHub Actions out of the catch-all group so workflow bumps land
+    // independently and aren't blocked by an unrelated failing dependency.
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+    },
+    // The @voidzero-dev/vite-plus suite must move in lockstep: vite-plus-test
+    // pins vite-plus-core to an exact version. Group them so a partial bump is
+    // isolated in its own PR instead of breaking the whole non-major group.
+    {
+      "matchPackageNames": [
+        "vite-plus",
+        "@voidzero-dev/vite-plus-core",
+        "@voidzero-dev/vite-plus-test",
+      ],
+      "groupName": "vite-plus",
+    },
   ],
 }


### PR DESCRIPTION
## Why

The `group:allNonMajor` preset lumped every non-major update into a single PR (#122). When one dependency breaks, the whole group goes red and unrelated bumps (e.g. `mise-action`) can't merge.

Concretely, #122 fails because `@voidzero-dev/vite-plus-core` was bumped to `0.2.0` while `@voidzero-dev/vite-plus-test` has no `0.2.x` release yet — and `vite-plus-test` pins `vite-plus-core` to an **exact** version, so the suite must move in lockstep.

## What

Add two `packageRules` (later rules override the `group:allNonMajor` grouping):

- **github-actions** — `matchManagers: ["github-actions"]` so workflow action bumps land in their own PR, independent of npm/go failures.
- **vite-plus** — group `vite-plus`, `@voidzero-dev/vite-plus-core`, `@voidzero-dev/vite-plus-test` so a partial/breaking bump is isolated in its own PR instead of blocking everything else.

## Effect on existing PRs

After this lands, Renovate will re-organize #122 into separate `github-actions` and `vite-plus` groups. The vite-plus PR will stay red until upstream ships `vite-plus-test@0.2.x`, but it no longer blocks other updates.