### PR TITLE
feat(frontend): sync active tab and detail selection to URL

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,8 +7,8 @@ import { Header } from "@/components/layout/header";
 import { TraceList } from "@/components/traces/trace-list";
 import { MetricList } from "@/components/metrics/metric-list";
 import { LogList } from "@/components/logs/log-list";
-import { activeTabAtom } from "@/stores/telemetry";
-import type { TabValue } from "@/stores/telemetry";
+import { activeTabAtom, useLocationSync } from "@/stores/navigation";
+import type { TabValue } from "@/stores/navigation";
 import { SIGNAL_LIST } from "@/lib/signals";
 
 const tabBody: Record<TabValue, () => React.ReactElement> = {
@@ -30,6 +30,7 @@ const tabTriggerClasses: Record<TabValue, string> = {
 
 function App() {
   useThemeSync();
+  useLocationSync();
   useWebSocket();
   useInitialLoad();
 

--- a/frontend/src/stores/navigation.test.ts
+++ b/frontend/src/stores/navigation.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createStore } from "jotai";
+import {
+  activeTabAtom,
+  applyLocationAtom,
+  buildPath,
+  parsePath,
+  selectedMetricKeyAtom,
+  selectedTraceIdAtom,
+} from "./navigation";
+
+describe("parsePath", () => {
+  it("maps the root path to traces with no selection", () => {
+    expect(parsePath("/")).toEqual({ tab: "traces", traceId: null, metricKey: null });
+  });
+
+  it("maps signal paths to their tabs", () => {
+    expect(parsePath("/traces").tab).toBe("traces");
+    expect(parsePath("/metrics").tab).toBe("metrics");
+    expect(parsePath("/logs").tab).toBe("logs");
+  });
+
+  it("tolerates trailing segments and slashes", () => {
+    expect(parsePath("/metrics/")).toEqual({ tab: "metrics", traceId: null, metricKey: null });
+  });
+
+  it("falls back to traces for unknown paths", () => {
+    expect(parsePath("/unknown").tab).toBe("traces");
+  });
+
+  it("extracts a decoded traceId under /traces", () => {
+    expect(parsePath("/traces/abc123")).toEqual({
+      tab: "traces",
+      traceId: "abc123",
+      metricKey: null,
+    });
+  });
+
+  it("decodes an encoded traceId", () => {
+    expect(parsePath("/traces/a%2Fb").traceId).toBe("a/b");
+  });
+
+  it("ignores a trailing segment on other tabs", () => {
+    expect(parsePath("/metrics/svc").metricKey).toBeNull();
+    expect(parsePath("/logs/whatever").traceId).toBeNull();
+  });
+
+  it("extracts a decoded metricKey only when both segments are present", () => {
+    expect(parsePath("/metrics/svc/cpu")).toEqual({
+      tab: "metrics",
+      traceId: null,
+      metricKey: { serviceName: "svc", name: "cpu" },
+    });
+  });
+
+  it("decodes encoded metricKey segments", () => {
+    const parsed = parsePath("/metrics/svc%2Fwith%20slash/cpu.usage");
+    expect(parsed.metricKey).toEqual({ serviceName: "svc/with slash", name: "cpu.usage" });
+  });
+});
+
+describe("buildPath", () => {
+  it("builds a bare tab path with no selection", () => {
+    expect(buildPath("traces", null, null)).toBe("/traces");
+    expect(buildPath("metrics", null, null)).toBe("/metrics");
+    expect(buildPath("logs", null, null)).toBe("/logs");
+  });
+
+  it("builds a trace detail path, encoding the traceId", () => {
+    expect(buildPath("traces", "a/b", null)).toBe("/traces/a%2Fb");
+  });
+
+  it("builds a metric detail path, encoding both segments", () => {
+    expect(buildPath("metrics", null, { serviceName: "svc/with slash", name: "cpu.usage" })).toBe(
+      "/metrics/svc%2Fwith%20slash/cpu.usage",
+    );
+  });
+
+  it("ignores a traceId when the tab is not traces", () => {
+    expect(buildPath("metrics", "abc", null)).toBe("/metrics");
+  });
+
+  it("ignores a metricKey when the tab is not metrics", () => {
+    expect(buildPath("traces", null, { serviceName: "svc", name: "cpu" })).toBe("/traces");
+  });
+
+  it("round-trips through parsePath, including characters needing encoding", () => {
+    const path = buildPath("metrics", null, { serviceName: "svc/with slash", name: "cpu.usage" });
+    expect(parsePath(path)).toEqual({
+      tab: "metrics",
+      traceId: null,
+      metricKey: { serviceName: "svc/with slash", name: "cpu.usage" },
+    });
+  });
+});
+
+describe("activeTabAtom", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("pushes the tab path to history on change", () => {
+    const store = createStore();
+    store.set(activeTabAtom, "metrics");
+    expect(store.get(activeTabAtom)).toBe("metrics");
+    expect(window.location.pathname).toBe("/metrics");
+  });
+
+  it("does not push a new URL when the tab is unchanged", () => {
+    const store = createStore();
+    store.set(activeTabAtom, "metrics");
+    window.history.replaceState(null, "", "/somewhere-else");
+    store.set(activeTabAtom, "metrics");
+    expect(window.location.pathname).toBe("/somewhere-else");
+  });
+
+  it("follows browser back/forward via applyLocationAtom", () => {
+    const store = createStore();
+    store.set(applyLocationAtom, "/logs");
+    window.history.replaceState(null, "", "/metrics");
+    store.set(applyLocationAtom, window.location.pathname);
+    expect(store.get(activeTabAtom)).toBe("metrics");
+  });
+
+  it("includes the selected trace when returning to the traces tab", () => {
+    const store = createStore();
+    store.set(selectedTraceIdAtom, "t1");
+    store.set(activeTabAtom, "metrics");
+    store.set(activeTabAtom, "traces");
+    expect(window.location.pathname).toBe("/traces/t1");
+  });
+});
+
+describe("selectedTraceIdAtom / selectedMetricKeyAtom (write-through)", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("pushes the URL when the traceId changes", () => {
+    const store = createStore();
+    store.set(selectedTraceIdAtom, "t1");
+    expect(window.location.pathname).toBe("/traces/t1");
+  });
+
+  it("does not push when set to the same traceId", () => {
+    const store = createStore();
+    store.set(selectedTraceIdAtom, "t1");
+    window.history.replaceState(null, "", "/somewhere-else");
+    store.set(selectedTraceIdAtom, "t1");
+    expect(window.location.pathname).toBe("/somewhere-else");
+  });
+
+  it("pushes the URL when the metricKey changes", () => {
+    const store = createStore();
+    store.set(activeTabAtom, "metrics");
+    store.set(selectedMetricKeyAtom, { serviceName: "svc", name: "cpu" });
+    expect(window.location.pathname).toBe("/metrics/svc/cpu");
+  });
+
+  it("does not push when set to an equal metricKey", () => {
+    const store = createStore();
+    store.set(activeTabAtom, "metrics");
+    store.set(selectedMetricKeyAtom, { serviceName: "svc", name: "cpu" });
+    window.history.replaceState(null, "", "/somewhere-else");
+    store.set(selectedMetricKeyAtom, { serviceName: "svc", name: "cpu" });
+    expect(window.location.pathname).toBe("/somewhere-else");
+  });
+});
+
+describe("applyLocationAtom", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("applies the tab and, for traces, the selected traceId", () => {
+    const store = createStore();
+    store.set(applyLocationAtom, "/traces/t1");
+    expect(store.get(activeTabAtom)).toBe("traces");
+    expect(store.get(selectedTraceIdAtom)).toBe("t1");
+  });
+
+  it("keeps the traceId selection when switching to a different tab", () => {
+    const store = createStore();
+    store.set(applyLocationAtom, "/traces/t1");
+    store.set(applyLocationAtom, "/metrics/svc/cpu");
+    expect(store.get(activeTabAtom)).toBe("metrics");
+    expect(store.get(selectedMetricKeyAtom)).toEqual({ serviceName: "svc", name: "cpu" });
+    expect(store.get(selectedTraceIdAtom)).toBe("t1");
+  });
+
+  it("clears the traceId when the applied traces path has no selection", () => {
+    const store = createStore();
+    store.set(applyLocationAtom, "/traces/t1");
+    store.set(applyLocationAtom, "/traces");
+    expect(store.get(selectedTraceIdAtom)).toBeNull();
+  });
+
+  it("does not push to history", () => {
+    const store = createStore();
+    store.set(applyLocationAtom, "/traces/t1");
+    expect(window.location.pathname).toBe("/");
+  });
+});

--- a/frontend/src/stores/navigation.ts
+++ b/frontend/src/stores/navigation.ts
@@ -1,0 +1,130 @@
+import { atom } from "jotai";
+import type { Getter } from "jotai";
+import { useSetAtom } from "jotai";
+import { useEffect } from "react";
+import { SIGNALS } from "@/lib/signals";
+import type { SignalKey } from "@/lib/signals";
+import type { MetricData } from "@/types/telemetry";
+
+export type TabValue = SignalKey;
+
+export type MetricKey = Pick<MetricData, "serviceName" | "name">;
+
+interface ParsedLocation {
+  tab: TabValue;
+  traceId: string | null;
+  metricKey: MetricKey | null;
+}
+
+// Only the tab of the currently active screen is meaningful in the path; a
+// traceId/metricKey segment left over from another tab is ignored.
+export function parsePath(pathname: string): ParsedLocation {
+  const [first, second, third] = pathname.split("/").filter(Boolean);
+  const tab: TabValue = first && first in SIGNALS ? (first as TabValue) : "traces";
+
+  return {
+    tab,
+    traceId: tab === "traces" && second ? decodeURIComponent(second) : null,
+    metricKey:
+      tab === "metrics" && second && third
+        ? { serviceName: decodeURIComponent(second), name: decodeURIComponent(third) }
+        : null,
+  };
+}
+
+export function buildPath(
+  tab: TabValue,
+  traceId: string | null,
+  metricKey: MetricKey | null,
+): string {
+  if (tab === "traces" && traceId) return `/traces/${encodeURIComponent(traceId)}`;
+  if (tab === "metrics" && metricKey) {
+    return `/metrics/${encodeURIComponent(metricKey.serviceName)}/${encodeURIComponent(metricKey.name)}`;
+  }
+  return `/${tab}`;
+}
+
+export function metricKeyEquals(a: MetricKey | null, b: MetricKey | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.serviceName === b.serviceName && a.name === b.name;
+}
+
+const initialLocation = parsePath(window.location.pathname);
+
+const currentTabAtom = atom<TabValue>(initialLocation.tab);
+
+const selectedTraceIdBaseAtom = atom<string | null>(initialLocation.traceId);
+const selectedMetricKeyBaseAtom = atom<MetricKey | null>(initialLocation.metricKey);
+
+// Shared by every public writer so the URL always reflects the current
+// tab + selection as a single pushState, and unchanged state never pushes.
+function syncLocation(get: Getter): void {
+  const path = buildPath(
+    get(currentTabAtom),
+    get(selectedTraceIdBaseAtom),
+    get(selectedMetricKeyBaseAtom),
+  );
+  if (window.location.pathname !== path) {
+    window.history.pushState(null, "", path);
+  }
+}
+
+// Write-through atoms: writing the id/key also syncs the URL, so callers
+// (telemetry.ts's selectedTraceAtom/selectedMetricAtom) can't forget to.
+export const selectedTraceIdAtom = atom(
+  (get) => get(selectedTraceIdBaseAtom),
+  (get, set, traceId: string | null) => {
+    if (get(selectedTraceIdBaseAtom) === traceId) return;
+    set(selectedTraceIdBaseAtom, traceId);
+    syncLocation(get);
+  },
+);
+
+export const selectedMetricKeyAtom = atom(
+  (get) => get(selectedMetricKeyBaseAtom),
+  (get, set, metricKey: MetricKey | null) => {
+    if (metricKeyEquals(get(selectedMetricKeyBaseAtom), metricKey)) return;
+    set(selectedMetricKeyBaseAtom, metricKey);
+    syncLocation(get);
+  },
+);
+
+// The tab/selection combo is mirrored to the URL so a reload (or shared link)
+// restores the same screen even though the telemetry data itself is volatile.
+export const activeTabAtom = atom(
+  (get) => get(currentTabAtom),
+  (get, set, tab: TabValue) => {
+    if (get(currentTabAtom) === tab) return;
+    set(currentTabAtom, tab);
+    syncLocation(get);
+  },
+);
+
+// Applies a browser-navigated (or restored) path to state without touching
+// history — history already reflects this path, pushing again would loop.
+// Only the tab matching the path's selection is updated; a selection held by
+// another tab is left as-is so switching back restores it.
+export const applyLocationAtom = atom(null, (_get, set, pathname: string) => {
+  const parsed = parsePath(pathname);
+  set(currentTabAtom, parsed.tab);
+  if (parsed.tab === "traces") {
+    set(selectedTraceIdBaseAtom, parsed.traceId);
+  }
+  if (parsed.tab === "metrics") {
+    set(selectedMetricKeyBaseAtom, parsed.metricKey);
+  }
+});
+
+// Keeps state in sync with browser back/forward navigation. Mounted once at
+// the app root (unlike the old currentTabAtom.onMount, this also restores
+// trace/metric selection, so it must run for the lifetime of the app).
+export function useLocationSync(): void {
+  const applyLocation = useSetAtom(applyLocationAtom);
+
+  useEffect(() => {
+    const onPopState = () => applyLocation(window.location.pathname);
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [applyLocation]);
+}

--- a/frontend/src/stores/telemetry.test.ts
+++ b/frontend/src/stores/telemetry.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { createStore } from "jotai";
-import { metricsAtom, addMetricAtom, serverConfigAtom } from "./telemetry";
-import { makeMetric, makeDataPoint } from "@/test/factories";
+import {
+  metricsAtom,
+  addMetricAtom,
+  serverConfigAtom,
+  tracesAtom,
+  selectedTraceAtom,
+  selectedMetricAtom,
+} from "./telemetry";
+import { selectedTraceIdAtom, selectedMetricKeyAtom } from "./navigation";
+import { makeMetric, makeDataPoint, makeTrace } from "@/test/factories";
 
 describe("addMetricAtom", () => {
   it("merges data points by id, dropping re-delivered duplicates", () => {
@@ -42,5 +50,44 @@ describe("addMetricAtom", () => {
     );
 
     expect(store.get(metricsAtom)[0].dataPoints.map((p) => p.id)).toEqual(["b", "c"]);
+  });
+});
+
+describe("selectedTraceAtom", () => {
+  it("resolves once the matching trace loads, restoring selection after a reload", () => {
+    const store = createStore();
+    // Simulate a reload where the URL already names a traceId before the
+    // WebSocket/REST load has populated tracesAtom.
+    store.set(selectedTraceIdAtom, "t1");
+    expect(store.get(selectedTraceAtom)).toBeNull();
+
+    store.set(tracesAtom, [makeTrace({ traceId: "t1" })]);
+    expect(store.get(selectedTraceAtom)?.traceId).toBe("t1");
+  });
+
+  it("setting the atom updates the shared traceId used for URL sync", () => {
+    const store = createStore();
+    const trace = makeTrace({ traceId: "t2" });
+    store.set(tracesAtom, [trace]);
+
+    store.set(selectedTraceAtom, trace);
+    expect(store.get(selectedTraceIdAtom)).toBe("t2");
+
+    store.set(selectedTraceAtom, null);
+    expect(store.get(selectedTraceIdAtom)).toBeNull();
+  });
+});
+
+describe("selectedMetricAtom", () => {
+  it("setting the atom updates the shared metricKey used for URL sync", () => {
+    const store = createStore();
+    const metric = makeMetric({ serviceName: "svc", name: "cpu" });
+    store.set(metricsAtom, [metric]);
+
+    store.set(selectedMetricAtom, metric);
+    expect(store.get(selectedMetricKeyAtom)).toEqual({ serviceName: "svc", name: "cpu" });
+
+    store.set(selectedMetricAtom, null);
+    expect(store.get(selectedMetricKeyAtom)).toBeNull();
   });
 });

--- a/frontend/src/stores/telemetry.ts
+++ b/frontend/src/stores/telemetry.ts
@@ -1,6 +1,13 @@
 import { atom } from "jotai";
+import type { Atom, WritableAtom } from "jotai";
 import { Temporal } from "temporal-polyfill";
 import type { TraceData, MetricData, LogData, SpanData, DataPoint } from "@/types/telemetry";
+import {
+  activeTabAtom,
+  metricKeyEquals,
+  selectedMetricKeyAtom,
+  selectedTraceIdAtom,
+} from "./navigation";
 
 // Server-side capacity config, fetched at startup.
 export interface ServerConfig {
@@ -101,9 +108,7 @@ function mergeDataPoints(existing: DataPoint[], incoming: DataPoint[]): DataPoin
 export const addMetricAtom = atom(null, (get, set, newMetric: MetricData) => {
   const current = get(metricsAtom);
   const maxMetrics = get(serverConfigAtom).metricCap;
-  const idx = current.findIndex(
-    (m) => m.serviceName === newMetric.serviceName && m.name === newMetric.name,
-  );
+  const idx = current.findIndex((m) => metricKeyEquals(m, newMetric));
   if (idx >= 0) {
     const existing = current[idx];
     const updated = [...current];
@@ -141,33 +146,43 @@ export const clearAllAtom = atom(null, (_get, set) => {
   set(logsAtom, []);
 });
 
-// Selection state
-export const selectedTraceAtom = atom<TraceData | null>(null);
+// Selection state. The id/key (not the object) is the source of truth so it
+// can be restored from the URL before the matching data has loaded — the
+// derived read resolves once tracesAtom/metricsAtom catch up. Equality
+// guarding and URL sync live on the key atom itself (navigation.ts).
+function createSelectionAtom<Item, Key>(
+  keyAtom: WritableAtom<Key | null, [Key | null], void>,
+  listAtom: Atom<Item[]>,
+  toKey: (item: Item) => Key,
+  matches: (item: Item, key: Key) => boolean,
+) {
+  return atom(
+    (get) => {
+      const key = get(keyAtom);
+      if (key === null) return null;
+      return get(listAtom).find((item) => matches(item, key)) ?? null;
+    },
+    (_get, set, item: Item | null) => {
+      set(keyAtom, item ? toKey(item) : null);
+    },
+  );
+}
 
-type MetricKey = Pick<MetricData, "serviceName" | "name">;
-const selectedMetricKeyAtom = atom<MetricKey | null>(null);
+export const selectedTraceAtom = createSelectionAtom(
+  selectedTraceIdAtom,
+  tracesAtom,
+  (t) => t.traceId,
+  (t, id) => t.traceId === id,
+);
 
-export const selectedMetricAtom = atom(
-  (get) => {
-    const key = get(selectedMetricKeyAtom);
-    if (!key) return null;
-    return (
-      get(metricsAtom).find((m) => m.serviceName === key.serviceName && m.name === key.name) ?? null
-    );
-  },
-  (_get, set, metric: MetricData | null) => {
-    set(
-      selectedMetricKeyAtom,
-      metric ? { serviceName: metric.serviceName, name: metric.name } : null,
-    );
-  },
+export const selectedMetricAtom = createSelectionAtom(
+  selectedMetricKeyAtom,
+  metricsAtom,
+  (m) => ({ serviceName: m.serviceName, name: m.name }),
+  metricKeyEquals,
 );
 
 export const selectedLogAtom = atom<LogData | null>(null);
-
-// Active tab
-export type TabValue = "traces" | "metrics" | "logs";
-export const activeTabAtom = atom<TabValue>("traces");
 
 // Log filter by traceId (set when jumping from trace → logs)
 export const logTraceFilterAtom = atom<string | null>(null);


### PR DESCRIPTION
## Summary

The UI state was previously in-memory only, so a reload always dropped back to the Traces tab with nothing selected. This PR mirrors the current screen to the URL path so a reload (or a shared link) restores it:

- `/traces`, `/metrics`, `/logs` — active tab
- `/traces/:traceId` — open trace detail
- `/metrics/:serviceName/:metricName` — open metric detail (segments URL-encoded)

Behavior:

- Tab switches and detail open/close push history entries, so browser back/forward walks through screens (back closes a detail).
- Returning to a tab restores its selection into the URL (existing UX of selections surviving tab switches is kept).
- The selection id/key is the source of truth and the object is derived from the store, so a selection restored from the URL resolves once the initial REST load delivers the data — and falls back to the plain list if the entry has already been evicted (data is volatile by design).
- No router library added; the existing SPA fallback in the Go server already serves `index.html` for these paths.

Implementation notes:

- `stores/navigation.ts` owns the URL: `parsePath`/`buildPath`, write-through key atoms (write = equality guard → set → single `pushState`), `applyLocationAtom` + `useLocationSync()` for popstate.
- `stores/telemetry.ts` derives `selectedTraceAtom`/`selectedMetricAtom` from the keys via a shared `createSelectionAtom` factory; component APIs are unchanged.
- Log detail selection is intentionally out of scope; it can reuse the same mechanism later.

## Test plan

- [x] `mise run check` — format, lint, type-check all clean
- [x] `mise run test` — Go + frontend, 117 frontend tests pass (30 new: path codec round-trips incl. encoded segments, push/no-push semantics, popstate application, reload-restore of a selection before data arrives)