### PR TITLE
feat(frontend): add time-range selector to metric detail chart

### DIFF
--- a/frontend/src/components/metrics/metric-chart.test.tsx
+++ b/frontend/src/components/metrics/metric-chart.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MetricChart } from "./metric-chart";
+import { makeDataPoint, makeMetric } from "@/test/factories";
+
+afterEach(cleanup);
+
+describe("MetricChart", () => {
+  it("renders a time-range selector with 1m/5m/15m/30m/1h/All, defaulting to All", () => {
+    const metric = makeMetric({
+      dataPoints: [makeDataPoint({ id: "dp-1", timestamp: "2024-01-01T00:00:00Z", value: 1 })],
+    });
+
+    render(<MetricChart metric={metric} />);
+
+    for (const label of ["1m", "5m", "15m", "30m", "1h", "All"]) {
+      expect(screen.getByRole("tab", { name: label })).toBeTruthy();
+    }
+    expect(screen.getByRole("tab", { name: "All" }).getAttribute("data-active")).not.toBeNull();
+  });
+
+  it("switches the selected range when a tab is clicked", () => {
+    const metric = makeMetric({
+      dataPoints: [makeDataPoint({ id: "dp-1", timestamp: "2024-01-01T00:00:00Z", value: 1 })],
+    });
+
+    render(<MetricChart metric={metric} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "5m" }));
+
+    expect(screen.getByRole("tab", { name: "5m" }).getAttribute("data-active")).not.toBeNull();
+    expect(screen.getByRole("tab", { name: "All" }).getAttribute("data-active")).toBeNull();
+  });
+});

--- a/frontend/src/components/metrics/metric-chart.tsx
+++ b/frontend/src/components/metrics/metric-chart.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleTime } from "@visx/scale";
 import { LinePath } from "@visx/shape";
@@ -10,6 +10,13 @@ import type { MetricData } from "@/types/telemetry";
 import { formatMetricValue } from "@/lib/format-metric";
 import { resolveMetricUnit, type MetricFacet } from "@/lib/metric-catalog";
 import { facetSeriesKey } from "@/lib/metric-stats";
+import {
+  CHART_TIME_RANGES,
+  filterPointsInDomain,
+  timeRangeDomain,
+  type ChartTimeRange,
+} from "@/lib/chart-time-range";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 const MARGIN = { top: 10, right: 20, bottom: 40, left: 72 };
 
@@ -70,18 +77,51 @@ function closestPoint(points: PointData[], targetMs: number): PointData | undefi
 }
 
 export function MetricChart({ metric, facet }: Props) {
+  const [range, setRange] = useState<ChartTimeRange>("all");
+
   return (
-    <ParentSize>
-      {({ width, height }) =>
-        width > 0 && height > 0 ? (
-          <ChartInner metric={metric} facet={facet} width={width} height={height} />
-        ) : null
-      }
-    </ParentSize>
+    <div className="flex h-full flex-col">
+      <div className="flex justify-end pb-1.5">
+        <Tabs value={range} onValueChange={(v) => setRange(v as ChartTimeRange)}>
+          <TabsList className="h-7 bg-muted/50">
+            {CHART_TIME_RANGES.map((r) => (
+              <TabsTrigger
+                key={r.value}
+                value={r.value}
+                className="h-6 px-2.5 text-xs data-active:bg-metric/15 data-active:text-metric"
+              >
+                {r.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+      <div className="min-h-0 flex-1">
+        <ParentSize>
+          {({ width, height }) =>
+            width > 0 && height > 0 ? (
+              <ChartInner
+                metric={metric}
+                facet={facet}
+                range={range}
+                width={width}
+                height={height}
+              />
+            ) : null
+          }
+        </ParentSize>
+      </div>
+    </div>
   );
 }
 
-function ChartInner({ metric, facet, width, height }: Props & { width: number; height: number }) {
+function ChartInner({
+  metric,
+  facet,
+  range,
+  width,
+  height,
+}: Props & { range: ChartTimeRange; width: number; height: number }) {
   const svgRef = useRef<SVGSVGElement>(null);
   const unit = resolveMetricUnit(metric.name, metric.unit);
 
@@ -107,29 +147,39 @@ function ChartInner({ metric, facet, width, height }: Props & { width: number; h
     return result;
   }, [metric.dataPoints, facet]);
 
+  // Kept unfiltered: the "No data points" branch reflects the raw metric,
+  // not the current time-range window.
   const allPoints = useMemo(() => series.flatMap((s) => s.points), [series]);
 
+  const domain = useMemo(() => timeRangeDomain(allPoints, range), [allPoints, range]);
+
+  const visibleSeries = useMemo(
+    () =>
+      domain
+        ? series.map((s) => ({ ...s, points: filterPointsInDomain(s.points, domain) }))
+        : series,
+    [series, domain],
+  );
+
+  const visiblePoints = useMemo(() => visibleSeries.flatMap((s) => s.points), [visibleSeries]);
+
+  // The legend row takes 28px out of the measured height; the axis must be
+  // laid out against the shrunken svg or its tick labels get clipped below it.
+  const showLegend = series.length > 1;
+  const svgHeight = showLegend ? height - 28 : height;
+
   const innerWidth = width - MARGIN.left - MARGIN.right;
-  const innerHeight = height - MARGIN.top - MARGIN.bottom;
+  const innerHeight = svgHeight - MARGIN.top - MARGIN.bottom;
 
   const xScale = useMemo(() => {
-    let minT = Infinity;
-    let maxT = -Infinity;
-    for (const p of allPoints) {
-      const t = p.time.getTime();
-      if (t < minT) minT = t;
-      if (t > maxT) maxT = t;
-    }
-    return scaleTime({
-      domain: Number.isFinite(minT) ? [new Date(minT), new Date(maxT)] : [new Date(), new Date()],
-      range: [0, innerWidth],
-    });
-  }, [allPoints, innerWidth]);
+    if (domain) return scaleTime({ domain, range: [0, innerWidth] });
+    return scaleTime({ domain: [new Date(), new Date()], range: [0, innerWidth] });
+  }, [domain, innerWidth]);
 
   const yScale = useMemo(() => {
     let min = 0;
     let max = 1;
-    for (const p of allPoints) {
+    for (const p of visiblePoints) {
       if (p.value < min) min = p.value;
       if (p.value > max) max = p.value;
     }
@@ -138,7 +188,7 @@ function ChartInner({ metric, facet, width, height }: Props & { width: number; h
       domain: [min - padding, max + padding],
       range: [innerHeight, 0],
     });
-  }, [allPoints, innerHeight]);
+  }, [visiblePoints, innerHeight]);
 
   const { showTooltip, hideTooltip, tooltipData, tooltipLeft, tooltipTop, tooltipOpen } =
     useTooltip<TooltipData>();
@@ -155,7 +205,7 @@ function ChartInner({ metric, facet, width, height }: Props & { width: number; h
       // Find the globally closest point, then collect all series at that timestamp.
       let nearestMs = 0;
       let nearestDist = Infinity;
-      for (const s of series) {
+      for (const s of visibleSeries) {
         const p = closestPoint(s.points, mouseTime);
         if (p) {
           const d = Math.abs(p.time.getTime() - mouseTime);
@@ -167,7 +217,7 @@ function ChartInner({ metric, facet, width, height }: Props & { width: number; h
       }
 
       const rows: TooltipRow[] = [];
-      for (const s of series) {
+      for (const s of visibleSeries) {
         const p = closestPoint(s.points, nearestMs);
         if (p) {
           rows.push({ label: s.label, color: s.color, value: p.value });
@@ -182,7 +232,7 @@ function ChartInner({ metric, facet, width, height }: Props & { width: number; h
         });
       }
     },
-    [series, xScale, showTooltip],
+    [visibleSeries, xScale, showTooltip],
   );
 
   if (allPoints.length === 0) {
@@ -193,8 +243,6 @@ function ChartInner({ metric, facet, width, height }: Props & { width: number; h
     );
   }
 
-  const showLegend = series.length > 1;
-  const svgHeight = showLegend ? height - 28 : height;
   const nearestMs = tooltipData?.time.getTime();
 
   return (
@@ -242,7 +290,7 @@ function ChartInner({ metric, facet, width, height }: Props & { width: number; h
           />
 
           {/* Lines and static points */}
-          {series.map((s) => (
+          {visibleSeries.map((s) => (
             <g key={s.key}>
               {s.points.length >= 2 && (
                 <LinePath
@@ -282,7 +330,7 @@ function ChartInner({ metric, facet, width, height }: Props & { width: number; h
                 opacity={0.4}
                 pointerEvents="none"
               />
-              {series.map((s) => {
+              {visibleSeries.map((s) => {
                 const p = closestPoint(s.points, nearestMs);
                 if (!p) return null;
                 return (

--- a/frontend/src/components/metrics/metric-detail.tsx
+++ b/frontend/src/components/metrics/metric-detail.tsx
@@ -134,7 +134,7 @@ function MetricDetailBody({ metric }: { metric: MetricData }) {
           <MetricSummary metric={metric} facet={effectiveFacet} />
 
           <div className="mb-4 rounded-lg border border-border/30 bg-muted/50 p-4">
-            <div className="h-[300px]">
+            <div className="h-[336px]">
               <MetricChart metric={metric} facet={effectiveFacet} />
             </div>
           </div>

--- a/frontend/src/lib/chart-time-range.test.ts
+++ b/frontend/src/lib/chart-time-range.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  CHART_TIME_RANGES,
+  rangeToMs,
+  timeRangeDomain,
+  filterPointsInDomain,
+  type ChartTimeRange,
+} from "./chart-time-range";
+
+describe("CHART_TIME_RANGES", () => {
+  it("lists 1m, 5m, 15m, 30m, 1h, all with an All label", () => {
+    expect(CHART_TIME_RANGES).toEqual([
+      { value: "1m", label: "1m" },
+      { value: "5m", label: "5m" },
+      { value: "15m", label: "15m" },
+      { value: "30m", label: "30m" },
+      { value: "1h", label: "1h" },
+      { value: "all", label: "All" },
+    ]);
+  });
+});
+
+describe("rangeToMs", () => {
+  it("returns null for all", () => {
+    expect(rangeToMs("all")).toBeNull();
+  });
+
+  it("converts minutes to milliseconds", () => {
+    expect(rangeToMs("1m")).toBe(60_000);
+    expect(rangeToMs("5m")).toBe(5 * 60_000);
+    expect(rangeToMs("15m")).toBe(15 * 60_000);
+    expect(rangeToMs("30m")).toBe(30 * 60_000);
+    expect(rangeToMs("1h")).toBe(60 * 60_000);
+  });
+});
+
+describe("timeRangeDomain", () => {
+  it("returns null when there are no points", () => {
+    expect(timeRangeDomain([], "all")).toBeNull();
+  });
+
+  it("fits min/max for all", () => {
+    const points = [
+      { time: new Date("2024-01-01T00:00:00Z") },
+      { time: new Date("2024-01-01T00:10:00Z") },
+      { time: new Date("2024-01-01T00:05:00Z") },
+    ];
+
+    const domain = timeRangeDomain(points, "all");
+
+    expect(domain).toEqual([new Date("2024-01-01T00:00:00Z"), new Date("2024-01-01T00:10:00Z")]);
+  });
+
+  it("anchors on the max data timestamp, not wall-clock, and ignores min", () => {
+    const points = [
+      { time: new Date("2024-01-01T00:00:00Z") },
+      { time: new Date("2024-01-01T00:20:00Z") },
+    ];
+
+    const domain = timeRangeDomain(points, "5m");
+
+    expect(domain).toEqual([new Date("2024-01-01T00:15:00Z"), new Date("2024-01-01T00:20:00Z")]);
+  });
+
+  it.each<ChartTimeRange>(["1m", "15m"])(
+    "computes a %s window ending at the max timestamp",
+    (range) => {
+      const max = new Date("2024-01-01T00:30:00Z");
+      const points = [{ time: new Date("2024-01-01T00:00:00Z") }, { time: max }];
+
+      const domain = timeRangeDomain(points, range);
+
+      expect(domain?.[1]).toEqual(max);
+      expect(domain?.[0]).toEqual(new Date(max.getTime() - rangeToMs(range)!));
+    },
+  );
+});
+
+describe("filterPointsInDomain", () => {
+  const domain: [Date, Date] = [new Date("2024-01-01T00:05:00Z"), new Date("2024-01-01T00:10:00Z")];
+
+  it("includes points on the domain boundary (inclusive)", () => {
+    const points = [{ time: domain[0] }, { time: domain[1] }];
+
+    expect(filterPointsInDomain(points, domain)).toEqual(points);
+  });
+
+  it("excludes points outside the domain", () => {
+    const before = { time: new Date("2024-01-01T00:00:00Z") };
+    const inside = { time: new Date("2024-01-01T00:07:00Z") };
+    const after = { time: new Date("2024-01-01T00:15:00Z") };
+
+    expect(filterPointsInDomain([before, inside, after], domain)).toEqual([inside]);
+  });
+
+  it("preserves extra fields on the filtered items", () => {
+    const points = [{ time: new Date("2024-01-01T00:07:00Z"), value: 42 }];
+
+    expect(filterPointsInDomain(points, domain)).toEqual([{ time: points[0]!.time, value: 42 }]);
+  });
+});

--- a/frontend/src/lib/chart-time-range.ts
+++ b/frontend/src/lib/chart-time-range.ts
@@ -1,0 +1,58 @@
+export type ChartTimeRange = "1m" | "5m" | "15m" | "30m" | "1h" | "all";
+
+export const CHART_TIME_RANGES: { value: ChartTimeRange; label: string }[] = [
+  { value: "1m", label: "1m" },
+  { value: "5m", label: "5m" },
+  { value: "15m", label: "15m" },
+  { value: "30m", label: "30m" },
+  { value: "1h", label: "1h" },
+  { value: "all", label: "All" },
+];
+
+const RANGE_MINUTES: Record<Exclude<ChartTimeRange, "all">, number> = {
+  "1m": 1,
+  "5m": 5,
+  "15m": 15,
+  "30m": 30,
+  "1h": 60,
+};
+
+export function rangeToMs(range: ChartTimeRange): number | null {
+  if (range === "all") return null;
+  return RANGE_MINUTES[range] * 60_000;
+}
+
+// Anchored on the max data timestamp (not Date.now()) so the chart keeps
+// showing the last window of data instead of going blank once data stops
+// arriving.
+export function timeRangeDomain(
+  points: { time: Date }[],
+  range: ChartTimeRange,
+): [Date, Date] | null {
+  if (points.length === 0) return null;
+
+  let minMs = Infinity;
+  let maxMs = -Infinity;
+  for (const p of points) {
+    const t = p.time.getTime();
+    if (t < minMs) minMs = t;
+    if (t > maxMs) maxMs = t;
+  }
+
+  const rangeMs = rangeToMs(range);
+  if (rangeMs === null) return [new Date(minMs), new Date(maxMs)];
+  return [new Date(maxMs - rangeMs), new Date(maxMs)];
+}
+
+export function filterPointsInDomain<T extends { time: Date }>(
+  points: T[],
+  domain: [Date, Date],
+): T[] {
+  const [start, end] = domain;
+  const startMs = start.getTime();
+  const endMs = end.getTime();
+  return points.filter((p) => {
+    const t = p.time.getTime();
+    return t >= startMs && t <= endMs;
+  });
+}


### PR DESCRIPTION
## Summary

Adds a time-range selector (1m / 5m / 15m / 30m / 1h / All) to the metric detail chart so recent activity can be zoomed into instead of always fitting the entire retained history.

- The window anchors on the newest data point timestamp (not wall-clock), so the chart keeps showing the last window of data when telemetry stops flowing
- The x-axis domain is pinned to the selected window; the y-axis rescales to the points visible in that window
- Range state is chart-local, defaulting to All (previous behavior); the selector reuses the same shadcn Tabs pattern as the Breakdown tabs
- Window/domain math lives in pure functions in `lib/chart-time-range.ts` with unit tests
- Presets stop at 1h because retention is 1000 data points per series (~2.8h at a 10s interval)

Also fixes a pre-existing bug where x-axis tick labels were invisible on multi-series charts: the legend row shrinks the svg by 28px, but the axis was laid out against the unshrunken height, pushing the tick labels below the svg bounds.

## Test plan

- [x] `mise run check` and `mise run test` pass (149 frontend tests, incl. new unit tests for range math and the selector component)
- [x] Verified against live data (`go.memory.allocated`, 450+ points): each preset pins the x-axis to the expected window and the y-axis rescales immediately on switching
- [x] Verified x-axis tick labels now render on a multi-series chart with legend (`claude_code.commit.count` broken down by session.id)
- [x] Checked both light and dark mode