### PR TITLE
feat(frontend): show log and data point details in sidebars, sync log selection to URL

### DIFF
--- a/frontend/src/components/common/detail-field.tsx
+++ b/frontend/src/components/common/detail-field.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+import type { Tone } from "@/lib/tones";
+
+// FieldTone restricts Field's highlight color to the signal tones (trace,
+// metric, log) — a Field never needs the status tones (success, warning, ...).
+type FieldTone = Extract<Tone, "trace" | "metric" | "log">;
+
+// Tailwind v4 can't scan dynamic class interpolation (e.g. `text-${tone}`),
+// so each tone's classes must be listed literally here.
+const toneClasses: Record<FieldTone, string> = {
+  trace: "text-trace",
+  metric: "text-metric",
+  log: "text-log",
+};
+
+// Field/Section are the label/value building blocks shared by every signal's
+// sidebar detail view (SpanDetail, LogDetail), so their layout stays visually
+// consistent across signals.
+export function Field({
+  label,
+  value,
+  mono,
+  tone,
+}: {
+  label: string;
+  value: ReactNode;
+  mono?: boolean;
+  tone?: FieldTone;
+}) {
+  return (
+    <div className="flex gap-2 text-sm">
+      <dt className="w-20 shrink-0 text-muted-foreground">{label}</dt>
+      <dd
+        className={`break-all ${mono ? "font-mono text-xs leading-5" : ""} ${tone ? `${toneClasses[tone]} font-semibold` : ""}`}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+export function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div>
+      <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {title}
+      </h4>
+      <div className="space-y-1.5 rounded-md bg-muted/50 p-2.5">{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/logs/log-list.tsx
+++ b/frontend/src/components/logs/log-list.tsx
@@ -1,8 +1,13 @@
-import { Fragment, useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { X } from "lucide-react";
-import { logsAtom, logTraceFilterAtom, navigateToTraceAtom } from "@/stores/telemetry";
+import {
+  logsAtom,
+  logTraceFilterAtom,
+  navigateToTraceAtom,
+  selectedLogAtom,
+} from "@/stores/telemetry";
 import { filteredLogsAtom, logSearchAtom } from "@/stores/filters";
+import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Table,
@@ -15,6 +20,7 @@ import {
 import { CopyJsonButton } from "@/components/ui/copy-json-button";
 import { formatTimestamp, isZeroId, shortId } from "@/lib/format";
 import { KVSection } from "@/components/ui/kv-section";
+import { Field, Section } from "@/components/common/detail-field";
 import { SearchFilter } from "@/components/filters/search-filter";
 import { ListPanel } from "@/components/common/list-panel";
 import { EmptyState, EmptyMatches } from "@/components/common/empty-state";
@@ -29,7 +35,8 @@ export function LogList() {
   const traceFilter = useAtomValue(logTraceFilterAtom);
   const setTraceFilter = useSetAtom(logTraceFilterAtom);
   const navigateToTrace = useSetAtom(navigateToTraceAtom);
-  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const selectedLog = useAtomValue(selectedLogAtom);
+  const setSelectedLog = useSetAtom(selectedLogAtom);
 
   if (allLogs.length === 0) {
     return <EmptyState signal={SIGNALS.logs} />;
@@ -55,29 +62,31 @@ export function LogList() {
         </>
       }
     >
-      {logs.length === 0 ? (
-        <EmptyMatches label="logs" />
-      ) : (
-        <ScrollArea className="min-h-0 flex-1">
-          <Table>
-            <TableHeader>
-              <TableRow className="border-b border-border/50 bg-muted hover:bg-muted">
-                <TableHead className="w-[110px] text-log/70">Timestamp</TableHead>
-                <TableHead className="w-[90px] text-log/70">Severity</TableHead>
-                <TableHead className="text-log/70">Service</TableHead>
-                <TableHead className="text-log/70">Body</TableHead>
-                <TableHead className="text-log/70">Trace ID</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {logs.map((log, i) => {
-                const hasTrace = !isZeroId(log.traceId);
-                return (
-                  <Fragment key={log.id}>
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        {logs.length === 0 ? (
+          <EmptyMatches label="logs" />
+        ) : (
+          <ScrollArea className="min-h-0 flex-1">
+            <Table>
+              <TableHeader>
+                <TableRow className="border-b border-border/50 bg-muted hover:bg-muted">
+                  <TableHead className="w-[110px] text-log/70">Timestamp</TableHead>
+                  <TableHead className="w-[90px] text-log/70">Severity</TableHead>
+                  <TableHead className="text-log/70">Service</TableHead>
+                  <TableHead className="text-log/70">Body</TableHead>
+                  <TableHead className="text-log/70">Trace ID</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {logs.map((log, i) => {
+                  const hasTrace = !isZeroId(log.traceId);
+                  const isSelected = selectedLog?.id === log.id;
+                  return (
                     <TableRow
-                      className="stagger-row cursor-pointer border-b border-border/30 transition-colors hover:bg-log/5"
+                      key={log.id}
+                      className={`stagger-row cursor-pointer border-b border-border/30 transition-colors hover:bg-log/5 ${isSelected ? "bg-log/10" : ""}`}
                       style={{ animationDelay: `${Math.min(i * 20, 200)}ms` }}
-                      onClick={() => setExpandedId(expandedId === log.id ? null : log.id)}
+                      onClick={() => setSelectedLog(isSelected ? null : log)}
                     >
                       <TableCell className="font-mono text-xs text-muted-foreground">
                         {formatTimestamp(log.timestamp)}
@@ -106,66 +115,92 @@ export function LogList() {
                         ) : null}
                       </TableCell>
                     </TableRow>
-                    {expandedId === log.id && (
-                      <TableRow key={`detail-${log.id}`}>
-                        <TableCell
-                          colSpan={5}
-                          className="whitespace-normal border-b border-border/20 bg-card/30 p-0"
-                        >
-                          <LogDetail log={log} onNavigateToTrace={navigateToTrace} />
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </Fragment>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </ScrollArea>
-      )}
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </ScrollArea>
+        )}
+        {selectedLog && (
+          <div className="w-[420px] border-l border-border/50">
+            <LogDetail
+              log={selectedLog}
+              onClose={() => setSelectedLog(null)}
+              onNavigateToTrace={navigateToTrace}
+            />
+          </div>
+        )}
+      </div>
     </ListPanel>
   );
 }
 
 function LogDetail({
   log,
+  onClose,
   onNavigateToTrace,
 }: {
   log: LogData;
+  onClose: () => void;
   onNavigateToTrace: (id: string) => void;
 }) {
   return (
-    <div className="animate-slide-up-fade relative space-y-3 overflow-hidden px-4 py-3 text-xs">
-      <div className="absolute right-3 top-2">
-        <CopyJsonButton data={log} size="xs" />
-      </div>
-      <div className="whitespace-pre-wrap break-all pr-20 font-mono text-foreground/80">
-        {log.body}
-      </div>
-      {!isZeroId(log.traceId) && (
-        <div className="flex items-center gap-2">
-          <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-            Trace ID{" "}
-          </span>
-          <button
-            className="font-mono text-trace underline decoration-trace/30 underline-offset-2 transition-colors hover:decoration-trace/60"
-            onClick={() => onNavigateToTrace(log.traceId)}
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-border/50 px-4 py-2">
+        <h3 className="text-sm font-semibold text-log">Log Details</h3>
+        <div className="flex items-center gap-1">
+          <CopyJsonButton data={log} size="xs" />
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground"
           >
-            {log.traceId}
-          </button>
-          {!isZeroId(log.spanId) && (
-            <>
-              <span className="mx-1 text-muted-foreground">/</span>
-              <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-                Span ID{" "}
-              </span>
-              <span className="font-mono text-log">{log.spanId}</span>
-            </>
-          )}
+            <X className="h-3 w-3" />
+          </Button>
         </div>
-      )}
-      <KVSection title="Attributes" data={log.attributes} />
-      <KVSection title="Resource" data={log.resource} />
+      </div>
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="animate-slide-up-fade space-y-5 p-4">
+          <div className="space-y-2.5">
+            <Field label="Timestamp" value={formatTimestamp(log.timestamp)} mono />
+            <Field
+              label="Severity"
+              value={
+                <Pill tone={severityTone(log.severityText)} dot>
+                  {log.severityText || "UNSET"}
+                </Pill>
+              }
+            />
+            <Field label="Service" value={log.serviceName || "-"} />
+            {!isZeroId(log.traceId) && (
+              <Field
+                label="Trace ID"
+                mono
+                value={
+                  <button
+                    className="text-trace underline decoration-trace/30 underline-offset-2 transition-colors hover:decoration-trace/60"
+                    onClick={() => onNavigateToTrace(log.traceId)}
+                  >
+                    {log.traceId}
+                  </button>
+                }
+              />
+            )}
+            {!isZeroId(log.spanId) && <Field label="Span ID" value={log.spanId} mono />}
+          </div>
+
+          <Section title="Body">
+            <div className="whitespace-pre-wrap break-all font-mono text-xs text-foreground/80">
+              {log.body}
+            </div>
+          </Section>
+
+          <KVSection title="Attributes" data={log.attributes} />
+
+          <KVSection title="Resource" data={log.resource} />
+        </div>
+      </ScrollArea>
     </div>
   );
 }

--- a/frontend/src/components/metrics/data-points-table.test.tsx
+++ b/frontend/src/components/metrics/data-points-table.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import { DataPointsTable } from "./metric-detail";
+import { DataPointsTable, DataPointDetail } from "./metric-detail";
 import { makeDataPoint, makeMetric } from "@/test/factories";
 
 afterEach(cleanup);
@@ -9,16 +9,8 @@ function attrRow(text: string) {
   return screen.getByText(text).closest("tr")!;
 }
 
-function attributesHeading() {
-  return screen.queryByRole("heading", { level: 4, name: "Attributes" });
-}
-
-function resourceHeading() {
-  return screen.queryByRole("heading", { level: 4, name: "Resource" });
-}
-
 describe("DataPointsTable", () => {
-  it("expands a row on click and shows Attributes with full key/value", () => {
+  it("calls onSelect with the data point id when a row is clicked", () => {
     const metric = makeMetric({
       dataPoints: [
         makeDataPoint({
@@ -27,35 +19,27 @@ describe("DataPointsTable", () => {
         }),
       ],
     });
+    const onSelect = vi.fn();
 
-    render(<DataPointsTable metric={metric} />);
-    expect(attributesHeading()).toBeNull();
-
+    render(<DataPointsTable metric={metric} selectedId={null} onSelect={onSelect} />);
     fireEvent.click(attrRow('http.method="GET", http.route="/api/users/{id}"'));
 
-    expect(attributesHeading()).toBeTruthy();
-    expect(screen.getByText("http.method")).toBeTruthy();
-    expect(screen.getByText("GET")).toBeTruthy();
-    expect(screen.getByText("http.route")).toBeTruthy();
-    expect(screen.getByText("/api/users/{id}")).toBeTruthy();
+    expect(onSelect).toHaveBeenCalledWith("dp-a");
   });
 
-  it("collapses the same row on second click", () => {
+  it("calls onSelect with null when the selected row is clicked again", () => {
     const metric = makeMetric({
       dataPoints: [makeDataPoint({ id: "dp-a", attributes: { k: "v" } })],
     });
+    const onSelect = vi.fn();
 
-    render(<DataPointsTable metric={metric} />);
-    const row = attrRow('k="v"');
+    render(<DataPointsTable metric={metric} selectedId="dp-a" onSelect={onSelect} />);
+    fireEvent.click(attrRow('k="v"'));
 
-    fireEvent.click(row);
-    expect(attributesHeading()).toBeTruthy();
-
-    fireEvent.click(row);
-    expect(attributesHeading()).toBeNull();
+    expect(onSelect).toHaveBeenCalledWith(null);
   });
 
-  it("closes the previous row when another row is expanded", () => {
+  it("highlights the selected row", () => {
     const metric = makeMetric({
       dataPoints: [
         makeDataPoint({ id: "dp-a", attributes: { k: "va" } }),
@@ -63,58 +47,126 @@ describe("DataPointsTable", () => {
       ],
     });
 
-    render(<DataPointsTable metric={metric} />);
+    render(<DataPointsTable metric={metric} selectedId="dp-b" onSelect={() => {}} />);
 
-    fireEvent.click(attrRow('k="va"'));
-    expect(screen.getAllByRole("heading", { level: 4, name: "Attributes" })).toHaveLength(1);
-    expect(screen.getByText("va")).toBeTruthy();
+    expect(attrRow('k="va"').className).not.toContain("bg-metric/10");
+    expect(attrRow('k="vb"').className).toContain("bg-metric/10");
+  });
 
-    fireEvent.click(attrRow('k="vb"'));
-    expect(screen.getAllByRole("heading", { level: 4, name: "Attributes" })).toHaveLength(1);
-    expect(screen.getByText("vb")).toBeTruthy();
-    expect(screen.queryByText("va")).toBeNull();
+  it("does not render an inline detail row for the selected data point", () => {
+    const metric = makeMetric({
+      dataPoints: [makeDataPoint({ id: "dp-a", attributes: { k: "v" } })],
+    });
+
+    render(<DataPointsTable metric={metric} selectedId="dp-a" onSelect={() => {}} />);
+
+    expect(screen.queryByRole("heading", { level: 4, name: "Attributes" })).toBeNull();
+  });
+});
+
+describe("DataPointDetail", () => {
+  it("shows Timestamp and Value fields", () => {
+    const dp = makeDataPoint({ id: "dp-a", timestamp: "2024-01-01T00:00:00Z", value: 42 });
+
+    render(<DataPointDetail dp={dp} resource={{}} unit="" isDistribution={false} />);
+
+    expect(screen.getByText("Timestamp")).toBeTruthy();
+    expect(screen.getByText("Value")).toBeTruthy();
+    expect(screen.getByText("42")).toBeTruthy();
+  });
+
+  it("shows the Value field in the metric tone", () => {
+    const dp = makeDataPoint({ id: "dp-a", value: 42 });
+
+    render(<DataPointDetail dp={dp} resource={{}} unit="" isDistribution={false} />);
+
+    expect(screen.getByText("42").className).toContain("text-metric");
+  });
+
+  it("shows Attributes with full key/value", () => {
+    const dp = makeDataPoint({
+      id: "dp-a",
+      attributes: { "http.method": "GET", "http.route": "/api/users/{id}" },
+    });
+
+    render(<DataPointDetail dp={dp} resource={{}} unit="" isDistribution={false} />);
+
+    expect(screen.getByRole("heading", { level: 4, name: "Attributes" })).toBeTruthy();
+    expect(screen.getByText("http.method")).toBeTruthy();
+    expect(screen.getByText("GET")).toBeTruthy();
+    expect(screen.getByText("http.route")).toBeTruthy();
+    expect(screen.getByText("/api/users/{id}")).toBeTruthy();
+  });
+
+  it("hides the Attributes section when the data point has no attributes", () => {
+    const dp = makeDataPoint({ id: "dp-a", attributes: {} });
+
+    render(
+      <DataPointDetail
+        dp={dp}
+        resource={{ "service.name": "checkout" }}
+        unit=""
+        isDistribution={false}
+      />,
+    );
+
+    expect(screen.queryByRole("heading", { level: 4, name: "Attributes" })).toBeNull();
   });
 
   it("hides the Resource section when the metric has no resource", () => {
-    const metric = makeMetric({
-      resource: {},
-      dataPoints: [makeDataPoint({ id: "dp-a", attributes: { k: "v" } })],
-    });
+    const dp = makeDataPoint({ id: "dp-a", attributes: { k: "v" } });
 
-    render(<DataPointsTable metric={metric} />);
-    fireEvent.click(attrRow('k="v"'));
+    render(<DataPointDetail dp={dp} resource={{}} unit="" isDistribution={false} />);
 
-    expect(attributesHeading()).toBeTruthy();
-    expect(resourceHeading()).toBeNull();
+    expect(screen.queryByRole("heading", { level: 4, name: "Resource" })).toBeNull();
   });
 
   it("shows the Resource section with keys and values when resource is set", () => {
-    const metric = makeMetric({
-      resource: { "service.name": "checkout", "service.version": "1.2.3" },
-      dataPoints: [makeDataPoint({ id: "dp-a", attributes: { k: "v" } })],
-    });
+    const dp = makeDataPoint({ id: "dp-a", attributes: { k: "v" } });
 
-    render(<DataPointsTable metric={metric} />);
-    fireEvent.click(attrRow('k="v"'));
+    render(
+      <DataPointDetail
+        dp={dp}
+        resource={{ "service.name": "checkout", "service.version": "1.2.3" }}
+        unit=""
+        isDistribution={false}
+      />,
+    );
 
-    expect(resourceHeading()).toBeTruthy();
+    expect(screen.getByRole("heading", { level: 4, name: "Resource" })).toBeTruthy();
     expect(screen.getByText("service.name")).toBeTruthy();
     expect(screen.getByText("checkout")).toBeTruthy();
     expect(screen.getByText("service.version")).toBeTruthy();
     expect(screen.getByText("1.2.3")).toBeTruthy();
   });
 
-  it("hides the Attributes section when the expanded data point has no attributes", () => {
-    const metric = makeMetric({
-      resource: { "service.name": "checkout" },
-      dataPoints: [makeDataPoint({ id: "dp-a", attributes: {} })],
+  it("shows Count/Sum/Min/Max for distribution metrics, omitting null fields", () => {
+    const dp = makeDataPoint({
+      id: "dp-a",
+      value: 12.5,
+      count: 10,
+      sum: 125,
+      min: null,
+      max: 20,
     });
 
-    render(<DataPointsTable metric={metric} />);
-    const bodyRow = document.querySelector("tbody tr")!;
-    fireEvent.click(bodyRow);
+    render(<DataPointDetail dp={dp} resource={{}} unit="" isDistribution={true} />);
 
-    expect(attributesHeading()).toBeNull();
-    expect(resourceHeading()).toBeTruthy();
+    expect(screen.getByText("Count")).toBeTruthy();
+    expect(screen.getByText("10")).toBeTruthy();
+    expect(screen.getByText("Sum")).toBeTruthy();
+    expect(screen.getByText("Max")).toBeTruthy();
+    expect(screen.queryByText("Min")).toBeNull();
+  });
+
+  it("does not show distribution fields for non-distribution metrics", () => {
+    const dp = makeDataPoint({ id: "dp-a", value: 1, count: 10, sum: 5, min: 1, max: 2 });
+
+    render(<DataPointDetail dp={dp} resource={{}} unit="" isDistribution={false} />);
+
+    expect(screen.queryByText("Count")).toBeNull();
+    expect(screen.queryByText("Sum")).toBeNull();
+    expect(screen.queryByText("Min")).toBeNull();
+    expect(screen.queryByText("Max")).toBeNull();
   });
 });

--- a/frontend/src/components/metrics/metric-detail.tsx
+++ b/frontend/src/components/metrics/metric-detail.tsx
@@ -1,14 +1,17 @@
-import { Fragment, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
+import { X } from "lucide-react";
 import { selectedMetricAtom } from "@/stores/telemetry";
 import { MetricChart } from "./metric-chart";
 import { MetricSummary } from "./metric-summary";
 import { attrKey } from "@/lib/metric-stats";
+import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { DetailPanel } from "@/components/common/detail-panel";
 import { Pill } from "@/components/common/pill";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { KVSection } from "@/components/ui/kv-section";
+import { Field } from "@/components/common/detail-field";
 import {
   facetId,
   isDistributionMetric,
@@ -17,6 +20,7 @@ import {
   type MetricFacet,
 } from "@/lib/metric-catalog";
 import { formatMetricValue } from "@/lib/format-metric";
+import { formatTimestamp } from "@/lib/format";
 import type { DataPoint, MetricData } from "@/types/telemetry";
 
 const ALL_FACET = "__all__";
@@ -88,49 +92,82 @@ function MetricDetailBody({ metric }: { metric: MetricData }) {
   const tabValue =
     pickedId === ALL_FACET ? ALL_FACET : effectiveFacet ? facetId(effectiveFacet) : ALL_FACET;
 
-  return (
-    <ScrollArea className="min-h-0 flex-1">
-      <div className="p-4">
-        {metric.description && (
-          <p className="mb-4 text-sm text-muted-foreground">{metric.description}</p>
-        )}
+  // dataPoints is a ring buffer, so a previously selected id can be evicted;
+  // resolving against the live array (rather than storing the DataPoint
+  // itself) lets the sidebar disappear automatically once that happens.
+  const [selectedDpId, setSelectedDpId] = useState<string | null>(null);
+  const selectedDp = metric.dataPoints.find((dp) => dp.id === selectedDpId) ?? null;
 
-        <div className="mb-3 flex items-center gap-3">
-          <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-            Breakdown
-          </span>
-          <Tabs value={tabValue} onValueChange={setPickedId}>
-            <TabsList className="h-8 bg-muted/50">
-              {facets.map((f) => (
+  return (
+    <div className="flex flex-1 overflow-hidden">
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="p-4">
+          {metric.description && (
+            <p className="mb-4 text-sm text-muted-foreground">{metric.description}</p>
+          )}
+
+          <div className="mb-3 flex items-center gap-3">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Breakdown
+            </span>
+            <Tabs value={tabValue} onValueChange={setPickedId}>
+              <TabsList className="h-8 bg-muted/50">
+                {facets.map((f) => (
+                  <TabsTrigger
+                    key={facetId(f)}
+                    value={facetId(f)}
+                    className="h-7 px-3 text-xs data-active:bg-metric/15 data-active:text-metric"
+                  >
+                    {f.label}
+                  </TabsTrigger>
+                ))}
                 <TabsTrigger
-                  key={facetId(f)}
-                  value={facetId(f)}
+                  value={ALL_FACET}
                   className="h-7 px-3 text-xs data-active:bg-metric/15 data-active:text-metric"
                 >
-                  {f.label}
+                  All
                 </TabsTrigger>
-              ))}
-              <TabsTrigger
-                value={ALL_FACET}
-                className="h-7 px-3 text-xs data-active:bg-metric/15 data-active:text-metric"
-              >
-                All
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
+              </TabsList>
+            </Tabs>
+          </div>
+
+          <MetricSummary metric={metric} facet={effectiveFacet} />
+
+          <div className="mb-4 rounded-lg border border-border/30 bg-muted/50 p-4">
+            <div className="h-[300px]">
+              <MetricChart metric={metric} facet={effectiveFacet} />
+            </div>
+          </div>
+
+          {metric.dataPoints.length > 0 && (
+            <DataPointsTable metric={metric} selectedId={selectedDpId} onSelect={setSelectedDpId} />
+          )}
         </div>
-
-        <MetricSummary metric={metric} facet={effectiveFacet} />
-
-        <div className="mb-4 rounded-lg border border-border/30 bg-muted/50 p-4">
-          <div className="h-[300px]">
-            <MetricChart metric={metric} facet={effectiveFacet} />
+      </ScrollArea>
+      {selectedDp && (
+        <div className="w-[420px] border-l border-border/50">
+          <div className="flex h-full flex-col">
+            <div className="flex items-center justify-between border-b border-border/50 px-4 py-2">
+              <h3 className="text-sm font-semibold text-metric">Data Point Details</h3>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => setSelectedDpId(null)}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </div>
+            <DataPointDetail
+              dp={selectedDp}
+              resource={metric.resource}
+              unit={resolveMetricUnit(metric.name, metric.unit)}
+              isDistribution={isDistributionMetric(metric.type)}
+            />
           </div>
         </div>
-
-        {metric.dataPoints.length > 0 && <DataPointsTable metric={metric} />}
-      </div>
-    </ScrollArea>
+      )}
+    </div>
   );
 }
 
@@ -142,12 +179,18 @@ function formatDistributionCell(v: number | null | undefined, unit: string): str
   return v != null ? formatMetricValue(v, unit) : "-";
 }
 
-export function DataPointsTable({ metric }: { metric: MetricData }) {
+export function DataPointsTable({
+  metric,
+  selectedId,
+  onSelect,
+}: {
+  metric: MetricData;
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+}) {
   const hasAttributes = metric.dataPoints.some((dp) => Object.keys(dp.attributes).length > 0);
   const isDistribution = isDistributionMetric(metric.type);
   const unit = resolveMetricUnit(metric.name, metric.unit);
-  const [expandedId, setExpandedId] = useState<string | null>(null);
-  const cols = 1 + (hasAttributes ? 1 : 0) + 1 + (isDistribution ? 4 : 0);
 
   return (
     <div>
@@ -173,43 +216,35 @@ export function DataPointsTable({ metric }: { metric: MetricData }) {
           </thead>
           <tbody>
             {[...metric.dataPoints].reverse().map((dp) => {
-              const isExpanded = expandedId === dp.id;
+              const isSelected = selectedId === dp.id;
               return (
-                <Fragment key={dp.id}>
-                  <tr
-                    className="cursor-pointer border-b border-border/20 last:border-0 transition-colors hover:bg-metric/5"
-                    onClick={() => setExpandedId(isExpanded ? null : dp.id)}
-                  >
-                    <td className="px-3 py-1.5 font-mono text-muted-foreground">
-                      {new Date(dp.timestamp).toLocaleTimeString()}
+                <tr
+                  key={dp.id}
+                  className={`cursor-pointer border-b border-border/20 last:border-0 transition-colors hover:bg-metric/5 ${isSelected ? "bg-metric/10" : ""}`}
+                  onClick={() => onSelect(isSelected ? null : dp.id)}
+                >
+                  <td className="px-3 py-1.5 font-mono text-muted-foreground">
+                    {new Date(dp.timestamp).toLocaleTimeString()}
+                  </td>
+                  {hasAttributes && (
+                    <td className="max-w-[250px] truncate px-3 py-1.5 font-mono text-foreground/60">
+                      {attrKey(dp.attributes) || "-"}
                     </td>
-                    {hasAttributes && (
-                      <td className="max-w-[250px] truncate px-3 py-1.5 font-mono text-foreground/60">
-                        {attrKey(dp.attributes) || "-"}
-                      </td>
-                    )}
-                    <td className="px-3 py-1.5 text-right font-mono text-metric">
-                      {formatMetricValue(dp.value, unit)}
-                    </td>
-                    {isDistribution && (
-                      <>
-                        <td className={numCellCls}>
-                          {dp.count != null ? dp.count.toLocaleString() : "-"}
-                        </td>
-                        <td className={numCellCls}>{formatDistributionCell(dp.sum, unit)}</td>
-                        <td className={numCellCls}>{formatDistributionCell(dp.min, unit)}</td>
-                        <td className={numCellCls}>{formatDistributionCell(dp.max, unit)}</td>
-                      </>
-                    )}
-                  </tr>
-                  {isExpanded && (
-                    <tr>
-                      <td colSpan={cols} className="whitespace-normal bg-card/30 p-0">
-                        <DataPointDetail dp={dp} resource={metric.resource} />
-                      </td>
-                    </tr>
                   )}
-                </Fragment>
+                  <td className="px-3 py-1.5 text-right font-mono text-metric">
+                    {formatMetricValue(dp.value, unit)}
+                  </td>
+                  {isDistribution && (
+                    <>
+                      <td className={numCellCls}>
+                        {dp.count != null ? dp.count.toLocaleString() : "-"}
+                      </td>
+                      <td className={numCellCls}>{formatDistributionCell(dp.sum, unit)}</td>
+                      <td className={numCellCls}>{formatDistributionCell(dp.min, unit)}</td>
+                      <td className={numCellCls}>{formatDistributionCell(dp.max, unit)}</td>
+                    </>
+                  )}
+                </tr>
               );
             })}
           </tbody>
@@ -219,11 +254,40 @@ export function DataPointsTable({ metric }: { metric: MetricData }) {
   );
 }
 
-function DataPointDetail({ dp, resource }: { dp: DataPoint; resource: Record<string, unknown> }) {
+export function DataPointDetail({
+  dp,
+  resource,
+  unit,
+  isDistribution,
+}: {
+  dp: DataPoint;
+  resource: Record<string, unknown>;
+  unit: string;
+  isDistribution: boolean;
+}) {
   return (
-    <div className="animate-slide-up-fade space-y-3 px-4 py-3">
-      <KVSection title="Attributes" data={dp.attributes} />
-      <KVSection title="Resource" data={resource} />
-    </div>
+    <ScrollArea className="min-h-0 flex-1">
+      <div className="animate-slide-up-fade space-y-5 p-4">
+        <div className="space-y-2.5">
+          <Field label="Timestamp" value={formatTimestamp(dp.timestamp)} mono />
+          <Field label="Value" mono value={formatMetricValue(dp.value, unit)} tone="metric" />
+          {isDistribution && dp.count != null && (
+            <Field label="Count" value={dp.count.toLocaleString()} mono />
+          )}
+          {isDistribution && dp.sum != null && (
+            <Field label="Sum" value={formatMetricValue(dp.sum, unit)} mono />
+          )}
+          {isDistribution && dp.min != null && (
+            <Field label="Min" value={formatMetricValue(dp.min, unit)} mono />
+          )}
+          {isDistribution && dp.max != null && (
+            <Field label="Max" value={formatMetricValue(dp.max, unit)} mono />
+          )}
+        </div>
+
+        <KVSection title="Attributes" data={dp.attributes} />
+        <KVSection title="Resource" data={resource} />
+      </div>
+    </ScrollArea>
   );
 }

--- a/frontend/src/components/traces/trace-detail.tsx
+++ b/frontend/src/components/traces/trace-detail.tsx
@@ -10,6 +10,7 @@ import { SpanWaterfall } from "./span-waterfall";
 import { KVSection } from "@/components/ui/kv-section";
 import { DetailPanel } from "@/components/common/detail-panel";
 import { Pill } from "@/components/common/pill";
+import { Field, Section } from "@/components/common/detail-field";
 import type { SpanData } from "@/types/telemetry";
 import { useState } from "react";
 
@@ -97,7 +98,7 @@ function SpanDetail({ span, onClose }: { span: SpanData; onClose: () => void }) 
             <Field label="Kind" value={span.kind} />
             <Field label="Status" value={span.statusCode} />
             {span.statusMessage && <Field label="Message" value={span.statusMessage} />}
-            <Field label="Duration" value={formatDuration(span.duration)} mono highlight />
+            <Field label="Duration" value={formatDuration(span.duration)} mono tone="trace" />
           </div>
 
           <KVSection title="Attributes" data={span.attributes} />
@@ -115,40 +116,6 @@ function SpanDetail({ span, onClose }: { span: SpanData; onClose: () => void }) 
           <KVSection title="Resource" data={span.resource} />
         </div>
       </ScrollArea>
-    </div>
-  );
-}
-
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div>
-      <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-        {title}
-      </h4>
-      <div className="space-y-1.5 rounded-md bg-muted/50 p-2.5">{children}</div>
-    </div>
-  );
-}
-
-function Field({
-  label,
-  value,
-  mono,
-  highlight,
-}: {
-  label: string;
-  value: string;
-  mono?: boolean;
-  highlight?: boolean;
-}) {
-  return (
-    <div className="flex gap-2 text-sm">
-      <dt className="w-20 shrink-0 text-muted-foreground">{label}</dt>
-      <dd
-        className={`break-all ${mono ? "font-mono text-xs leading-5" : ""} ${highlight ? "text-trace font-semibold" : ""}`}
-      >
-        {value}
-      </dd>
     </div>
   );
 }

--- a/frontend/src/stores/navigation.test.ts
+++ b/frontend/src/stores/navigation.test.ts
@@ -5,13 +5,14 @@ import {
   applyLocationAtom,
   buildPath,
   parsePath,
+  selectedLogIdAtom,
   selectedMetricKeyAtom,
   selectedTraceIdAtom,
 } from "./navigation";
 
 describe("parsePath", () => {
   it("maps the root path to traces with no selection", () => {
-    expect(parsePath("/")).toEqual({ tab: "traces", traceId: null, metricKey: null });
+    expect(parsePath("/")).toEqual({ tab: "traces", traceId: null, metricKey: null, logId: null });
   });
 
   it("maps signal paths to their tabs", () => {
@@ -21,7 +22,12 @@ describe("parsePath", () => {
   });
 
   it("tolerates trailing segments and slashes", () => {
-    expect(parsePath("/metrics/")).toEqual({ tab: "metrics", traceId: null, metricKey: null });
+    expect(parsePath("/metrics/")).toEqual({
+      tab: "metrics",
+      traceId: null,
+      metricKey: null,
+      logId: null,
+    });
   });
 
   it("falls back to traces for unknown paths", () => {
@@ -33,6 +39,7 @@ describe("parsePath", () => {
       tab: "traces",
       traceId: "abc123",
       metricKey: null,
+      logId: null,
     });
   });
 
@@ -42,7 +49,9 @@ describe("parsePath", () => {
 
   it("ignores a trailing segment on other tabs", () => {
     expect(parsePath("/metrics/svc").metricKey).toBeNull();
+    expect(parsePath("/traces/whatever").metricKey).toBeNull();
     expect(parsePath("/logs/whatever").traceId).toBeNull();
+    expect(parsePath("/logs/whatever").metricKey).toBeNull();
   });
 
   it("extracts a decoded metricKey only when both segments are present", () => {
@@ -50,6 +59,7 @@ describe("parsePath", () => {
       tab: "metrics",
       traceId: null,
       metricKey: { serviceName: "svc", name: "cpu" },
+      logId: null,
     });
   });
 
@@ -57,40 +67,96 @@ describe("parsePath", () => {
     const parsed = parsePath("/metrics/svc%2Fwith%20slash/cpu.usage");
     expect(parsed.metricKey).toEqual({ serviceName: "svc/with slash", name: "cpu.usage" });
   });
+
+  it("extracts a decoded logId under /logs", () => {
+    expect(parsePath("/logs/log-1")).toEqual({
+      tab: "logs",
+      traceId: null,
+      metricKey: null,
+      logId: "log-1",
+    });
+  });
+
+  it("decodes an encoded logId", () => {
+    expect(parsePath("/logs/a%2Fb").logId).toBe("a/b");
+  });
 });
 
 describe("buildPath", () => {
   it("builds a bare tab path with no selection", () => {
-    expect(buildPath("traces", null, null)).toBe("/traces");
-    expect(buildPath("metrics", null, null)).toBe("/metrics");
-    expect(buildPath("logs", null, null)).toBe("/logs");
+    expect(buildPath({ tab: "traces", traceId: null, metricKey: null, logId: null })).toBe(
+      "/traces",
+    );
+    expect(buildPath({ tab: "metrics", traceId: null, metricKey: null, logId: null })).toBe(
+      "/metrics",
+    );
+    expect(buildPath({ tab: "logs", traceId: null, metricKey: null, logId: null })).toBe("/logs");
   });
 
   it("builds a trace detail path, encoding the traceId", () => {
-    expect(buildPath("traces", "a/b", null)).toBe("/traces/a%2Fb");
+    expect(buildPath({ tab: "traces", traceId: "a/b", metricKey: null, logId: null })).toBe(
+      "/traces/a%2Fb",
+    );
   });
 
   it("builds a metric detail path, encoding both segments", () => {
-    expect(buildPath("metrics", null, { serviceName: "svc/with slash", name: "cpu.usage" })).toBe(
-      "/metrics/svc%2Fwith%20slash/cpu.usage",
+    expect(
+      buildPath({
+        tab: "metrics",
+        traceId: null,
+        metricKey: { serviceName: "svc/with slash", name: "cpu.usage" },
+        logId: null,
+      }),
+    ).toBe("/metrics/svc%2Fwith%20slash/cpu.usage");
+  });
+
+  it("builds a log detail path, encoding the logId", () => {
+    expect(buildPath({ tab: "logs", traceId: null, metricKey: null, logId: "a/b" })).toBe(
+      "/logs/a%2Fb",
     );
   });
 
   it("ignores a traceId when the tab is not traces", () => {
-    expect(buildPath("metrics", "abc", null)).toBe("/metrics");
+    expect(buildPath({ tab: "metrics", traceId: "abc", metricKey: null, logId: null })).toBe(
+      "/metrics",
+    );
   });
 
   it("ignores a metricKey when the tab is not metrics", () => {
-    expect(buildPath("traces", null, { serviceName: "svc", name: "cpu" })).toBe("/traces");
+    expect(
+      buildPath({
+        tab: "traces",
+        traceId: null,
+        metricKey: { serviceName: "svc", name: "cpu" },
+        logId: null,
+      }),
+    ).toBe("/traces");
+  });
+
+  it("ignores a logId when the tab is not logs", () => {
+    expect(buildPath({ tab: "traces", traceId: null, metricKey: null, logId: "l1" })).toBe(
+      "/traces",
+    );
   });
 
   it("round-trips through parsePath, including characters needing encoding", () => {
-    const path = buildPath("metrics", null, { serviceName: "svc/with slash", name: "cpu.usage" });
+    const path = buildPath({
+      tab: "metrics",
+      traceId: null,
+      metricKey: { serviceName: "svc/with slash", name: "cpu.usage" },
+      logId: null,
+    });
     expect(parsePath(path)).toEqual({
       tab: "metrics",
       traceId: null,
       metricKey: { serviceName: "svc/with slash", name: "cpu.usage" },
+      logId: null,
     });
+  });
+
+  it("round-trips a logId through parsePath", () => {
+    const path = buildPath({ tab: "logs", traceId: null, metricKey: null, logId: "a/b" });
+    expect(parsePath(path)).toEqual({ tab: "logs", traceId: null, metricKey: null, logId: "a/b" });
   });
 });
 
@@ -129,9 +195,18 @@ describe("activeTabAtom", () => {
     store.set(activeTabAtom, "traces");
     expect(window.location.pathname).toBe("/traces/t1");
   });
+
+  it("includes the selected log when returning to the logs tab", () => {
+    const store = createStore();
+    store.set(activeTabAtom, "logs");
+    store.set(selectedLogIdAtom, "log-1");
+    store.set(activeTabAtom, "metrics");
+    store.set(activeTabAtom, "logs");
+    expect(window.location.pathname).toBe("/logs/log-1");
+  });
 });
 
-describe("selectedTraceIdAtom / selectedMetricKeyAtom (write-through)", () => {
+describe("selectedTraceIdAtom / selectedMetricKeyAtom / selectedLogIdAtom (write-through)", () => {
   beforeEach(() => {
     window.history.replaceState(null, "", "/");
   });
@@ -165,6 +240,22 @@ describe("selectedTraceIdAtom / selectedMetricKeyAtom (write-through)", () => {
     store.set(selectedMetricKeyAtom, { serviceName: "svc", name: "cpu" });
     expect(window.location.pathname).toBe("/somewhere-else");
   });
+
+  it("pushes the URL when the logId changes", () => {
+    const store = createStore();
+    store.set(activeTabAtom, "logs");
+    store.set(selectedLogIdAtom, "log-1");
+    expect(window.location.pathname).toBe("/logs/log-1");
+  });
+
+  it("does not push when set to the same logId", () => {
+    const store = createStore();
+    store.set(activeTabAtom, "logs");
+    store.set(selectedLogIdAtom, "log-1");
+    window.history.replaceState(null, "", "/somewhere-else");
+    store.set(selectedLogIdAtom, "log-1");
+    expect(window.location.pathname).toBe("/somewhere-else");
+  });
 });
 
 describe("applyLocationAtom", () => {
@@ -179,6 +270,13 @@ describe("applyLocationAtom", () => {
     expect(store.get(selectedTraceIdAtom)).toBe("t1");
   });
 
+  it("applies the tab and, for logs, the selected logId", () => {
+    const store = createStore();
+    store.set(applyLocationAtom, "/logs/log-1");
+    expect(store.get(activeTabAtom)).toBe("logs");
+    expect(store.get(selectedLogIdAtom)).toBe("log-1");
+  });
+
   it("keeps the traceId selection when switching to a different tab", () => {
     const store = createStore();
     store.set(applyLocationAtom, "/traces/t1");
@@ -188,11 +286,26 @@ describe("applyLocationAtom", () => {
     expect(store.get(selectedTraceIdAtom)).toBe("t1");
   });
 
+  it("keeps the logId selection when switching to a different tab", () => {
+    const store = createStore();
+    store.set(applyLocationAtom, "/logs/log-1");
+    store.set(applyLocationAtom, "/metrics/svc/cpu");
+    expect(store.get(activeTabAtom)).toBe("metrics");
+    expect(store.get(selectedLogIdAtom)).toBe("log-1");
+  });
+
   it("clears the traceId when the applied traces path has no selection", () => {
     const store = createStore();
     store.set(applyLocationAtom, "/traces/t1");
     store.set(applyLocationAtom, "/traces");
     expect(store.get(selectedTraceIdAtom)).toBeNull();
+  });
+
+  it("clears the logId when the applied logs path has no selection", () => {
+    const store = createStore();
+    store.set(applyLocationAtom, "/logs/log-1");
+    store.set(applyLocationAtom, "/logs");
+    expect(store.get(selectedLogIdAtom)).toBeNull();
   });
 
   it("does not push to history", () => {

--- a/frontend/src/stores/navigation.ts
+++ b/frontend/src/stores/navigation.ts
@@ -14,10 +14,11 @@ interface ParsedLocation {
   tab: TabValue;
   traceId: string | null;
   metricKey: MetricKey | null;
+  logId: string | null;
 }
 
 // Only the tab of the currently active screen is meaningful in the path; a
-// traceId/metricKey segment left over from another tab is ignored.
+// traceId/metricKey/logId segment left over from another tab is ignored.
 export function parsePath(pathname: string): ParsedLocation {
   const [first, second, third] = pathname.split("/").filter(Boolean);
   const tab: TabValue = first && first in SIGNALS ? (first as TabValue) : "traces";
@@ -29,18 +30,19 @@ export function parsePath(pathname: string): ParsedLocation {
       tab === "metrics" && second && third
         ? { serviceName: decodeURIComponent(second), name: decodeURIComponent(third) }
         : null,
+    logId: tab === "logs" && second ? decodeURIComponent(second) : null,
   };
 }
 
-export function buildPath(
-  tab: TabValue,
-  traceId: string | null,
-  metricKey: MetricKey | null,
-): string {
+// Takes a full ParsedLocation (rather than positional args) so it stays
+// symmetric with parsePath as more selection kinds are added.
+export function buildPath(location: ParsedLocation): string {
+  const { tab, traceId, metricKey, logId } = location;
   if (tab === "traces" && traceId) return `/traces/${encodeURIComponent(traceId)}`;
   if (tab === "metrics" && metricKey) {
     return `/metrics/${encodeURIComponent(metricKey.serviceName)}/${encodeURIComponent(metricKey.name)}`;
   }
+  if (tab === "logs" && logId) return `/logs/${encodeURIComponent(logId)}`;
   return `/${tab}`;
 }
 
@@ -56,22 +58,25 @@ const currentTabAtom = atom<TabValue>(initialLocation.tab);
 
 const selectedTraceIdBaseAtom = atom<string | null>(initialLocation.traceId);
 const selectedMetricKeyBaseAtom = atom<MetricKey | null>(initialLocation.metricKey);
+const selectedLogIdBaseAtom = atom<string | null>(initialLocation.logId);
 
 // Shared by every public writer so the URL always reflects the current
 // tab + selection as a single pushState, and unchanged state never pushes.
 function syncLocation(get: Getter): void {
-  const path = buildPath(
-    get(currentTabAtom),
-    get(selectedTraceIdBaseAtom),
-    get(selectedMetricKeyBaseAtom),
-  );
+  const path = buildPath({
+    tab: get(currentTabAtom),
+    traceId: get(selectedTraceIdBaseAtom),
+    metricKey: get(selectedMetricKeyBaseAtom),
+    logId: get(selectedLogIdBaseAtom),
+  });
   if (window.location.pathname !== path) {
     window.history.pushState(null, "", path);
   }
 }
 
 // Write-through atoms: writing the id/key also syncs the URL, so callers
-// (telemetry.ts's selectedTraceAtom/selectedMetricAtom) can't forget to.
+// (telemetry.ts's selectedTraceAtom/selectedMetricAtom/selectedLogAtom) can't
+// forget to.
 export const selectedTraceIdAtom = atom(
   (get) => get(selectedTraceIdBaseAtom),
   (get, set, traceId: string | null) => {
@@ -86,6 +91,15 @@ export const selectedMetricKeyAtom = atom(
   (get, set, metricKey: MetricKey | null) => {
     if (metricKeyEquals(get(selectedMetricKeyBaseAtom), metricKey)) return;
     set(selectedMetricKeyBaseAtom, metricKey);
+    syncLocation(get);
+  },
+);
+
+export const selectedLogIdAtom = atom(
+  (get) => get(selectedLogIdBaseAtom),
+  (get, set, logId: string | null) => {
+    if (get(selectedLogIdBaseAtom) === logId) return;
+    set(selectedLogIdBaseAtom, logId);
     syncLocation(get);
   },
 );
@@ -113,6 +127,9 @@ export const applyLocationAtom = atom(null, (_get, set, pathname: string) => {
   }
   if (parsed.tab === "metrics") {
     set(selectedMetricKeyBaseAtom, parsed.metricKey);
+  }
+  if (parsed.tab === "logs") {
+    set(selectedLogIdBaseAtom, parsed.logId);
   }
 });
 

--- a/frontend/src/stores/telemetry.test.ts
+++ b/frontend/src/stores/telemetry.test.ts
@@ -5,11 +5,13 @@ import {
   addMetricAtom,
   serverConfigAtom,
   tracesAtom,
+  logsAtom,
   selectedTraceAtom,
   selectedMetricAtom,
+  selectedLogAtom,
 } from "./telemetry";
-import { selectedTraceIdAtom, selectedMetricKeyAtom } from "./navigation";
-import { makeMetric, makeDataPoint, makeTrace } from "@/test/factories";
+import { selectedTraceIdAtom, selectedMetricKeyAtom, selectedLogIdAtom } from "./navigation";
+import { makeMetric, makeDataPoint, makeTrace, makeLog } from "@/test/factories";
 
 describe("addMetricAtom", () => {
   it("merges data points by id, dropping re-delivered duplicates", () => {
@@ -89,5 +91,30 @@ describe("selectedMetricAtom", () => {
 
     store.set(selectedMetricAtom, null);
     expect(store.get(selectedMetricKeyAtom)).toBeNull();
+  });
+});
+
+describe("selectedLogAtom", () => {
+  it("resolves once the matching log loads, restoring selection after a reload", () => {
+    const store = createStore();
+    // Simulate a reload where the URL already names a logId before the
+    // WebSocket/REST load has populated logsAtom.
+    store.set(selectedLogIdAtom, "log-1");
+    expect(store.get(selectedLogAtom)).toBeNull();
+
+    store.set(logsAtom, [makeLog({ id: "log-1" })]);
+    expect(store.get(selectedLogAtom)?.id).toBe("log-1");
+  });
+
+  it("setting the atom updates the shared logId used for URL sync", () => {
+    const store = createStore();
+    const log = makeLog({ id: "log-2" });
+    store.set(logsAtom, [log]);
+
+    store.set(selectedLogAtom, log);
+    expect(store.get(selectedLogIdAtom)).toBe("log-2");
+
+    store.set(selectedLogAtom, null);
+    expect(store.get(selectedLogIdAtom)).toBeNull();
   });
 });

--- a/frontend/src/stores/telemetry.ts
+++ b/frontend/src/stores/telemetry.ts
@@ -5,6 +5,7 @@ import type { TraceData, MetricData, LogData, SpanData, DataPoint } from "@/type
 import {
   activeTabAtom,
   metricKeyEquals,
+  selectedLogIdAtom,
   selectedMetricKeyAtom,
   selectedTraceIdAtom,
 } from "./navigation";
@@ -182,7 +183,12 @@ export const selectedMetricAtom = createSelectionAtom(
   metricKeyEquals,
 );
 
-export const selectedLogAtom = atom<LogData | null>(null);
+export const selectedLogAtom = createSelectionAtom(
+  selectedLogIdAtom,
+  logsAtom,
+  (l) => l.id,
+  (l, id) => l.id === id,
+);
 
 // Log filter by traceId (set when jumping from trace → logs)
 export const logTraceFilterAtom = atom<string | null>(null);


### PR DESCRIPTION
## Summary

- Replace the inline expand rows in the log list and the metric data points table with right sidebars, matching the trace screen's span detail panel, and share the `Field`/`Section` building blocks via `common/detail-field.tsx` (with a `tone` prop for per-signal highlight color)
- Sync the selected log to the URL as `/logs/<id>` using the same write-through atom pattern as traces/metrics, so reload and back/forward restore the selection; data point selection stays local state (same tier as span selection) and auto-closes when the point is evicted from the ring buffer

## Test plan

- [x] `mise run check` — format/lint/type-check clean
- [x] `mise run test` — Go tests and 136 frontend tests pass (added coverage for `/logs/<id>` parse/build/apply, `selectedLogAtom` URL restore, and `DataPointsTable`/`DataPointDetail` selection)
- [x] Verified against real data on the dev server in both light and dark mode: sidebar open/close, selected-row highlight, URL push on select and pop on close, reload restore of `/logs/<id>`, log→trace link navigation, and data point selection surviving live updates