### PR TITLE
chore(deps): group OpenTelemetry modules in renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -41,6 +41,16 @@
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",
     },
+    // OpenTelemetry Go modules release in lockstep (collector 1.x/0.x pairs,
+    // otel SDK and contrib instrumentation track each other). Group them so a
+    // collector bump lands as one PR instead of dominating the catch-all group.
+    {
+      "matchPackageNames": [
+        "go.opentelemetry.io/**",
+        "github.com/open-telemetry/**",
+      ],
+      "groupName": "opentelemetry-go",
+    },
     // The @voidzero-dev/vite-plus suite must move in lockstep: vite-plus-test
     // pins vite-plus-core to an exact version. Group them so a partial bump is
     // isolated in its own PR instead of breaking the whole non-major group.


### PR DESCRIPTION
## Summary

- Add a `packageRules` entry grouping all OpenTelemetry Go modules (`go.opentelemetry.io/**`, `github.com/open-telemetry/**`) into a dedicated `opentelemetry-go` Renovate group
- OpenTelemetry Go modules release in lockstep (collector 1.x/0.x pairs, otel SDK and contrib instrumentation track each other), so a collector bump now lands as one PR instead of dominating the catch-all non-major group

## Test plan

- [x] `npx renovate-config-validator renovate.json5` passes
- [x] `mise run check` / `mise run test` pass