### PR TITLE
fix(server): restrict WS origins, add CSRF and Host validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ equivalent) to opt in to exposing it on the LAN. The published Docker image
 binds `0.0.0.0:4319` inside the container by default, since Docker's own
 `-p` publishing is itself an explicit opt-in.
 
+To guard against DNS rebinding, `/graphql` and `/ws` also reject requests
+whose `Host` header isn't an IP literal or `localhost`. If you run `otelop`
+under a hostname (e.g. reverse-proxied at `http://otelop.internal:4319`),
+add it to `allowed_hosts` (or `--allowed-hosts`/`OTELOP_ALLOWED_HOSTS`) —
+see [Configuration](#configuration).
+
 ## Commands
 
 ```
@@ -136,6 +142,7 @@ otelop version
   --http             Web UI listen address           (default 127.0.0.1:4319)
   --otlp-grpc        OTLP gRPC receiver endpoint     (default 0.0.0.0:4317)
   --otlp-http        OTLP HTTP receiver endpoint     (default 0.0.0.0:4318)
+  --allowed-hosts    comma-separated hostnames to allow beyond loopback/IP literals (e.g. otelop.internal,*.example.com)
   --proxy-url        upstream OTLP endpoint for forwarding
   --proxy-protocol   upstream OTLP protocol          (grpc|http)
   --proxy-auth-type  upstream OTLP auth type         (bearer|basic|headers)
@@ -170,6 +177,7 @@ Example `~/.config/otelop/config.toml`:
 http = "127.0.0.1:4319"
 otlp_grpc = "0.0.0.0:4317"
 otlp_http = "0.0.0.0:4318"
+allowed_hosts = [] # e.g. ["otelop.internal", "*.example.com"]
 log_level = "warn"
 debug = false
 
@@ -187,7 +195,7 @@ type = "bearer"
 token = "replace-me"
 ```
 
-The matching environment variables are `OTELOP_HTTP`, `OTELOP_OTLP_GRPC`, `OTELOP_OTLP_HTTP`, `OTELOP_PROXY_URL`, `OTELOP_PROXY_PROTOCOL`, `OTELOP_PROXY_AUTH_TYPE`, `OTELOP_PROXY_AUTH_TOKEN`, `OTELOP_PROXY_AUTH_USERNAME`, `OTELOP_PROXY_AUTH_PASSWORD`, `OTELOP_PROXY_HEADERS`, `OTELOP_STORAGE_PATH`, `OTELOP_RETENTION`, `OTELOP_MAX_SIZE`, `OTELOP_LOG_LEVEL`, and `OTELOP_DEBUG`.
+The matching environment variables are `OTELOP_HTTP`, `OTELOP_OTLP_GRPC`, `OTELOP_OTLP_HTTP`, `OTELOP_PROXY_URL`, `OTELOP_PROXY_PROTOCOL`, `OTELOP_PROXY_AUTH_TYPE`, `OTELOP_PROXY_AUTH_TOKEN`, `OTELOP_PROXY_AUTH_USERNAME`, `OTELOP_PROXY_AUTH_PASSWORD`, `OTELOP_PROXY_HEADERS`, `OTELOP_STORAGE_PATH`, `OTELOP_RETENTION`, `OTELOP_MAX_SIZE`, `OTELOP_LOG_LEVEL`, `OTELOP_DEBUG`, and `OTELOP_ALLOWED_HOSTS` (comma-separated).
 
 When proxying is enabled, `otelop` still stores incoming telemetry locally for the UI and also forwards the same traces, metrics, and logs to the configured upstream OTLP endpoint.
 

--- a/cmd/otelop/start.go
+++ b/cmd/otelop/start.go
@@ -64,6 +64,7 @@ func startCommand() *cli.Command {
 			&cli.StringFlag{Name: "http", Value: cfg.HTTPAddr, Usage: "Web UI + REST API listen address", Sources: cli.EnvVars("OTELOP_HTTP")},
 			&cli.StringFlag{Name: "otlp-grpc", Value: cfg.OTLPGRPCAddr, Usage: "OTLP gRPC receiver endpoint", Sources: cli.EnvVars("OTELOP_OTLP_GRPC")},
 			&cli.StringFlag{Name: "otlp-http", Value: cfg.OTLPHTTPAddr, Usage: "OTLP HTTP receiver endpoint", Sources: cli.EnvVars("OTELOP_OTLP_HTTP")},
+			&cli.StringFlag{Name: "allowed-hosts", Value: strings.Join(cfg.AllowedHosts, ","), Usage: "comma-separated hostnames to allow beyond loopback/IP literals, e.g. otelop.internal,*.example.com", Sources: cli.EnvVars("OTELOP_ALLOWED_HOSTS")},
 			&cli.StringFlag{Name: "proxy-url", Value: cfg.Proxy.URL, Usage: "upstream OTLP endpoint for forwarding", Sources: cli.EnvVars("OTELOP_PROXY_URL")},
 			&cli.StringFlag{Name: "proxy-protocol", Value: cfg.Proxy.Protocol, Usage: "upstream OTLP protocol (grpc|http)", Sources: cli.EnvVars("OTELOP_PROXY_PROTOCOL")},
 			&cli.StringFlag{Name: "proxy-auth-type", Value: cfg.Proxy.Auth.Type, Usage: "upstream OTLP auth type (bearer|basic|headers)", Sources: cli.EnvVars("OTELOP_PROXY_AUTH_TYPE")},
@@ -94,6 +95,7 @@ type startOptions struct {
 	HTTPAddr      string
 	OTLPGRPCAddr  string
 	OTLPHTTPAddr  string
+	AllowedHosts  []string
 	ProxyURL      string
 	ProxyProtocol string
 	ProxyAuth     proxyAuthOptions
@@ -110,6 +112,7 @@ func optionsFromCmd(cmd *cli.Command) startOptions {
 		HTTPAddr:      cmd.String("http"),
 		OTLPGRPCAddr:  cmd.String("otlp-grpc"),
 		OTLPHTTPAddr:  cmd.String("otlp-http"),
+		AllowedHosts:  splitCSV(cmd.String("allowed-hosts")),
 		ProxyURL:      strings.TrimSpace(cmd.String("proxy-url")),
 		ProxyProtocol: normalizeProxyProtocol(cmd.String("proxy-protocol")),
 		ProxyAuth: proxyAuthOptions{
@@ -126,6 +129,26 @@ func optionsFromCmd(cmd *cli.Command) startOptions {
 		Debug:       cmd.Bool("debug"),
 		Foreground:  cmd.Bool("foreground"),
 	}
+}
+
+// splitCSV splits a comma-separated flag/env value (e.g. --allowed-hosts,
+// OTELOP_ALLOWED_HOSTS) into its trimmed, non-empty entries. Returns nil for
+// an empty/all-whitespace input so callers see the same "no entries" shape
+// TOML's native array gives for an omitted key.
+func splitCSV(v string) []string {
+	fields := strings.Split(v, ",")
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		out = append(out, f)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func runStart(ctx context.Context, cmd *cli.Command) error {
@@ -297,7 +320,7 @@ func bootstrap(ctx context.Context, opts startOptions) (*runtime, error) {
 		RetentionDisplay: opts.Retention,
 		MaxSizeDisplay:   opts.MaxSize,
 	}
-	rt.srv = server.New(rt.storage, rt.hub, otelop.FrontendFS(), runtimeInfo)
+	rt.srv = server.New(rt.storage, rt.hub, otelop.FrontendFS(), runtimeInfo, opts.AllowedHosts)
 
 	// Eager listen so port conflicts surface before we signal ready.
 	if err := rt.srv.Listen(ctx); err != nil {

--- a/cmd/otelop/start_test.go
+++ b/cmd/otelop/start_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -63,5 +64,27 @@ func TestRedactURL(t *testing.T) {
 	got := redactURL("https://user:pass@example.com:4318")
 	if got != "https://REDACTED:REDACTED@example.com:4318" {
 		t.Fatalf("redactURL = %q", got)
+	}
+}
+
+func TestSplitCSV(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "empty", in: "", want: nil},
+		{name: "whitespace only", in: "   ", want: nil},
+		{name: "single", in: "otelop.internal", want: []string{"otelop.internal"}},
+		{name: "multiple", in: "otelop.internal,*.example.com", want: []string{"otelop.internal", "*.example.com"}},
+		{name: "trims whitespace and drops empties", in: " otelop.internal ,, *.example.com ", want: []string{"otelop.internal", "*.example.com"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitCSV(tc.in)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("splitCSV(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,9 +82,18 @@ type StorageConfig struct {
 // keys to match TOML conventions (CLI flags are kebab-case, env vars are
 // SCREAMING_SNAKE — pick whichever surface is most ergonomic).
 type Config struct {
-	HTTPAddr     string        `toml:"http"`
-	OTLPGRPCAddr string        `toml:"otlp_grpc"`
-	OTLPHTTPAddr string        `toml:"otlp_http"`
+	HTTPAddr     string `toml:"http"`
+	OTLPGRPCAddr string `toml:"otlp_grpc"`
+	OTLPHTTPAddr string `toml:"otlp_http"`
+	// AllowedHosts additionally permits Host headers beyond the always-allowed
+	// IP literals/localhost that internal/server's DNS-rebinding guard
+	// enforces (see internal/server/host_check.go) — for operators who run
+	// otelop under a hostname, e.g. reverse-proxied at "otelop.internal".
+	// Entries are matched case-insensitively with the port ignored; a
+	// "*.example.com" entry matches "example.com" itself and any depth of
+	// subdomain. Empty (the default) keeps the strict IP-literal/localhost-only
+	// behavior.
+	AllowedHosts []string      `toml:"allowed_hosts"`
 	Proxy        ProxyConfig   `toml:"proxy"`
 	Storage      StorageConfig `toml:"storage"`
 	LogLevel     string        `toml:"log_level"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -28,6 +29,9 @@ func TestDefaults_AppliedWhenFileMissing(t *testing.T) {
 	}
 	if cfg.LogLevel != DefaultLogLevel {
 		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, DefaultLogLevel)
+	}
+	if len(cfg.AllowedHosts) != 0 {
+		t.Errorf("AllowedHosts = %v, want empty default (strict Host checking)", cfg.AllowedHosts)
 	}
 }
 
@@ -122,6 +126,27 @@ X-Api-Key = "secret"
 	}
 	if got := cfg.Proxy.Auth.Headers["Authorization"]; got != "Bearer abc" {
 		t.Errorf("Proxy.Auth.Headers[Authorization] = %q", got)
+	}
+}
+
+func TestLoad_AllowedHosts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := `
+allowed_hosts = ["otelop.internal", "*.example.com"]
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv(EnvConfigFile, path)
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := []string{"otelop.internal", "*.example.com"}
+	if !slices.Equal(cfg.AllowedHosts, want) {
+		t.Errorf("AllowedHosts = %v, want %v", cfg.AllowedHosts, want)
 	}
 }
 

--- a/internal/server/handler_ws.go
+++ b/internal/server/handler_ws.go
@@ -10,9 +10,23 @@ import (
 	ws "github.com/mashiro/otelop/internal/websocket"
 )
 
+// wsOriginPatterns allow-lists browser Origins for the WebSocket upgrade.
+// coder/websocket matches each pattern against the Origin's host:port with
+// path.Match, so `[` and `]` (IPv6 literal delimiters) must be escaped —
+// they're path.Match character-class metacharacters, not literal brackets.
+// The request's own Host is always implicitly permitted by coder/websocket
+// regardless of this list (see authenticateOrigin in accept.go), so
+// same-origin browser connections and non-browser clients (which send no
+// Origin header at all) are unaffected by this allowlist.
+var wsOriginPatterns = []string{
+	"localhost:*",
+	"127.0.0.1:*",
+	`\[::1\]:*`,
+}
+
 func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		OriginPatterns:  []string{"*"},
+		OriginPatterns:  wsOriginPatterns,
 		CompressionMode: websocket.CompressionNoContextTakeover,
 	})
 	if err != nil {

--- a/internal/server/host_check.go
+++ b/internal/server/host_check.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// requireLocalHost blocks DNS rebinding attacks against otelop's raw data
+// endpoints. A page served from an attacker-controlled DNS name that
+// resolves to 127.0.0.1 would still satisfy same-origin checks (its Origin
+// header matches its own Host header) while running attacker JS against the
+// local server. Restricting Host to IP literals and localhost forecloses
+// that, since DNS rebinding depends on the browser being tricked via a
+// hostname — an IP literal or "localhost" can't be rebound. This mirrors the
+// approach Vite's dev server uses for `server.allowedHosts`.
+func requireLocalHost(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isLocalHost(r.Host) {
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isLocalHost reports whether host — an http.Request.Host value, optionally
+// carrying a port — names an IP literal (v4 or v6), "localhost", or a
+// "*.localhost" subdomain.
+func isLocalHost(host string) bool {
+	h := host
+	if hostname, _, err := net.SplitHostPort(host); err == nil {
+		h = hostname
+	}
+	// A bracketed IPv6 literal without a port (e.g. "[::1]") isn't valid
+	// input for SplitHostPort, so strip the brackets by hand.
+	h = strings.TrimSuffix(strings.TrimPrefix(h, "["), "]")
+	if h == "" {
+		return false
+	}
+	if net.ParseIP(h) != nil {
+		return true
+	}
+	lower := strings.ToLower(h)
+	return lower == "localhost" || strings.HasSuffix(lower, ".localhost")
+}

--- a/internal/server/host_check.go
+++ b/internal/server/host_check.go
@@ -6,17 +6,20 @@ import (
 	"strings"
 )
 
-// requireLocalHost blocks DNS rebinding attacks against otelop's raw data
+// requireAllowedHost blocks DNS rebinding attacks against otelop's raw data
 // endpoints. A page served from an attacker-controlled DNS name that
 // resolves to 127.0.0.1 would still satisfy same-origin checks (its Origin
 // header matches its own Host header) while running attacker JS against the
-// local server. Restricting Host to IP literals and localhost forecloses
-// that, since DNS rebinding depends on the browser being tricked via a
-// hostname — an IP literal or "localhost" can't be rebound. This mirrors the
+// local server. Restricting Host to IP literals, "localhost", and an
+// operator-configured allowlist (allowed) forecloses that, since DNS
+// rebinding depends on tricking the browser into trusting an
+// attacker-registered hostname — an IP literal, "localhost", or a hostname
+// the operator explicitly opted into (e.g. running otelop behind
+// "otelop.internal") can't be rebound by a third party. This mirrors the
 // approach Vite's dev server uses for `server.allowedHosts`.
-func requireLocalHost(next http.Handler) http.Handler {
+func requireAllowedHost(allowed []string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !isLocalHost(r.Host) {
+		if !isAllowedHost(r.Host, allowed) {
 			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 			return
 		}
@@ -26,15 +29,11 @@ func requireLocalHost(next http.Handler) http.Handler {
 
 // isLocalHost reports whether host — an http.Request.Host value, optionally
 // carrying a port — names an IP literal (v4 or v6), "localhost", or a
-// "*.localhost" subdomain.
+// "*.localhost" subdomain. These are always allowed, independent of any
+// operator-configured allowlist, since none of them can be a DNS rebinding
+// target.
 func isLocalHost(host string) bool {
-	h := host
-	if hostname, _, err := net.SplitHostPort(host); err == nil {
-		h = hostname
-	}
-	// A bracketed IPv6 literal without a port (e.g. "[::1]") isn't valid
-	// input for SplitHostPort, so strip the brackets by hand.
-	h = strings.TrimSuffix(strings.TrimPrefix(h, "["), "]")
+	h := hostnameOnly(host)
 	if h == "" {
 		return false
 	}
@@ -43,4 +42,59 @@ func isLocalHost(host string) bool {
 	}
 	lower := strings.ToLower(h)
 	return lower == "localhost" || strings.HasSuffix(lower, ".localhost")
+}
+
+// isAllowedHost reports whether host is always-allowed (isLocalHost) or
+// matches one of the operator-configured allowed hostnames (config's
+// allowed_hosts / --allowed-hosts / OTELOP_ALLOWED_HOSTS).
+func isAllowedHost(host string, allowed []string) bool {
+	if isLocalHost(host) {
+		return true
+	}
+	h := hostnameOnly(host)
+	if h == "" {
+		return false
+	}
+	lower := strings.ToLower(h)
+	for _, pattern := range allowed {
+		if hostMatchesPattern(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// hostMatchesPattern reports whether host (already lowercased, with any port
+// stripped) matches pattern, a single allowed_hosts entry.
+//
+// A "*.example.com" pattern matches "example.com" itself and any depth of
+// subdomain ("foo.example.com", "foo.bar.example.com", ...) — mirroring
+// Vite's `server.allowedHosts` leading-dot wildcard (".example.com" allows
+// "example.com", "foo.example.com", and "foo.bar.example.com" alike), which
+// operators reaching for this otelop setting are likely already familiar
+// with from the frontend dev server. Arbitrary depth also avoids operators
+// needing a separate allowed_hosts entry per subdomain level. Anything else
+// is a case-insensitive exact match.
+func hostMatchesPattern(host, pattern string) bool {
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	if pattern == "" {
+		return false
+	}
+	suffix, ok := strings.CutPrefix(pattern, "*.")
+	if !ok {
+		return host == pattern
+	}
+	return host == suffix || strings.HasSuffix(host, "."+suffix)
+}
+
+// hostnameOnly strips an optional ":port" suffix (and, for a bracketed IPv6
+// literal, the brackets) from an http.Request.Host value.
+func hostnameOnly(host string) string {
+	h := host
+	if hostname, _, err := net.SplitHostPort(host); err == nil {
+		h = hostname
+	}
+	// A bracketed IPv6 literal without a port (e.g. "[::1]") isn't valid
+	// input for SplitHostPort, so strip the brackets by hand.
+	return strings.TrimSuffix(strings.TrimPrefix(h, "["), "]")
 }

--- a/internal/server/host_check_test.go
+++ b/internal/server/host_check_test.go
@@ -1,0 +1,33 @@
+package server
+
+import "testing"
+
+func TestIsLocalHost(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{host: "localhost", want: true},
+		{host: "localhost:4319", want: true},
+		{host: "LOCALHOST:4319", want: true},
+		{host: "foo.localhost:4319", want: true},
+		{host: "127.0.0.1", want: true},
+		{host: "127.0.0.1:4319", want: true},
+		{host: "192.168.1.5:4319", want: true},
+		{host: "::1", want: true},
+		{host: "[::1]", want: true},
+		{host: "[::1]:4319", want: true},
+		{host: "evil.com", want: false},
+		{host: "evil.com:4319", want: false},
+		{host: "notlocalhost:4319", want: false},
+		{host: "localhost.evil.com:4319", want: false},
+		{host: "", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.host, func(t *testing.T) {
+			if got := isLocalHost(tc.host); got != tc.want {
+				t.Errorf("isLocalHost(%q) = %v, want %v", tc.host, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/host_check_test.go
+++ b/internal/server/host_check_test.go
@@ -31,3 +31,72 @@ func TestIsLocalHost(t *testing.T) {
 		})
 	}
 }
+
+func TestIsAllowedHost(t *testing.T) {
+	allowed := []string{"otelop.internal", "*.example.com"}
+	tests := []struct {
+		host string
+		want bool
+	}{
+		// Always-allowed regardless of the allowlist.
+		{host: "localhost:4319", want: true},
+		{host: "127.0.0.1:4319", want: true},
+		{host: "[::1]:4319", want: true},
+		// Exact allowlist match, case-insensitive, port ignored.
+		{host: "otelop.internal", want: true},
+		{host: "otelop.internal:4319", want: true},
+		{host: "OTELOP.INTERNAL:4319", want: true},
+		// Wildcard allowlist entry: matches the bare domain and any depth of
+		// subdomain.
+		{host: "example.com:4319", want: true},
+		{host: "foo.example.com:4319", want: true},
+		{host: "foo.bar.example.com:4319", want: true},
+		{host: "EXAMPLE.COM:4319", want: true},
+		// Not on the allowlist and not otherwise local.
+		{host: "evil.com:4319", want: false},
+		{host: "notexample.com:4319", want: false},
+		{host: "example.com.evil.com:4319", want: false},
+		{host: "", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.host, func(t *testing.T) {
+			if got := isAllowedHost(tc.host, allowed); got != tc.want {
+				t.Errorf("isAllowedHost(%q, %v) = %v, want %v", tc.host, allowed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsAllowedHost_EmptyAllowlistKeepsStrictBehavior(t *testing.T) {
+	if isAllowedHost("otelop.internal:4319", nil) {
+		t.Error("isAllowedHost with empty allowlist should reject a non-local hostname")
+	}
+	if !isAllowedHost("localhost:4319", nil) {
+		t.Error("isAllowedHost with empty allowlist should still allow localhost")
+	}
+}
+
+func TestHostMatchesPattern(t *testing.T) {
+	tests := []struct {
+		host    string
+		pattern string
+		want    bool
+	}{
+		{host: "otelop.internal", pattern: "otelop.internal", want: true},
+		{host: "otelop.internal", pattern: "OTELOP.INTERNAL", want: true},
+		{host: "other.internal", pattern: "otelop.internal", want: false},
+		{host: "example.com", pattern: "*.example.com", want: true},
+		{host: "foo.example.com", pattern: "*.example.com", want: true},
+		{host: "foo.bar.example.com", pattern: "*.example.com", want: true},
+		{host: "notexample.com", pattern: "*.example.com", want: false},
+		{host: "example.com.evil.com", pattern: "*.example.com", want: false},
+		{host: "example.com", pattern: "", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.host+"/"+tc.pattern, func(t *testing.T) {
+			if got := hostMatchesPattern(tc.host, tc.pattern); got != tc.want {
+				t.Errorf("hostMatchesPattern(%q, %q) = %v, want %v", tc.host, tc.pattern, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,8 +23,8 @@ import (
 // provider still see their own span recorder.
 func tracer() oteltrace.Tracer { return otel.Tracer("otelop/server") }
 
-// Server serves the GraphQL endpoint, WebSocket stream, and
-// embedded frontend.
+// Server serves the GraphQL endpoint, WebSocket stream, and embedded
+// frontend.
 type Server struct {
 	storage    *storage.Storage
 	hub        *ws.Hub
@@ -44,10 +44,19 @@ func New(s *storage.Storage, hub *ws.Hub, frontendFS fs.FS, runtime otelopgraphq
 
 	mux := http.NewServeMux()
 
-	// GraphQL — primary data surface for the frontend and AI clients.
-	mux.Handle("POST /graphql", &relay.Handler{Schema: srv.schema})
+	// CSRF protection: otelop is a localhost dev tool, so any page open in the
+	// browser — including malicious ones — can reach it. Without this, a
+	// cross-site page could issue an unsafe /graphql request (no preflight
+	// required for simple POSTs) and otelop would happily execute it.
+	// NewCrossOriginProtection lets same-origin requests and non-browser
+	// clients (curl, scripts — no Sec-Fetch-Site/Origin headers) through, and
+	// rejects unsafe cross-site browser requests.
+	csrf := http.NewCrossOriginProtection()
 
-	mux.HandleFunc("GET /ws", srv.handleWebSocket)
+	// GraphQL — primary data surface for the frontend and AI clients.
+	mux.Handle("POST /graphql", requireLocalHost(csrf.Handler(&relay.Handler{Schema: srv.schema})))
+
+	mux.Handle("GET /ws", requireLocalHost(http.HandlerFunc(srv.handleWebSocket)))
 
 	// Static files with SPA fallback
 	mux.Handle("/", spaHandler(frontendFS))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,8 +34,13 @@ type Server struct {
 }
 
 // New creates a new Server. When runtime.Debug is true, HTTP requests are
-// instrumented with OpenTelemetry spans via otelhttp.
-func New(s *storage.Storage, hub *ws.Hub, frontendFS fs.FS, runtime otelopgraphql.RuntimeInfo) *Server {
+// instrumented with OpenTelemetry spans via otelhttp. allowedHosts extends
+// the Host header allowlist enforced by requireAllowedHost beyond IP
+// literals/localhost — see internal/server/host_check.go and
+// config.Config.AllowedHosts. It's a plain parameter rather than a field on
+// otelopgraphql.RuntimeInfo because RuntimeInfo is graphql's own
+// status/config query payload, not a general server-config bag.
+func New(s *storage.Storage, hub *ws.Hub, frontendFS fs.FS, runtime otelopgraphql.RuntimeInfo, allowedHosts []string) *Server {
 	srv := &Server{
 		storage: s,
 		hub:     hub,
@@ -54,9 +59,9 @@ func New(s *storage.Storage, hub *ws.Hub, frontendFS fs.FS, runtime otelopgraphq
 	csrf := http.NewCrossOriginProtection()
 
 	// GraphQL — primary data surface for the frontend and AI clients.
-	mux.Handle("POST /graphql", requireLocalHost(csrf.Handler(&relay.Handler{Schema: srv.schema})))
+	mux.Handle("POST /graphql", requireAllowedHost(allowedHosts, csrf.Handler(&relay.Handler{Schema: srv.schema})))
 
-	mux.Handle("GET /ws", requireLocalHost(http.HandlerFunc(srv.handleWebSocket)))
+	mux.Handle("GET /ws", requireAllowedHost(allowedHosts, http.HandlerFunc(srv.handleWebSocket)))
 
 	// Static files with SPA fallback
 	mux.Handle("/", spaHandler(frontendFS))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -24,6 +24,14 @@ import (
 // port.
 func newTestServer(t *testing.T) *Server {
 	t.Helper()
+	return newTestServerWithAllowedHosts(t, nil)
+}
+
+// newTestServerWithAllowedHosts is newTestServer with a non-empty
+// allowed_hosts list, for tests exercising requireAllowedHost's allowlist
+// path.
+func newTestServerWithAllowedHosts(t *testing.T, allowedHosts []string) *Server {
+	t.Helper()
 
 	st, err := storage.Open(context.Background(), storage.Options{})
 	if err != nil {
@@ -41,7 +49,7 @@ func newTestServer(t *testing.T) *Server {
 	go hub.Run(ctx)
 
 	fsys := fstest.MapFS{"index.html": {Data: []byte("<html></html>")}}
-	return New(st, hub, fsys, otelopgraphql.RuntimeInfo{})
+	return New(st, hub, fsys, otelopgraphql.RuntimeInfo{}, allowedHosts)
 }
 
 func TestHandleWebSocket_OriginAllowlist(t *testing.T) {
@@ -188,6 +196,44 @@ func TestHostHeaderValidation(t *testing.T) {
 			if tc.method == http.MethodPost {
 				req.Header.Set("Content-Type", "application/json")
 			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			gotForbidden := resp.StatusCode == http.StatusForbidden
+			if gotForbidden != tc.wantForbidden {
+				t.Errorf("status = %d, wantForbidden = %v", resp.StatusCode, tc.wantForbidden)
+			}
+		})
+	}
+}
+
+func TestHostHeaderValidation_AllowedHosts(t *testing.T) {
+	srv := newTestServerWithAllowedHosts(t, []string{"otelop.internal", "*.example.com"})
+	ts := httptest.NewServer(srv.httpServer.Handler)
+	t.Cleanup(ts.Close)
+
+	tests := []struct {
+		name          string
+		host          string
+		wantForbidden bool
+	}{
+		{name: "exact allowlist match", host: "otelop.internal:4319", wantForbidden: false},
+		{name: "allowlist match is case-insensitive", host: "OTELOP.INTERNAL:4319", wantForbidden: false},
+		{name: "wildcard entry matches subdomain", host: "app.example.com:4319", wantForbidden: false},
+		{name: "wildcard entry matches bare domain", host: "example.com:4319", wantForbidden: false},
+		{name: "loopback still allowed alongside allowlist", host: "127.0.0.1:4319", wantForbidden: false},
+		{name: "host outside allowlist still blocked", host: "evil.com:4319", wantForbidden: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL+"/graphql", strings.NewReader(`{"query":"{ status { version } }"}`))
+			if err != nil {
+				t.Fatalf("NewRequestWithContext: %v", err)
+			}
+			req.Host = tc.host
+			req.Header.Set("Content-Type", "application/json")
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				t.Fatalf("Do: %v", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,15 +2,204 @@ package server
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"testing/fstest"
 
+	"github.com/coder/websocket"
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	otelopgraphql "github.com/mashiro/otelop/internal/graphql"
+	"github.com/mashiro/otelop/internal/storage"
+	ws "github.com/mashiro/otelop/internal/websocket"
 )
+
+// newTestServer wires a Server with in-memory storage and an unstarted
+// listener, so tests can drive it via httptest instead of binding a real
+// port.
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+
+	st, err := storage.Open(context.Background(), storage.Options{})
+	if err != nil {
+		t.Fatalf("storage.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := st.Close(); err != nil {
+			t.Errorf("storage.Close: %v", err)
+		}
+	})
+
+	hub := ws.NewHub()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go hub.Run(ctx)
+
+	fsys := fstest.MapFS{"index.html": {Data: []byte("<html></html>")}}
+	return New(st, hub, fsys, otelopgraphql.RuntimeInfo{})
+}
+
+func TestHandleWebSocket_OriginAllowlist(t *testing.T) {
+	srv := newTestServer(t)
+	ts := httptest.NewServer(srv.httpServer.Handler)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+
+	tests := []struct {
+		name      string
+		origin    string
+		wantAllow bool
+	}{
+		{name: "evil origin rejected", origin: "http://evil.com", wantAllow: false},
+		{name: "vite dev server origin allowed", origin: "http://localhost:5173", wantAllow: true},
+		{name: "loopback IP origin allowed", origin: "http://127.0.0.1:5173", wantAllow: true},
+		{name: "no origin header allowed (non-browser client)", origin: "", wantAllow: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			header := http.Header{}
+			if tc.origin != "" {
+				header.Set("Origin", tc.origin)
+			}
+			conn, resp, err := websocket.Dial(context.Background(), wsURL, &websocket.DialOptions{HTTPHeader: header})
+			if resp != nil && resp.Body != nil {
+				defer func() { _ = resp.Body.Close() }()
+			}
+			if tc.wantAllow {
+				if err != nil {
+					t.Fatalf("Dial: %v", err)
+				}
+				_ = conn.Close(websocket.StatusNormalClosure, "")
+				return
+			}
+			if err == nil {
+				_ = conn.Close(websocket.StatusNormalClosure, "")
+				t.Fatalf("expected dial to fail for origin %q", tc.origin)
+			}
+			if resp == nil || resp.StatusCode != http.StatusForbidden {
+				status := -1
+				if resp != nil {
+					status = resp.StatusCode
+				}
+				t.Errorf("status = %d, want %d", status, http.StatusForbidden)
+			}
+		})
+	}
+}
+
+func TestGraphQL_CSRFProtection(t *testing.T) {
+	srv := newTestServer(t)
+	ts := httptest.NewServer(srv.httpServer.Handler)
+	t.Cleanup(ts.Close)
+
+	body := `{"query":"{ status { version } }"}`
+
+	tests := []struct {
+		name       string
+		path       string
+		headers    map[string]string
+		wantStatus func(int) bool
+	}{
+		{
+			name: "cross-site graphql mutation blocked",
+			path: "/graphql",
+			headers: map[string]string{
+				"Sec-Fetch-Site": "cross-site",
+				"Origin":         "http://evil.com",
+				"Content-Type":   "application/json",
+			},
+			wantStatus: func(code int) bool { return code == http.StatusForbidden },
+		},
+		{
+			name: "no browser headers allowed (curl, scripts)",
+			path: "/graphql",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+			wantStatus: func(code int) bool { return code != http.StatusForbidden },
+		},
+		{
+			name: "vite dev proxy same-origin allowed",
+			path: "/graphql",
+			headers: map[string]string{
+				"Sec-Fetch-Site": "same-origin",
+				"Origin":         "http://localhost:5173",
+				"Content-Type":   "application/json",
+			},
+			wantStatus: func(code int) bool { return code != http.StatusForbidden },
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL+tc.path, strings.NewReader(body))
+			if err != nil {
+				t.Fatalf("NewRequestWithContext: %v", err)
+			}
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if !tc.wantStatus(resp.StatusCode) {
+				t.Errorf("path %s: status = %d", tc.path, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestHostHeaderValidation(t *testing.T) {
+	srv := newTestServer(t)
+	ts := httptest.NewServer(srv.httpServer.Handler)
+	t.Cleanup(ts.Close)
+
+	tests := []struct {
+		name          string
+		method        string
+		path          string
+		host          string
+		wantForbidden bool
+	}{
+		{name: "graphql dns rebind host blocked", method: http.MethodPost, path: "/graphql", host: "evil.com:4319", wantForbidden: true},
+		{name: "graphql ip literal host allowed", method: http.MethodPost, path: "/graphql", host: "192.168.1.5:4319", wantForbidden: false},
+		{name: "graphql localhost host allowed", method: http.MethodPost, path: "/graphql", host: "localhost:4319", wantForbidden: false},
+		{name: "ws dns rebind host blocked", method: http.MethodGet, path: "/ws", host: "evil.com:4319", wantForbidden: true},
+		{name: "ws ip literal host allowed", method: http.MethodGet, path: "/ws", host: "192.168.1.5:4319", wantForbidden: false},
+		{name: "static assets ignore host check", method: http.MethodGet, path: "/", host: "evil.com:4319", wantForbidden: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var bodyReader io.Reader
+			if tc.method == http.MethodPost {
+				bodyReader = strings.NewReader(`{"query":"{ status { version } }"}`)
+			}
+			req, err := http.NewRequestWithContext(context.Background(), tc.method, ts.URL+tc.path, bodyReader)
+			if err != nil {
+				t.Fatalf("NewRequestWithContext: %v", err)
+			}
+			req.Host = tc.host
+			if tc.method == http.MethodPost {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			gotForbidden := resp.StatusCode == http.StatusForbidden
+			if gotForbidden != tc.wantForbidden {
+				t.Errorf("status = %d, wantForbidden = %v", resp.StatusCode, tc.wantForbidden)
+			}
+		})
+	}
+}
 
 func TestSpaHandler_EmitsStatAndServeSpans(t *testing.T) {
 	orig := otel.GetTracerProvider()


### PR DESCRIPTION
## Summary

Closes the three browser-borne holes in the HTTP boundary — localhost is not a security boundary against the user's own browser:

- **WS Origin allowlist** (`handler_ws.go`): `OriginPatterns` was `"*"`, so any web page could open `ws://localhost:4319/ws` and read live telemetry (cross-site WebSocket hijacking). Now allowlisted to `localhost:*` / `127.0.0.1:*` / `[::1]:*` (escaped — `path.Match` treats brackets as character classes). Same-origin and Origin-less (non-browser) clients are unaffected.
- **CSRF protection on `/graphql`**: wrapped with Go 1.25+ `http.NewCrossOriginProtection`. Cross-site unsafe requests (e.g. a preflight-free `mutation{clearSignals}` POST from a malicious page) get 403; same-origin, the vite dev proxy, and headerless clients (curl) pass.
- **Host validation on `/graphql` and `/ws`** (`host_check.go`): DNS rebinding defeats origin checks, so Host must be an IP literal, `localhost`, or `*.localhost` — rebinding needs a DNS name, IP literals can't be rebound.

### Escape hatch for hostname deployments (`allowed_hosts`)

Running otelop behind a hostname (e.g. `http://otelop.internal:4319`) would 403 on every API request under the Host check alone. `allowed_hosts` (TOML) / `--allowed-hosts` (comma-separated) / `OTELOP_ALLOWED_HOSTS` lets operators opt hostnames back in, following the existing flag > env > config precedence. `*.example.com` matches the bare domain and any subdomain depth (Vite's leading-dot semantics); matching is case-insensitive, port ignored. Default is empty — strict behavior unchanged. WS needs no equivalent: coder/websocket always permits same-origin (Origin == Host), so a UI served from an allowed hostname connects fine.

## Test plan

- [x] New tests: origin allowlist (evil/vite/loopback/no-header), CSRF (cross-site 403, same-origin + headerless pass), Host validation (rebind blocked, IP literal + localhost pass, static exempt), `isLocalHost`/`isAllowedHost`/`hostMatchesPattern` units, allowed-hosts wiring test, config parsing + `splitCSV`
- [x] `mise run check` / `mise run test` (backend + frontend) all pass