### PR TITLE
ci(renovate): run go mod tidy after Go module updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,9 @@
   "timezone": "Asia/Tokyo",
   "minimumReleaseAge": "3 days",
   "labels": ["renovate"],
+  // Run `go mod tidy` after Go module updates so superseded versions don't pile
+  // up in go.sum (every collector bump otherwise leaves the old checksums behind).
+  "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
Adds `postUpdateOptions: ["gomodTidy"]` to the Renovate config so `go mod tidy` runs after every Go module bump.

Without it, each collector version bump appends new checksums to `go.sum` but never removes the superseded ones — which is how ~890 stale lines accumulated (cleaned up in #127). This keeps `go.sum` tidy going forward.

Config validated with `renovate-config-validator`.