### PR TITLE
fix(cli): shut down daemon when collector fails after startup

### DIFF
--- a/cmd/otelop/start.go
+++ b/cmd/otelop/start.go
@@ -373,6 +373,13 @@ func bootstrap(ctx context.Context, opts startOptions) (*runtime, error) {
 		return nil, err
 	}
 
+	// Once ready, nothing else reads colErrCh — without this, a post-ready
+	// Run failure (e.g. the OTLP listener dying) would go unnoticed and
+	// `otelop status` would keep reporting "running" while ingestion is
+	// silently dead. rt.cancel() unwinds waitForSignal, which triggers the
+	// deferred rt.shutdown() in runServer.
+	go watchCollectorErrors(colErrCh, rt.cancel, slog.Default())
+
 	if opts.Debug {
 		slog.Debug("starting self-telemetry", "endpoint", selfTelemetryEndpoint)
 		result, err := selftelemetry.Setup(ctx, selfTelemetryEndpoint)
@@ -423,6 +430,20 @@ func waitCollectorReady(ctx context.Context, col *otelcol.Collector, errCh <-cha
 			return nil
 		}
 	}
+}
+
+// watchCollectorErrors observes errCh for a collector failure that happens
+// after waitCollectorReady already returned success, and cancels the daemon
+// so the failure isn't silent. errCh is only ever populated when col.Run
+// returns a non-nil error; a clean shutdown (col.Shutdown() making Run
+// return nil) closes it without sending, which is a no-op here.
+func watchCollectorErrors(errCh <-chan error, cancel context.CancelFunc, logger *slog.Logger) {
+	err, ok := <-errCh
+	if !ok || err == nil {
+		return
+	}
+	logger.Error("collector stopped unexpectedly, shutting down", "error", err)
+	cancel()
 }
 
 func (r *runtime) printBanner(w io.Writer, opts startOptions) {

--- a/cmd/otelop/start_test.go
+++ b/cmd/otelop/start_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"bytes"
+	"errors"
+	"log/slog"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestValidateProxyOptions_RejectsSelfProxy(t *testing.T) {
@@ -86,5 +90,60 @@ func TestSplitCSV(t *testing.T) {
 				t.Errorf("splitCSV(%q) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestWatchCollectorErrors_CancelsOnPostReadyFailure(t *testing.T) {
+	ch := make(chan error, 1)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	canceled := make(chan struct{})
+	cancel := func() { close(canceled) }
+
+	ch <- errors.New("boom")
+	close(ch)
+
+	done := make(chan struct{})
+	go func() {
+		watchCollectorErrors(ch, cancel, logger)
+		close(done)
+	}()
+
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("cancel was not called after a post-ready collector error")
+	}
+	<-done
+
+	if !strings.Contains(buf.String(), "boom") {
+		t.Errorf("log output = %q, want it to mention the collector error", buf.String())
+	}
+}
+
+func TestWatchCollectorErrors_NoOpOnCleanShutdown(t *testing.T) {
+	// col.Run returning nil (e.g. rt.shutdown() calling col.Shutdown()) closes
+	// the channel without ever sending — that's expected daemon shutdown, not
+	// a failure, so cancel must not be invoked again.
+	ch := make(chan error)
+	close(ch)
+
+	canceled := false
+	cancel := func() { canceled = true }
+
+	done := make(chan struct{})
+	go func() {
+		watchCollectorErrors(ch, cancel, slog.Default())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watchCollectorErrors did not return on channel close")
+	}
+
+	if canceled {
+		t.Error("cancel was called on a clean collector shutdown")
 	}
 }


### PR DESCRIPTION
## Summary

`colErrCh` was only consumed by `waitCollectorReady`, so a post-ready `col.Run` failure (e.g. the OTLP listener dying) was silently dropped: the daemon kept its HTTP server alive and `otelop status` kept reporting *running* while ingestion was dead. Adds `watchCollectorErrors`, wired right after readiness: it logs the error and cancels the runtime, which unwinds `waitForSignal` and triggers the normal deferred shutdown. A clean shutdown (`col.Shutdown()` → `Run` returns nil → channel closed without a send) stays a no-op.

## Test plan

- [x] New tests: post-ready failure cancels and logs; clean close never cancels
- [x] `go test ./cmd/...` / `go build ./...` pass, `golangci-lint` 0 issues