### PR TITLE
ci: allow manual dispatch of the release workflow for a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,15 @@ on:
         description: Tag to release (e.g. v0.1.0)
         required: true
         type: string
+  # Manual escape hatch to (re-)publish a release's artifacts for an existing
+  # tag, e.g. when an earlier run failed after the tag was created. Triggered
+  # directly (not via workflow_call), so this workflow's own permissions apply.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to release (e.g. v0.1.0)
+        required: true
+        type: string
 permissions:
   contents: write
   packages: write


### PR DESCRIPTION
## Why

The v0.6.2 container image push [failed](https://github.com/mashiro/otelop/actions/runs/27896351527), and #132 fixed the permission cause — but that fix only takes effect on a **new** release-job run. Re-running the original run reuses the pre-fix workflow (re-runs use the workflow file from the original commit SHA), so it keeps failing, and release-please won't re-cut 0.6.2.

## What

Add a `workflow_dispatch` trigger to `release.yml` so a release can be (re-)published for an existing tag.

A dispatched run executes the workflow **directly** (not via `workflow_call`), so its own top-level `permissions: packages: write` applies and overrides the read-only default — exactly what the failed `workflow_call` path lacked. It doubles as a permanent manual re-release escape hatch.

## After merge

Publish the missing v0.6.2 image:

```
gh workflow run release.yml -f tag=v0.6.2
```

`ci:` typed so release-please cuts no version bump.