### PR TITLE
fix(config): bind Web UI/API to loopback by default

### DIFF
--- a/.mise/tasks/e2e-env/backend
+++ b/.mise/tasks/e2e-env/backend
@@ -27,7 +27,7 @@ echo "  Storage (temp)  : ${storage_dir}"
 echo "=========================================================================="
 
 OTELOP_CONFIG_FILE="$config_file" go run ./cmd/otelop start --foreground \
-  --http ":${http_port}" \
+  --http "127.0.0.1:${http_port}" \
   --otlp-grpc "127.0.0.1:${grpc_port}" \
   --otlp-http "127.0.0.1:${otlp_http_port}" \
   --storage-path "${storage_dir}/otelop.duckdb" \

--- a/.mise/tasks/e2e-env/frontend
+++ b/.mise/tasks/e2e-env/frontend
@@ -6,5 +6,7 @@ set -euo pipefail
 http_port="${OTELOP_E2E_HTTP:-14319}"
 frontend_port="${OTELOP_E2E_FRONTEND:-15173}"
 
-OTELOP_BACKEND_ORIGIN="http://localhost:${http_port}" \
+# 127.0.0.1, not localhost: the backend binds loopback-only and Node's DNS
+# resolution order can try ::1 first, which the IPv4-only bind won't accept.
+OTELOP_BACKEND_ORIGIN="http://127.0.0.1:${http_port}" \
   pnpm run dev -- --port "${frontend_port}" --strictPort

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,12 @@ ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/otelop /usr/local/bin/otelop
 
 ENV HOME=/home/nonroot \
-    OTELOP_STORAGE_PATH=/data/otelop.duckdb
+    OTELOP_STORAGE_PATH=/data/otelop.duckdb \
+    # otelop's default HTTP bind is loopback-only (no auth on the
+    # GraphQL/UI endpoint), but Docker's own network namespace already
+    # isolates the container — `docker run -p` is the explicit opt-in — so
+    # bind all interfaces here or the published port would be unreachable.
+    OTELOP_HTTP=0.0.0.0:4319
 
 USER nonroot:nonroot
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Any AI coding agent that supports OpenTelemetry can export to `otelop`, so you c
 The GraphQL and Streamable HTTP MCP endpoints are available at
 `http://localhost:4319/graphql` and `http://localhost:4319/mcp`.
 
+The Web UI/GraphQL endpoint has no authentication, so it binds to
+`127.0.0.1` by default — set `--http 0.0.0.0:4319` (or an env/config
+equivalent) to opt in to exposing it on the LAN. The published Docker image
+binds `0.0.0.0:4319` inside the container by default, since Docker's own
+`-p` publishing is itself an explicit opt-in.
+
 ## Commands
 
 ```
@@ -129,7 +135,7 @@ otelop version
 
 ```
   --foreground, -f   run in the foreground instead of detaching
-  --http             Web UI listen address           (default :4319)
+  --http             Web UI listen address           (default 127.0.0.1:4319)
   --otlp-grpc        OTLP gRPC receiver endpoint     (default 0.0.0.0:4317)
   --otlp-http        OTLP HTTP receiver endpoint     (default 0.0.0.0:4318)
   --proxy-url        upstream OTLP endpoint for forwarding
@@ -156,14 +162,14 @@ paths and current storage usage.
 
 Every `start` flag can be set three ways. Higher precedence wins:
 
-1. CLI flag (`otelop start --http :4319`)
-2. Environment variable (`OTELOP_HTTP=:4319 otelop start`)
+1. CLI flag (`otelop start --http 127.0.0.1:4319`)
+2. Environment variable (`OTELOP_HTTP=127.0.0.1:4319 otelop start`)
 3. TOML config file at `$XDG_CONFIG_HOME/otelop/config.toml` (defaults to `~/.config/otelop/config.toml`; override with `OTELOP_CONFIG_FILE=/path/to/config.toml`)
 
 Example `~/.config/otelop/config.toml`:
 
 ```toml
-http = ":4319"
+http = "127.0.0.1:4319"
 otlp_grpc = "0.0.0.0:4317"
 otlp_http = "0.0.0.0:4318"
 log_level = "warn"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,7 +10,10 @@ const generatedSources = ["src/gql/**"];
 // isolated backend instance instead of the developer's live :4319 server
 // (see .mise/tasks/e2e-env). The ws:// target is derived from the same
 // origin rather than duplicated, so the two proxies can never drift apart.
-const backendOrigin = process.env.OTELOP_BACKEND_ORIGIN ?? "http://localhost:4319";
+// 127.0.0.1, not localhost: the backend now binds loopback-only
+// (internal/config.DefaultHTTPAddr), and Node's DNS resolution order can
+// try ::1 first, which the IPv4-only bind won't accept.
+const backendOrigin = process.env.OTELOP_BACKEND_ORIGIN ?? "http://127.0.0.1:4319";
 const backendWsOrigin = backendOrigin.replace(/^http/, "ws");
 
 export default defineConfig({

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,12 @@ const (
 // a given field. Mirrored as the built-in CLI flag defaults so the values
 // stay visible in `otelop start --help`.
 const (
-	DefaultHTTPAddr     = ":4319"
+	// DefaultHTTPAddr binds loopback-only: the Web UI/GraphQL endpoint
+	// carries no auth, so exposing it to the LAN by default would let anyone
+	// on the network read stored telemetry. OTLP receivers below stay on
+	// 0.0.0.0 to match OTel convention; LAN exposure of the UI is opt-in via
+	// --http/OTELOP_HTTP/config.
+	DefaultHTTPAddr     = "127.0.0.1:4319"
 	DefaultOTLPGRPCAddr = "0.0.0.0:4317"
 	DefaultOTLPHTTPAddr = "0.0.0.0:4318"
 	DefaultLogLevel     = "warn"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,6 +31,15 @@ func TestDefaults_AppliedWhenFileMissing(t *testing.T) {
 	}
 }
 
+// TestDefaultHTTPAddr_IsLoopback pins the literal value (not just equality
+// with the constant) so a future edit can't silently widen the unauthenticated
+// GraphQL/UI listener back to all interfaces the way ":4319" used to.
+func TestDefaultHTTPAddr_IsLoopback(t *testing.T) {
+	if DefaultHTTPAddr != "127.0.0.1:4319" {
+		t.Errorf("DefaultHTTPAddr = %q, want a loopback-bound address (127.0.0.1:4319)", DefaultHTTPAddr)
+	}
+}
+
 func TestLoad_MergesPartialFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")


### PR DESCRIPTION
## Summary

The `:4319` GraphQL/UI endpoint has no authentication, and the old `":4319"` default binds all interfaces — anyone on the same Wi-Fi could read stored telemetry (span attributes and log bodies can carry auth headers, SQL, PII) or clear it. This changes the default to `127.0.0.1:4319`; LAN exposure becomes an explicit opt-in (`--http 0.0.0.0:4319` / `OTELOP_HTTP` / config). OTLP receivers (4317/4318) stay on `0.0.0.0` per OTel convention.

Follow-through so nothing silently breaks:

- **Docker**: image now sets `OTELOP_HTTP=0.0.0.0:4319` — a loopback bind inside the container's own network namespace would make `docker run -p 4319:4319` unreachable, and `-p` is already an explicit opt-in
- **vite dev proxy / e2e-env**: switched `localhost` → `127.0.0.1` because Node's DNS resolution order can try `::1` first, which an IPv4-only loopback bind won't accept
- README: documents the loopback default and the opt-in
- Regression test pins the literal default so a future edit can't silently widen the bind again

## Test plan

- [x] `go test ./internal/config/... ./cmd/...` (includes new `TestDefaultHTTPAddr_IsLoopback`) pass
- [x] `go build ./...` / `golangci-lint run ./...` clean
- [x] Verified multi-line Dockerfile `ENV` with inline comment via a minimal build + hadolint