### PR TITLE
ci(renovate): exempt timestampless updates from the release-age gate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,14 +14,26 @@
   // Run `go mod tidy` after Go module updates so superseded versions don't pile
   // up in go.sum (every collector bump otherwise leaves the old checksums behind).
   "postUpdateOptions": ["gomodTidy"],
+  // Lock file maintenance refreshes already-published transitive deps and has no
+  // releaseTimestamp of its own, so the inherited 3-day gate leaves its PR
+  // perpetually pending under the default timestamp-required behaviour. null
+  // exempts it from the release-age gate.
+  "lockFileMaintenance": {
+    "enabled": true,
+    "minimumReleaseAge": null,
+  },
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
     },
+    // Digest updates carry no releaseTimestamp, so under the default
+    // timestamp-required behaviour any minimumReleaseAge would hold them
+    // indefinitely. null exempts them from the release-age gate outright,
+    // rather than relying on "0 days" being treated as "skip the check".
     {
       "matchUpdateTypes": ["pinDigest", "digest"],
-      "minimumReleaseAge": "0 days",
+      "minimumReleaseAge": null,
     },
     // Split GitHub Actions out of the catch-all group so workflow bumps land
     // independently and aren't blocked by an unrelated failing dependency.


### PR DESCRIPTION
## Why

Renovate 42 made `minimumReleaseAgeBehaviour: timestamp-required` the default: an update that has **no `releaseTimestamp`** is treated as *not yet past* the minimum age, so it's held **forever** (the gate can never be satisfied — there's nothing to age).

Two update types have no timestamp, and both were affected:

- **lockFileMaintenance** — refreshes already-published transitive deps; it has no release of its own. It inherited the top-level `minimumReleaseAge: "3 days"` and its PR (#26) has sat `renovate/stability-days` **pending since April** (~2 months).
- **pinDigest / digest** — digests (Docker image / GitHub Action SHA) carry no release timestamp either.

## Change

```json5
// lock maintenance: not tied to a release, exempt from release-age
"lockFileMaintenance": { "enabled": true, "minimumReleaseAge": null }

// digests: explicit exemption instead of relying on "0 days" == skip
{ "matchUpdateTypes": ["pinDigest", "digest"], "minimumReleaseAge": null }
```

- `lockFileMaintenance` → `null` fixes #26 (it can finally merge once Renovate re-evaluates).
- digests were already passing (the `"0 days"` rule produced no stability check — e.g. #90 had none), so this is a clarity/robustness change: `null` states "release-age does not apply" directly instead of depending on Renovate treating `0` as "skip".

Maintainer-recommended approach (set `minimumReleaseAge: null` for timestampless update types, as the `security:minimumReleaseAgeNpm` preset does) — see renovatebot/renovate discussions #38115 and #39781.

Config validated with `renovate-config-validator`.