### PR TITLE
feat(frontend): add 3h and 12h time range options

### DIFF
--- a/frontend/src/lib/chart-time-range.test.ts
+++ b/frontend/src/lib/chart-time-range.test.ts
@@ -14,14 +14,16 @@ import {
 } from "./chart-time-range";
 
 describe("CHART_TIME_RANGES", () => {
-  it("lists 1m, 5m, 15m, 30m, 1h, 6h, 24h, all with an All label", () => {
+  it("lists 1m, 5m, 15m, 30m, 1h, 3h, 6h, 12h, 24h, all with an All label", () => {
     expect(CHART_TIME_RANGES).toEqual([
       { value: "1m", label: "1m" },
       { value: "5m", label: "5m" },
       { value: "15m", label: "15m" },
       { value: "30m", label: "30m" },
       { value: "1h", label: "1h" },
+      { value: "3h", label: "3h" },
       { value: "6h", label: "6h" },
+      { value: "12h", label: "12h" },
       { value: "24h", label: "24h" },
       { value: "all", label: "All" },
     ]);
@@ -39,7 +41,9 @@ describe("rangeToMs", () => {
     expect(rangeToMs("15m")).toBe(15 * 60_000);
     expect(rangeToMs("30m")).toBe(30 * 60_000);
     expect(rangeToMs("1h")).toBe(60 * 60_000);
+    expect(rangeToMs("3h")).toBe(3 * 60 * 60_000);
     expect(rangeToMs("6h")).toBe(6 * 60 * 60_000);
+    expect(rangeToMs("12h")).toBe(12 * 60 * 60_000);
     expect(rangeToMs("24h")).toBe(24 * 60 * 60_000);
   });
 });
@@ -49,7 +53,7 @@ describe("rangeToFrom", () => {
     expect(rangeToFrom("all")).toBeUndefined();
   });
 
-  it.each<ChartTimeRange>(["1m", "5m", "15m", "30m", "1h", "6h", "24h"])(
+  it.each<ChartTimeRange>(["1m", "5m", "15m", "30m", "1h", "3h", "6h", "12h", "24h"])(
     "subtracts the %s window from now",
     (range) => {
       const before = Temporal.Now.instant();
@@ -113,8 +117,12 @@ describe("bucketSecondsForRange", () => {
     expect(bucketSecondsForRange("1h")).toBe(24);
     // 5m / 150 = 2s.
     expect(bucketSecondsForRange("5m")).toBe(2);
+    // 3h / 150 = 72s.
+    expect(bucketSecondsForRange("3h")).toBe(72);
     // 6h / 150 = 144s.
     expect(bucketSecondsForRange("6h")).toBe(144);
+    // 12h / 150 = 288s.
+    expect(bucketSecondsForRange("12h")).toBe(288);
     // 24h / 150 = 576s.
     expect(bucketSecondsForRange("24h")).toBe(576);
   });

--- a/frontend/src/lib/chart-time-range.ts
+++ b/frontend/src/lib/chart-time-range.ts
@@ -1,6 +1,16 @@
 import { Temporal } from "temporal-polyfill";
 
-export type ChartTimeRange = "1m" | "5m" | "15m" | "30m" | "1h" | "6h" | "24h" | "all";
+export type ChartTimeRange =
+  | "1m"
+  | "5m"
+  | "15m"
+  | "30m"
+  | "1h"
+  | "3h"
+  | "6h"
+  | "12h"
+  | "24h"
+  | "all";
 
 // No 7d option: the default retention window is 7d, so a 7d range would just
 // duplicate "all" instead of offering a genuinely narrower/wider choice.
@@ -10,7 +20,9 @@ export const CHART_TIME_RANGES: { value: ChartTimeRange; label: string }[] = [
   { value: "15m", label: "15m" },
   { value: "30m", label: "30m" },
   { value: "1h", label: "1h" },
+  { value: "3h", label: "3h" },
   { value: "6h", label: "6h" },
+  { value: "12h", label: "12h" },
   { value: "24h", label: "24h" },
   { value: "all", label: "All" },
 ];
@@ -21,7 +33,9 @@ const RANGE_MINUTES: Record<Exclude<ChartTimeRange, "all">, number> = {
   "15m": 15,
   "30m": 30,
   "1h": 60,
+  "3h": 3 * 60,
   "6h": 6 * 60,
+  "12h": 12 * 60,
   "24h": 24 * 60,
 };
 


### PR DESCRIPTION
## Summary

- Add `3h` and `12h` to the chart time-range options (`ChartTimeRange` type, `CHART_TIME_RANGES`, `RANGE_MINUTES`), slotting them between the existing 1h / 6h / 24h choices
- URL `?range=` parsing picks them up automatically via `isChartTimeRange`, and the select's separator grouping (keyed on `1h` / `all`) needs no change

## Test plan

- [x] `mise run check` passes
- [x] `mise run test` passes (Go + frontend; updated `chart-time-range.test.ts` covers the new ranges in the list, `rangeToMs`, `rangeToFrom`, and `bucketSecondsForRange`)