### PR TITLE
feat(metrics): expose raw cumulative alongside delta on DataPoint

### DIFF
--- a/internal/graphql/metric_resolver.go
+++ b/internal/graphql/metric_resolver.go
@@ -31,11 +31,14 @@ type DataPointResolver struct {
 	dp *store.DataPoint
 }
 
-func (r *DataPointResolver) ID() gql.ID          { return gql.ID(r.dp.ID) }
-func (r *DataPointResolver) Timestamp() gql.Time { return gql.Time{Time: r.dp.Timestamp} }
-func (r *DataPointResolver) Value() float64      { return r.dp.Value }
-func (r *DataPointResolver) Count() *float64     { return r.dp.Count }
-func (r *DataPointResolver) Sum() *float64       { return r.dp.Sum }
-func (r *DataPointResolver) Min() *float64       { return r.dp.Min }
-func (r *DataPointResolver) Max() *float64       { return r.dp.Max }
-func (r *DataPointResolver) Attributes() JSONMap { return attrsToJSON(r.dp.Attributes) }
+func (r *DataPointResolver) ID() gql.ID                { return gql.ID(r.dp.ID) }
+func (r *DataPointResolver) Timestamp() gql.Time       { return gql.Time{Time: r.dp.Timestamp} }
+func (r *DataPointResolver) Value() float64            { return r.dp.Value }
+func (r *DataPointResolver) Cumulative() *float64      { return r.dp.Cumulative }
+func (r *DataPointResolver) Count() *float64           { return r.dp.Count }
+func (r *DataPointResolver) CountCumulative() *float64 { return r.dp.CountCumulative }
+func (r *DataPointResolver) Sum() *float64             { return r.dp.Sum }
+func (r *DataPointResolver) SumCumulative() *float64   { return r.dp.SumCumulative }
+func (r *DataPointResolver) Min() *float64             { return r.dp.Min }
+func (r *DataPointResolver) Max() *float64             { return r.dp.Max }
+func (r *DataPointResolver) Attributes() JSONMap       { return attrsToJSON(r.dp.Attributes) }

--- a/internal/graphql/schema.graphql
+++ b/internal/graphql/schema.graphql
@@ -147,8 +147,12 @@ type Metric {
 """
 One point in a metric's series. For cumulative OTLP inputs (monotonic Sum,
 Histogram, Summary, ExponentialHistogram) the server delta-izes against the
-previous observation before returning, so the fields below describe
-per-interval activity, not running totals.
+previous observation before returning, so the primary fields describe
+per-interval activity. The `cumulative` family carries the raw running totals
+the OTLP exporter sent, so clients can show running totals "since otelop
+started observing this series" without re-summing the delta column. Note that
+otelop is a local in-memory viewer: the running total resets when the daemon
+restarts and is not preserved through ring-buffer eviction.
 """
 type DataPoint {
   "Stable, globally unique identity (UUIDv7) assigned at ingestion. Survives ring-buffer eviction and reconnects, so clients can use it as a durable key."
@@ -160,10 +164,28 @@ type DataPoint {
   (sum / count) so the metric's declared unit applies directly.
   """
   value: Float!
+  """
+  Raw cumulative value as reported by the OTLP exporter. Populated only for
+  monotonic cumulative Sum points; null for Gauge, delta Sum, non-monotonic
+  Sum, and distribution metrics.
+  """
+  cumulative: Float
   "Delta observation count for distribution metrics. Null for Gauge/Sum."
   count: Float
+  """
+  Raw cumulative observation count for distribution metrics. Populated only
+  for cumulative Histogram / Summary / ExponentialHistogram; null for Gauge,
+  Sum, and delta-temporality distribution inputs.
+  """
+  countCumulative: Float
   "Delta of observation sums for distribution metrics. Null for Gauge/Sum."
   sum: Float
+  """
+  Raw cumulative observation sum for distribution metrics. Populated only for
+  cumulative Histogram / Summary / ExponentialHistogram that report a sum;
+  null otherwise.
+  """
+  sumCumulative: Float
   "Minimum observation in this window, as reported by the SDK. Null when unavailable."
   min: Float
   "Maximum observation in this window, as reported by the SDK. Null when unavailable."

--- a/internal/store/metric.go
+++ b/internal/store/metric.go
@@ -28,6 +28,12 @@ type MetricData struct {
 // Value is the primary chart scalar per type: instantaneous for Gauge, delta
 // for Sum, per-window mean (sum/count) for Histogram/Summary/ExponentialHistogram.
 // Count/Sum/Min/Max are only set for distribution types.
+//
+// Cumulative / CountCumulative / SumCumulative carry the raw OTLP cumulative
+// counterpart of Value / Count / Sum. They're only populated for inputs we
+// delta-ize (cumulative monotonic Sum, cumulative Histogram / Summary /
+// ExponentialHistogram), so consumers can display running totals "since otelop
+// started observing" without re-summing the delta column.
 type DataPoint struct {
 	// ID is a stable, globally unique identity assigned by the Store when the
 	// point is ingested (a UUIDv7). Two observations can share the same
@@ -36,14 +42,17 @@ type DataPoint struct {
 	// identity. The UUIDv7 travels with the point through eviction, WebSocket
 	// replay, and any future persistence, giving consumers (e.g. React keys) a
 	// key that never collides and never changes.
-	ID         string         `json:"id"`
-	Timestamp  time.Time      `json:"timestamp"`
-	Value      float64        `json:"value"`
-	Count      *float64       `json:"count,omitempty"`
-	Sum        *float64       `json:"sum,omitempty"`
-	Min        *float64       `json:"min,omitempty"`
-	Max        *float64       `json:"max,omitempty"`
-	Attributes map[string]any `json:"attributes"`
+	ID              string         `json:"id"`
+	Timestamp       time.Time      `json:"timestamp"`
+	Value           float64        `json:"value"`
+	Cumulative      *float64       `json:"cumulative,omitempty"`
+	Count           *float64       `json:"count,omitempty"`
+	CountCumulative *float64       `json:"countCumulative,omitempty"`
+	Sum             *float64       `json:"sum,omitempty"`
+	SumCumulative   *float64       `json:"sumCumulative,omitempty"`
+	Min             *float64       `json:"min,omitempty"`
+	Max             *float64       `json:"max,omitempty"`
+	Attributes      map[string]any `json:"attributes"`
 }
 
 // convertMetrics converts pmetric.Metrics into a slice of MetricData,
@@ -132,17 +141,20 @@ func extractDataPoints(m pmetric.Metric, serviceName string, series *seriesStore
 				continue
 			}
 			attrs := attributesToMap(dp.Attributes())
+			var cum *float64
 			if cumulative && sum.IsMonotonic() && series != nil {
 				key := seriesKey(serviceName, m.Name(), attrs)
-				delta, ok := series.numberDelta(key, v, now)
+				delta, rawCum, ok := series.numberDelta(key, v, now)
 				if !ok {
 					continue
 				}
 				v = delta
+				cum = floatPtr(rawCum)
 			}
 			points = append(points, DataPoint{
 				Timestamp:  dp.Timestamp().AsTime(),
 				Value:      v,
+				Cumulative: cum,
 				Attributes: attrs,
 			})
 		}
@@ -228,23 +240,30 @@ func extractDataPoints(m pmetric.Metric, serviceName string, series *seriesStore
 // reset observations).
 func emitDistributionPoint(hp histogramPoint, metricName, serviceName string, series *seriesStore, now time.Time, cumulative bool) (DataPoint, bool) {
 	emitCount, emitSum := float64(hp.count), hp.sum
+	var cumCount, cumSum *float64
 	if cumulative && series != nil {
 		key := seriesKey(serviceName, metricName, hp.attributes)
-		countDelta, sumDelta, ok := series.histogramDelta(key, hp.count, hp.sum, now)
+		countDelta, sumDelta, countCum, sumCum, ok := series.histogramDelta(key, hp.count, hp.sum, now)
 		if !ok {
 			return DataPoint{}, false
 		}
 		emitCount = float64(countDelta)
 		emitSum = sumDelta
+		cumCount = floatPtr(float64(countCum))
+		if hp.hasSum {
+			cumSum = floatPtr(sumCum)
+		}
 	}
 	point := DataPoint{
-		Timestamp:  hp.timestamp,
-		Value:      histogramMean(emitCount, emitSum, hp.hasSum),
-		Count:      &emitCount,
-		Attributes: hp.attributes,
+		Timestamp:       hp.timestamp,
+		Value:           histogramMean(emitCount, emitSum, hp.hasSum),
+		Count:           &emitCount,
+		CountCumulative: cumCount,
+		Attributes:      hp.attributes,
 	}
 	if hp.hasSum {
 		point.Sum = floatPtr(emitSum)
+		point.SumCumulative = cumSum
 	}
 	// Min/Max are per-point extrema reported by the SDK; they can't be
 	// delta'd so they pass through untouched.

--- a/internal/store/series.go
+++ b/internal/store/series.go
@@ -115,33 +115,35 @@ func writeAttrValue(h *maphash.Hash, v any) {
 	}
 }
 
-// numberDelta returns the delta from the previous raw value to rawValue and
-// updates the stored snapshot. If there is no prior snapshot, or the new
-// value is smaller (counter reset), it records the baseline and returns
-// ok=false so the caller can drop the point.
-func (s *seriesStore) numberDelta(key uint64, rawValue float64, now time.Time) (delta float64, ok bool) {
+// numberDelta returns the delta from the previous raw value to rawValue,
+// the current raw cumulative value, and updates the stored snapshot. If
+// there is no prior snapshot, or the new value is smaller (counter reset),
+// it records the baseline and returns ok=false so the caller can drop the
+// point.
+func (s *seriesStore) numberDelta(key uint64, rawValue float64, now time.Time) (delta, cumulative float64, ok bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.pruneLocked(now)
 	entry, exists := s.entries[key]
 	if !exists {
 		s.admitLocked(key, &seriesState{lastSeen: now, value: rawValue, hasValue: true})
-		return 0, false
+		return 0, 0, false
 	}
 	entry.lastSeen = now
 	if !entry.hasValue || rawValue < entry.value {
 		entry.value = rawValue
 		entry.hasValue = true
-		return 0, false
+		return 0, 0, false
 	}
 	delta = rawValue - entry.value
 	entry.value = rawValue
-	return delta, true
+	return delta, rawValue, true
 }
 
-// histogramDelta returns (countDelta, sumDelta) and updates the stored
-// snapshot. Same reset semantics as numberDelta.
-func (s *seriesStore) histogramDelta(key uint64, rawCount uint64, rawSum float64, now time.Time) (countDelta uint64, sumDelta float64, ok bool) {
+// histogramDelta returns (countDelta, sumDelta) plus the current raw
+// cumulative count/sum, and updates the stored snapshot. Same reset
+// semantics as numberDelta.
+func (s *seriesStore) histogramDelta(key uint64, rawCount uint64, rawSum float64, now time.Time) (countDelta uint64, sumDelta float64, countCumulative uint64, sumCumulative float64, ok bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.pruneLocked(now)
@@ -154,7 +156,7 @@ func (s *seriesStore) histogramDelta(key uint64, rawCount uint64, rawSum float64
 			sum:      rawSum,
 			hasSum:   true,
 		})
-		return 0, 0, false
+		return 0, 0, 0, 0, false
 	}
 	entry.lastSeen = now
 	if !entry.hasCount || rawCount < entry.count {
@@ -162,13 +164,13 @@ func (s *seriesStore) histogramDelta(key uint64, rawCount uint64, rawSum float64
 		entry.hasCount = true
 		entry.sum = rawSum
 		entry.hasSum = true
-		return 0, 0, false
+		return 0, 0, 0, 0, false
 	}
 	countDelta = rawCount - entry.count
 	sumDelta = rawSum - entry.sum
 	entry.count = rawCount
 	entry.sum = rawSum
-	return countDelta, sumDelta, true
+	return countDelta, sumDelta, rawCount, rawSum, true
 }
 
 // admitLocked inserts a new entry, evicting the oldest-lastSeen entry when

--- a/internal/store/series_test.go
+++ b/internal/store/series_test.go
@@ -43,20 +43,20 @@ func TestNumberDelta_BaselineThenDelta(t *testing.T) {
 	const k uint64 = 1
 
 	// First observation → baseline, emit nothing.
-	if _, ok := s.numberDelta(k, 10, now); ok {
+	if _, _, ok := s.numberDelta(k, 10, now); ok {
 		t.Fatalf("first observation should be a baseline (ok=false)")
 	}
 
-	// Second observation → delta = 5.
-	delta, ok := s.numberDelta(k, 15, now.Add(time.Second))
-	if !ok || delta != 5 {
-		t.Fatalf("expected delta=5, got delta=%v ok=%v", delta, ok)
+	// Second observation → delta = 5, cumulative = 15.
+	delta, cum, ok := s.numberDelta(k, 15, now.Add(time.Second))
+	if !ok || delta != 5 || cum != 15 {
+		t.Fatalf("expected delta=5 cumulative=15, got delta=%v cumulative=%v ok=%v", delta, cum, ok)
 	}
 
-	// Third observation → delta = 3.
-	delta, ok = s.numberDelta(k, 18, now.Add(2*time.Second))
-	if !ok || delta != 3 {
-		t.Fatalf("expected delta=3, got delta=%v ok=%v", delta, ok)
+	// Third observation → delta = 3, cumulative = 18.
+	delta, cum, ok = s.numberDelta(k, 18, now.Add(2*time.Second))
+	if !ok || delta != 3 || cum != 18 {
+		t.Fatalf("expected delta=3 cumulative=18, got delta=%v cumulative=%v ok=%v", delta, cum, ok)
 	}
 }
 
@@ -67,13 +67,13 @@ func TestNumberDelta_ResetReestablishesBaseline(t *testing.T) {
 	s.numberDelta(k, 100, now)
 	s.numberDelta(k, 120, now.Add(time.Second))
 	// Process restart / counter reset — raw value goes down.
-	if _, ok := s.numberDelta(k, 5, now.Add(2*time.Second)); ok {
+	if _, _, ok := s.numberDelta(k, 5, now.Add(2*time.Second)); ok {
 		t.Fatalf("reset should emit no delta")
 	}
 	// Next point is a delta against the new baseline.
-	delta, ok := s.numberDelta(k, 8, now.Add(3*time.Second))
-	if !ok || delta != 3 {
-		t.Fatalf("expected delta=3 after reset, got delta=%v ok=%v", delta, ok)
+	delta, cum, ok := s.numberDelta(k, 8, now.Add(3*time.Second))
+	if !ok || delta != 3 || cum != 8 {
+		t.Fatalf("expected delta=3 cumulative=8 after reset, got delta=%v cumulative=%v ok=%v", delta, cum, ok)
 	}
 }
 
@@ -82,12 +82,12 @@ func TestHistogramDelta_CountAndSum(t *testing.T) {
 	now := time.Unix(0, 0)
 	const k uint64 = 1
 
-	if _, _, ok := s.histogramDelta(k, 10, 100, now); ok {
+	if _, _, _, _, ok := s.histogramDelta(k, 10, 100, now); ok {
 		t.Fatalf("first observation should be baseline")
 	}
-	c, sm, ok := s.histogramDelta(k, 13, 130, now.Add(time.Second))
-	if !ok || c != 3 || sm != 30 {
-		t.Fatalf("expected count=3 sum=30, got count=%d sum=%v ok=%v", c, sm, ok)
+	c, sm, cc, cs, ok := s.histogramDelta(k, 13, 130, now.Add(time.Second))
+	if !ok || c != 3 || sm != 30 || cc != 13 || cs != 130 {
+		t.Fatalf("expected count_delta=3 sum_delta=30 count_cum=13 sum_cum=130, got cd=%d sd=%v cc=%d cs=%v ok=%v", c, sm, cc, cs, ok)
 	}
 }
 
@@ -95,8 +95,8 @@ func TestSeriesStore_TTLPrune(t *testing.T) {
 	s := newSeriesStore()
 	s.ttl = time.Second
 	now := time.Unix(0, 0)
-	s.numberDelta(1, 1, now)
-	s.numberDelta(2, 1, now.Add(10*time.Second))
+	s.numberDelta(uint64(1), 1, now)
+	s.numberDelta(uint64(2), 1, now.Add(10*time.Second))
 	// The second write prunes anything older than 10s - 1s = 9s, which
 	// includes the first entry (lastSeen=0s).
 	if s.len() != 1 {
@@ -142,8 +142,12 @@ func TestConvertMetrics_CumulativeSumDeltaized(t *testing.T) {
 	if len(got[0].DataPoints) != 1 {
 		t.Fatalf("second scrape should produce 1 point, got %d", len(got[0].DataPoints))
 	}
-	if got[0].DataPoints[0].Value != 50 {
-		t.Fatalf("expected delta value=50, got %v", got[0].DataPoints[0].Value)
+	p := got[0].DataPoints[0]
+	if p.Value != 50 {
+		t.Fatalf("expected delta value=50, got %v", p.Value)
+	}
+	if p.Cumulative == nil || *p.Cumulative != 150 {
+		t.Fatalf("expected cumulative=150, got %v", p.Cumulative)
 	}
 }
 
@@ -163,6 +167,10 @@ func TestConvertMetrics_NonMonotonicSumPassthrough(t *testing.T) {
 	got := convertMetrics(md, s)
 	if len(got[0].DataPoints) != 1 || got[0].DataPoints[0].Value != 42 {
 		t.Fatalf("non-monotonic sum should pass through unchanged, got %+v", got[0].DataPoints)
+	}
+	// Non-monotonic Sum isn't delta-ized, so we don't synthesize a cumulative.
+	if got[0].DataPoints[0].Cumulative != nil {
+		t.Fatalf("non-monotonic sum should not carry cumulative, got %v", *got[0].DataPoints[0].Cumulative)
 	}
 }
 
@@ -214,6 +222,12 @@ func TestConvertMetrics_HistogramDeltaized(t *testing.T) {
 	if p.Max == nil || *p.Max != 0.9 {
 		t.Errorf("max = %v, want 0.9", p.Max)
 	}
+	if p.CountCumulative == nil || *p.CountCumulative != 15 {
+		t.Errorf("countCumulative = %v, want 15", p.CountCumulative)
+	}
+	if p.SumCumulative == nil || *p.SumCumulative != 4.0 {
+		t.Errorf("sumCumulative = %v, want 4.0", p.SumCumulative)
+	}
 }
 
 func TestConvertMetrics_GaugeUnaffected(t *testing.T) {
@@ -230,6 +244,9 @@ func TestConvertMetrics_GaugeUnaffected(t *testing.T) {
 	got := convertMetrics(md, s)
 	if got[0].DataPoints[0].Value != 0.7 {
 		t.Fatalf("gauge should pass through, got %v", got[0].DataPoints[0].Value)
+	}
+	if got[0].DataPoints[0].Cumulative != nil {
+		t.Fatalf("gauge should not carry cumulative, got %v", *got[0].DataPoints[0].Cumulative)
 	}
 	if s.len() != 0 {
 		t.Fatalf("gauge should not touch the series store, got len=%d", s.len())


### PR DESCRIPTION
## Summary

Add raw OTLP cumulative values to `DataPoint` for inputs we already
delta-ize (cumulative monotonic Sum, cumulative Histogram / Summary /
ExponentialHistogram):

- `DataPoint.Cumulative` — Sum
- `DataPoint.CountCumulative` / `DataPoint.SumCumulative` — distributions

Until now `Value` / `Count` / `Sum` intentionally carried only the
per-window delta (or mean), but UIs frequently want a running total
"since otelop started observing" — e.g. showing `claude_code.cost.usage`
as a session total. Clients can re-sum the delta column themselves, but
they lose data across ring-buffer eviction and reconnects. Surfacing the
raw cumulative the `seriesStore` already retains avoids that.

## Implementation

- `seriesStore` already keeps the previous raw observation per series to
  compute deltas, so `numberDelta` / `histogramDelta` just return that
  snapshot alongside the delta. No new bookkeeping.
- The cumulative fields populate only for delta-ized inputs. They are
  `null` for Gauge, non-monotonic Sum, and delta-temporality inputs.
- GraphQL schema exposes `cumulative` / `countCumulative` /
  `sumCumulative: Float` (nullable), with docstrings spelling out exactly
  when each is `null`.
- Existing behaviour (`value` as a delta) is unchanged.

## Caveats

otelop is an in-memory viewer by design, so "cumulative" means
"cumulative since the otelop process started observing this series" and
resets on daemon restart or ring-buffer eviction. The schema docstring
calls this out.

WebSocket replay, ring buffer, and MCP treat `MetricData` as opaque JSON
and marshal the struct as a whole, so the new fields ride through via
their `json` tags with no per-consumer change.

## Tests

- `mise run check` / `mise run test` (Go + frontend) all pass
- New assertions cover cumulative values on cumulative Sum / Histogram
  and `nil` cumulative on Gauge / non-monotonic Sum