### PR TITLE
ci: grant packages:write on the release job that calls release.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,13 @@ jobs:
   release:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
+    # A called workflow inherits the GITHUB_TOKEN scopes from the calling job,
+    # not from this workflow's top-level permissions. Without this block the job
+    # falls back to the repository default (read-only), so release.yml can't push
+    # the container image to ghcr.io (permission_denied: write_package).
+    permissions:
+      contents: write
+      packages: write
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Problem

The v0.6.2 release [failed](https://github.com/mashiro/otelop/actions/runs/27896351527/job/82548505417) pushing the container image:

```
failed to push ghcr.io/mashiro/otelop:0.6.2: denied: permission_denied: write_package
```

## Root cause

`release.yml` is a **reusable workflow** (`workflow_call`), invoked by the `release` job in `release-please.yml`.

A called workflow inherits the `GITHUB_TOKEN` scopes from the **calling job's** `permissions`, **not** from the caller's top-level `permissions` block. The `release` job had no job-level `permissions`, so the called workflow fell back to the repository default — which is **read-only** (`default_workflow_permissions: read`). The `packages: write` declared at `release.yml`'s top level (and at `release-please.yml`'s top level, added in #68) therefore never applied, and the push was denied.

This is the **first** container push to go through CI: `dockers_v2` publishing was added after v0.6.1 (#67/#68), and v0.6.2 is the first release where the `release` job actually ran. (The existing `0.6.1` / `latest` tags in GHCR were pushed outside this CI path.) So it's a latent setup gap, not a regression.

## Fix

Set `permissions: { contents: write, packages: write }` on the **calling `release` job** so the scopes propagate into `release.yml`. No repository-setting change needed — job-level permissions override the read-only default.

Typed `ci:` (not `fix:`) so release-please does not cut a version bump for this CI-only change.

## After merge

Re-run the failed release to push the image:

```
gh run rerun 27896351527 --failed
```

Refs: [Reuse workflows — permissions](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)