### PR TITLE
fix(frontend): show time range labels instead of raw values in select trigger

### DIFF
--- a/frontend/src/components/common/time-range-select.test.tsx
+++ b/frontend/src/components/common/time-range-select.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach } from "vite-plus/test";
+import { render, screen, cleanup } from "@testing-library/react";
+import { TimeRangeSelect } from "./time-range-select";
+
+afterEach(cleanup);
+
+describe("TimeRangeSelect", () => {
+  // Base UI's Select.Value shows the selected item's raw value unless an
+  // `items` map is passed — without it, "all" and "custom" showed up
+  // lowercase in the trigger instead of their "All"/"Custom" labels.
+  it("shows the 'All' label (not the raw 'all' value) when range is all", () => {
+    render(<TimeRangeSelect range="all" onRangeChange={() => {}} tone="trace" />);
+
+    expect(screen.getByText("All")).toBeTruthy();
+    expect(screen.queryByText("all")).toBeNull();
+  });
+
+  it("shows '1h' when range is 1h", () => {
+    render(<TimeRangeSelect range="1h" onRangeChange={() => {}} tone="trace" />);
+
+    expect(screen.getByText("1h")).toBeTruthy();
+  });
+
+  it("shows the 'Custom' label when range is null", () => {
+    render(<TimeRangeSelect range={null} onRangeChange={() => {}} tone="trace" />);
+
+    expect(screen.getByText("Custom")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/common/time-range-select.tsx
+++ b/frontend/src/components/common/time-range-select.tsx
@@ -24,9 +24,17 @@ interface TimeRangeSelectProps {
   size?: "sm" | "md";
 }
 
+const CUSTOM_ITEM = { value: "custom", label: "Custom" };
+
 export function TimeRangeSelect({ range, onRangeChange, tone, size = "sm" }: TimeRangeSelectProps) {
+  // Base UI's Select.Value shows the selected item's raw value by default
+  // (unlike Radix, it doesn't read the rendered SelectItem's label) — items
+  // tells it which label to render for each value instead.
+  const items = range === null ? [CUSTOM_ITEM, ...CHART_TIME_RANGES] : CHART_TIME_RANGES;
+
   return (
     <Select
+      items={items}
       value={range ?? "custom"}
       onValueChange={(value) => {
         if (value && value !== "custom") onRangeChange(value as ChartTimeRange);


### PR DESCRIPTION
## Summary

- The time range select trigger displayed the raw value (lowercase `all` / `custom`) instead of the label (`All` / `Custom`). Base UI's `Select.Value` renders the selected raw value by default — unlike Radix, it doesn't read the rendered `SelectItem`'s label. Presets like `1h` only looked correct because their value and label are identical strings
- Pass an `items` (value → label) array to `Select.Root` so `Select.Value` resolves the label, including the `Custom` placeholder entry when the window is a fixed range restored from URL `?from=&to=` bounds

## Test plan

- [x] New `time-range-select.test.tsx`: trigger shows `All` (not `all`) for `range="all"`, `1h` for `range="1h"`, and `Custom` for `range={null}`
- [x] `mise run check` passes
- [x] `mise run test` passes (29 test files, 399 tests)