### PR TITLE
fix(graphql): bound query depth, length, and page limits

### DIFF
--- a/internal/graphql/limits_test.go
+++ b/internal/graphql/limits_test.go
@@ -1,0 +1,229 @@
+package graphql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	otelopgraphql "github.com/mashiro/otelop/internal/graphql"
+	"github.com/mashiro/otelop/internal/storage"
+)
+
+// execErrors runs a query against s and returns the raw GraphQL errors
+// (nil when none), for tests that assert on rejection rather than success —
+// unlike exec() (schema_test.go), which fails the test on any error.
+func execErrors(t *testing.T, s *storage.Storage, query string) []string {
+	t.Helper()
+	schema := otelopgraphql.MustNewSchema(s, testRuntime())
+	resp := schema.Exec(context.Background(), query, "", nil)
+	msgs := make([]string, len(resp.Errors))
+	for i, e := range resp.Errors {
+		msgs[i] = e.Error()
+	}
+	return msgs
+}
+
+// nestedTraceLogQuery builds a query that alternates through the schema's
+// circular Trace.spans -> Span.trace -> Trace.logs -> Log.trace edges depth
+// times, the exact shape schema.go's MaxDepth guards against
+// (traces(limit:0){spans{trace{logs{trace{...}}}}}).
+func nestedTraceLogQuery(depth int) string {
+	var b strings.Builder
+	b.WriteString(`{ trace(traceId: "x") {`)
+	for i := 0; i < depth; i++ {
+		b.WriteString(` spans { trace {`)
+	}
+	b.WriteString(` traceId `)
+	for i := 0; i < depth; i++ {
+		b.WriteString(` } } `)
+	}
+	b.WriteString(` } }`)
+	return b.String()
+}
+
+func TestMaxDepth_RejectsDeeplyNestedCircularQuery(t *testing.T) {
+	s := newTestStorage(t)
+	// 20 round trips through spans/trace comfortably exceeds MaxDepth (15)
+	// regardless of the exact counting convention.
+	errs := execErrors(t, s, nestedTraceLogQuery(20))
+	if len(errs) == 0 {
+		t.Fatal("expected a MaxDepthExceeded error for a deeply nested query, got none")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e, "MaxDepthExceeded") || strings.Contains(e, "depth") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("errors = %v, want a max-depth error", errs)
+	}
+}
+
+// TestMaxDepth_AllowsFrontendShapedQuery guards against setting MaxDepth too
+// low: the deepest real document the frontend sends (TraceById/TraceSpans —
+// trace { spans { ...SpanFields } } with SpanFields' nested `events`) must
+// still parse and execute without a depth error.
+func TestMaxDepth_AllowsFrontendShapedQuery(t *testing.T) {
+	s := seedStorage(t)
+	errs := execErrors(t, s, `{
+		trace(traceId: "02000000000000000000000000000000") {
+			traceId
+			serviceName
+			spanCount
+			startTime
+			durationMs
+			rootSpan { name kind statusCode durationMs }
+			spans {
+				traceId
+				spanId
+				parentSpanId
+				name
+				kind
+				serviceName
+				startTime
+				endTime
+				durationMs
+				statusCode
+				statusMessage
+				attributes
+				events { name timestamp attributes }
+				resource
+			}
+		}
+	}`)
+	for _, e := range errs {
+		if strings.Contains(e, "depth") || strings.Contains(e, "MaxDepth") {
+			t.Errorf("frontend-shaped query rejected on depth: %v", errs)
+		}
+	}
+}
+
+// TestMaxDepth_AllowsIntrospectionExample guards the standard schema
+// introspection query any GraphQL client runs to discover the schema before
+// it knows the field names:
+// '{ __schema { queryType { fields { name description args { name type { name ofType { name } } } } } } }'.
+// It is deeper than any real data query (7 levels under graph-gophers'
+// counting, root query field = depth 1) and must not be rejected.
+func TestMaxDepth_AllowsIntrospectionExample(t *testing.T) {
+	s := newTestStorage(t)
+	errs := execErrors(t, s, `{ __schema { queryType { fields { name description args { name type { name ofType { name } } } } } } }`)
+	for _, e := range errs {
+		if strings.Contains(e, "depth") || strings.Contains(e, "MaxDepth") {
+			t.Errorf("introspection example rejected on depth: %v", errs)
+		}
+	}
+}
+
+func TestMaxQueryLength_RejectsHugeQuery(t *testing.T) {
+	s := newTestStorage(t)
+	// Pad well past 50KB with a syntactically-valid (if pointless) alias list
+	// on a cheap field, so the query is rejected for length, not parse errors.
+	var b strings.Builder
+	b.WriteString("{ config { ")
+	for b.Len() < 60_000 {
+		b.WriteString("traceCount ")
+	}
+	b.WriteString("} }")
+
+	errs := execErrors(t, s, b.String())
+	if len(errs) == 0 {
+		t.Fatal("expected a max-query-length error for a 60KB query, got none")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e, "exceeds the maximum allowed query length") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("errors = %v, want a max query length error", errs)
+	}
+}
+
+func TestMaxQueryLength_AllowsRealisticQuery(t *testing.T) {
+	s := seedStorage(t)
+	// Nowhere near 50KB; must not be rejected.
+	errs := execErrors(t, s, `{ traces(limit: 10) { items { traceId serviceName } } }`)
+	if len(errs) != 0 {
+		t.Errorf("realistic-size query rejected: %v", errs)
+	}
+}
+
+// TestTracesLimit_ZeroClampsToDefault is the GraphQL-boundary regression
+// test for storage's pageLimit "limit <= 0 means unlimited" sentinel
+// (query_trace.go) being reachable directly through the `limit` arg — an
+// explicit `traces(limit: 0)` must return a bounded default page, not every
+// retained trace.
+func TestTracesLimit_ZeroClampsToDefault(t *testing.T) {
+	const n = 60 // comfortably above the 50-row default
+	s := seedManyTraces(t, n)
+
+	data := exec(t, s, `{ traces(limit: 0) { limit hasNextPage items { traceId } } }`, nil)
+	conn := data["traces"].(map[string]any)
+	if conn["limit"].(float64) != 50 {
+		t.Errorf("limit = %v, want 50 (the clamped default)", conn["limit"])
+	}
+	items := conn["items"].([]any)
+	if len(items) != 50 {
+		t.Fatalf("items len = %d, want 50 (clamped, not all %d retained traces)", len(items), n)
+	}
+	if !conn["hasNextPage"].(bool) {
+		t.Error("hasNextPage = false, want true (more than the clamped page remains)")
+	}
+}
+
+func TestTracesLimit_ExcessiveClampsToMax(t *testing.T) {
+	s := seedStorage(t)
+	data := exec(t, s, `{ traces(limit: 100000) { limit } }`, nil)
+	if got := data["traces"].(map[string]any)["limit"].(float64); got != 1000 {
+		t.Errorf("limit = %v, want 1000 (the clamped max)", got)
+	}
+}
+
+func TestLogsLimit_ZeroClampsToDefault(t *testing.T) {
+	s := seedStorage(t)
+	data := exec(t, s, `{ logs(limit: 0) { limit } }`, nil)
+	if got := data["logs"].(map[string]any)["limit"].(float64); got != 50 {
+		t.Errorf("limit = %v, want 50 (the clamped default)", got)
+	}
+}
+
+func TestLogsLimit_ExcessiveClampsToMax(t *testing.T) {
+	s := seedStorage(t)
+	data := exec(t, s, `{ logs(limit: 100000) { limit } }`, nil)
+	if got := data["logs"].(map[string]any)["limit"].(float64); got != 1000 {
+		t.Errorf("limit = %v, want 1000 (the clamped max)", got)
+	}
+}
+
+// TestMetricsLimit_ZeroClampsToMaxNotSmallDefault documents a deliberate
+// asymmetry: unlike traces/logs, the frontend's metrics list intentionally
+// sends an explicit `limit: 0` today to mean "every metric group" (see
+// hooks/use-initial-load.ts, hooks/use-metric-list-search.ts). Clamping that
+// sentinel down to the small 50-row page default would silently truncate
+// real metrics tabs with more than 50 (service, metric name) groups, so
+// metrics' zero-sentinel clamps to the generous hard cap (1000) instead —
+// still bounded, but high enough that no real deployment notices.
+func TestMetricsLimit_ZeroClampsToMaxNotSmallDefault(t *testing.T) {
+	s := seedStorage(t) // 1 metric group
+	data := exec(t, s, `{ metrics(limit: 0) { limit hasNextPage items { name } } }`, nil)
+	conn := data["metrics"].(map[string]any)
+	if got := conn["limit"].(float64); got != 1000 {
+		t.Errorf("limit = %v, want 1000 (metrics' zero-sentinel clamp target)", got)
+	}
+	if conn["hasNextPage"].(bool) {
+		t.Error("hasNextPage = true, want false")
+	}
+	if len(conn["items"].([]any)) != 1 {
+		t.Errorf("items len = %d, want 1 (unaffected by the clamp at this cardinality)", len(conn["items"].([]any)))
+	}
+}
+
+func TestMetricsLimit_ExcessiveClampsToMax(t *testing.T) {
+	s := seedStorage(t)
+	data := exec(t, s, `{ metrics(limit: 100000) { limit } }`, nil)
+	if got := data["metrics"].(map[string]any)["limit"].(float64); got != 1000 {
+		t.Errorf("limit = %v, want 1000 (the clamped max)", got)
+	}
+}

--- a/internal/graphql/resolver.go
+++ b/internal/graphql/resolver.go
@@ -31,6 +31,64 @@ func (r *Resolver) fullWindow() (from, to time.Time) {
 	return now.Add(-r.runtime.Retention - slack), now.Add(slack)
 }
 
+// graphQLListDefaultLimit and graphQLListMaxLimit bound every top-level
+// connection's page size at the GraphQL boundary, independent of storage's
+// own "limit <= 0 means unlimited" sentinel (see query_trace.go's pageLimit
+// doc comment). That sentinel exists for storage's internal callers (e.g.
+// internal/broadcast's predecessor batches) and stays as-is; a GraphQL
+// caller reaching it directly — e.g. traces(limit:0){spans{trace{logs{...}}}}
+// — would otherwise get every retained trace's full span/log graph in one
+// response, combinatorially worse once combined with the schema's circular
+// edges (see schema.go's MaxDepth comment).
+//
+// graphQLListDefaultLimit (50) matches schema.graphql's declared
+// `limit: Int = 50`, the value graph-gophers substitutes when a caller
+// omits the argument entirely — a resolver only ever observes limit <= 0
+// when a caller explicitly passes it. Clamping to the same number keeps
+// "explicitly zero" and "omitted" behaviorally identical for traces/logs,
+// values no real frontend caller sends today: hooks/use-trace-list-page.ts
+// and hooks/use-log-list-page.ts always pass an explicit positive
+// SIGNAL_PAGE_SIZE (100).
+//
+// graphQLListMaxLimit (1000) is the hard ceiling every connection clamps
+// down to when asked for more, and also clampUnboundedLimit's target for
+// limit <= 0 on the metrics query. That's a deliberate asymmetry: unlike
+// traces/logs, hooks/use-initial-load.ts and hooks/use-metric-list-search.ts
+// intentionally send an explicit `limit: 0` today to mean "every metric
+// group". Real (service, metric name) group cardinality stays far below
+// four figures, so clamping that sentinel to 1000 rather than 50 keeps that
+// existing behavior working in practice while still bounding the worst case.
+const (
+	graphQLListDefaultLimit = 50
+	graphQLListMaxLimit     = 1000
+)
+
+// clampLimit bounds a client-supplied `limit` argument to
+// [1, graphQLListMaxLimit], substituting graphQLListDefaultLimit for
+// storage's "unlimited" sentinel (limit <= 0). Used by traces and logs.
+func clampLimit(limit int32) int32 {
+	return clampLimitTo(limit, graphQLListDefaultLimit)
+}
+
+// clampUnboundedLimit is clampLimit's counterpart for connections whose
+// zero/negative sentinel must keep meaning "as many as we're willing to
+// serve" rather than shrink to the ordinary page-size default — see the
+// metrics case in the doc comment above. Used by metrics.
+func clampUnboundedLimit(limit int32) int32 {
+	return clampLimitTo(limit, graphQLListMaxLimit)
+}
+
+func clampLimitTo(limit, zeroDefault int32) int32 {
+	switch {
+	case limit <= 0:
+		return zeroDefault
+	case limit > graphQLListMaxLimit:
+		return graphQLListMaxLimit
+	default:
+		return limit
+	}
+}
+
 // stringArg unwraps an optional GraphQL string argument to storage's plain
 // "" (no-op filter) sentinel, since a nil `search` arg (omitted or explicit
 // null) means "no search" the same way an empty string does.
@@ -111,7 +169,8 @@ func (r *Resolver) Traces(ctx context.Context, args TracesArgs) (*ConnectionReso
 	if err != nil {
 		return nil, err
 	}
-	items, hasNextPage, err := r.storage.TracesPage(ctx, from, to, after, int(args.Limit), stringArg(args.Search))
+	limit := clampLimit(args.Limit)
+	items, hasNextPage, err := r.storage.TracesPage(ctx, from, to, after, int(limit), stringArg(args.Search))
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +178,7 @@ func (r *Resolver) Traces(ctx context.Context, args TracesArgs) (*ConnectionReso
 	for i := range items {
 		resolved[i] = newTraceResolver(r.storage, items[i])
 	}
-	return newConnection(resolved, hasNextPage, args.Limit, traceEndCursor(items), func(item *TraceResolver) *TraceResolver { return item }), nil
+	return newConnection(resolved, hasNextPage, limit, traceEndCursor(items), func(item *TraceResolver) *TraceResolver { return item }), nil
 }
 
 type TraceArgs struct {
@@ -151,11 +210,12 @@ func (r *Resolver) Metrics(ctx context.Context, args MetricsArgs) (*ConnectionRe
 	if err != nil {
 		return nil, err
 	}
-	items, hasNextPage, err := r.storage.MetricsPageSearch(ctx, from, to, after, int(args.Limit), stringArg(args.Search))
+	limit := clampUnboundedLimit(args.Limit)
+	items, hasNextPage, err := r.storage.MetricsPageSearch(ctx, from, to, after, int(limit), stringArg(args.Search))
 	if err != nil {
 		return nil, err
 	}
-	return newConnection(items, hasNextPage, args.Limit, metricEndCursor(items), func(m storage.MetricSummary) *MetricResolver {
+	return newConnection(items, hasNextPage, limit, metricEndCursor(items), func(m storage.MetricSummary) *MetricResolver {
 		return &MetricResolver{storage: r.storage, m: m, from: from, to: to}
 	}), nil
 }
@@ -179,18 +239,19 @@ func (r *Resolver) Logs(ctx context.Context, args LogsArgs) (*ConnectionResolver
 	if err != nil {
 		return nil, err
 	}
+	limit := clampLimit(args.Limit)
 	if args.TraceID != nil && *args.TraceID != "" {
 		// Trace correlation is a retained-history filter rather than a time
 		// window. Search remains an independent predicate and composes with it.
-		items, hasNextPage, err = r.storage.LogsPageByTraceID(ctx, *args.TraceID, after, int(args.Limit), stringArg(args.Search))
+		items, hasNextPage, err = r.storage.LogsPageByTraceID(ctx, *args.TraceID, after, int(limit), stringArg(args.Search))
 	} else {
 		from, to := r.resolveWindow(args.From, args.To)
-		items, hasNextPage, err = r.storage.LogsPage(ctx, from, to, after, int(args.Limit), stringArg(args.Search))
+		items, hasNextPage, err = r.storage.LogsPage(ctx, from, to, after, int(limit), stringArg(args.Search))
 	}
 	if err != nil {
 		return nil, err
 	}
-	return newConnection(items, hasNextPage, args.Limit, logEndCursor(items), func(l storage.LogDetail) *LogResolver {
+	return newConnection(items, hasNextPage, limit, logEndCursor(items), func(l storage.LogDetail) *LogResolver {
 		return &LogResolver{storage: r.storage, l: l}
 	}), nil
 }

--- a/internal/graphql/schema.go
+++ b/internal/graphql/schema.go
@@ -53,11 +53,44 @@ type RuntimeInfo struct {
 	MaxSizeDisplay   string
 }
 
+// maxQueryDepth bounds field nesting depth (graph-gophers counts the
+// top-level query/mutation field itself as depth 1, then +1 per nested
+// selection level — see internal/validation/validation.go's
+// validateMaxDepth in the graph-gophers/graphql-go v1.10.2 module source).
+// It exists because the schema has a circular Trace.spans <-> Span.trace
+// <-> Trace.logs <-> Log.trace edge with no built-in depth limit, so an
+// unbounded query like
+// `traces(limit:0){spans{trace{logs{trace{spans{...}}}}}}` would otherwise
+// make the resolver count grow with every extra nesting level a client
+// cares to type.
+//
+// The deepest real document is a standard GraphQL introspection query
+// (`{ __schema { queryType { fields { name description args { name type {
+// name ofType { name } } } } } } }`, the shape any GraphQL client — codegen
+// tooling, GraphiQL, an ad-hoc script — runs to discover the schema before
+// it knows the field names) at depth 7; the frontend's deepest data query
+// (trace { spans { ...SpanFields } }, whose SpanFields fragment nests
+// `events`) reaches depth 4. 15 is roughly double the deeper of the two
+// (7), leaving headroom for query shapes not enumerated here while still
+// keeping the circular edge's fan-out bounded.
+const maxQueryDepth = 15
+
+// maxQueryLength bounds the raw query document size in bytes. Every real
+// document (frontend's generated queries, the introspection example above)
+// is well under 1KB; 50KB is a generous multiple of that, comfortably above
+// any legitimate query while still rejecting a pathological giant document
+// before it reaches parsing/validation.
+const maxQueryLength = 50 * 1024
+
 // MustNewSchema parses the embedded schema and binds it to a resolver backed
 // by the given storage. It panics on schema errors so misconfigurations fail
 // at startup, not at query time.
 func MustNewSchema(s *storage.Storage, runtime RuntimeInfo) *gql.Schema {
-	return gql.MustParseSchema(schemaSource, &Resolver{storage: s, runtime: runtime}, gql.Tracer(slogTracer{}))
+	return gql.MustParseSchema(schemaSource, &Resolver{storage: s, runtime: runtime},
+		gql.Tracer(slogTracer{}),
+		gql.MaxDepth(maxQueryDepth),
+		gql.MaxQueryLength(maxQueryLength),
+	)
 }
 
 // Source returns the raw GraphQL schema document. Useful for tests and for


### PR DESCRIPTION
## Summary

The schema has circular `Trace.spans ↔ Span.trace ↔ Trace.logs` edges with no depth limit, and `limit <= 0` leaked storage's "unlimited" sentinel to clients — `traces(limit:0){spans{trace{logs{...}}}}` in one request could walk every retained trace's full span/log graph with exponentially growing resolver counts.

- **`MaxDepth(15)`** — graph-gophers counts the root field as depth 1; the deepest real documents are a standard introspection query (7) and the frontend's deepest data query (4), so 15 is ~2× headroom
- **`MaxQueryLength(50KB)`** — real documents are well under 1KB
- **Limit clamp at the GraphQL boundary** — `limit` clamps to [1, 1000]; `limit <= 0` becomes the schema default (50) for traces/logs. For metrics it deliberately clamps to 1000 instead: `use-initial-load.ts` / `use-metric-list-search.ts` send `limit: 0` today meaning "every metric group", and real group cardinality stays far below 1000, so the small default would have silently truncated the metrics tab. Storage's internal unlimited sentinel (used by broadcast's predecessor batches) is unchanged.

## Test plan

- [x] New tests: deep circular query rejected; frontend-shaped and introspection-shaped queries pass; `limit:0` and `limit:100000` clamp for traces/logs/metrics; oversized document rejected
- [x] `go test ./internal/graphql/...` / `go build ./...` pass, `golangci-lint` 0 issues