### PR TITLE
perf(frontend): parse timestamps once at the ingest boundary

### DIFF
--- a/frontend/src/components/metrics/metric-chart.tsx
+++ b/frontend/src/components/metrics/metric-chart.tsx
@@ -160,7 +160,9 @@ function ChartInner({
     for (const dp of metric.dataPoints) {
       const key = facetSeriesKey(dp.attributes, facet);
       if (!groups.has(key)) groups.set(key, []);
-      groups.get(key)!.push({ time: new Date(dp.timestamp), value: dp.value });
+      // dp.epochNs is already parsed (see lib/normalize.ts) — building the
+      // chart's Date from it avoids re-parsing dp.timestamp as a string.
+      groups.get(key)!.push({ time: new Date(Number(dp.epochNs / 1_000_000n)), value: dp.value });
     }
     const result: SeriesData[] = [];
     let i = 0;

--- a/frontend/src/components/traces/span-waterfall.tsx
+++ b/frontend/src/components/traces/span-waterfall.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { Group } from "@visx/group";
 import { scaleLinear } from "@visx/scale";
 import { ParentSize } from "@visx/responsive";
-import { Temporal } from "temporal-polyfill";
 import { useTooltip, TooltipWithBounds } from "@visx/tooltip";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { formatDuration, createDurationFormatter } from "@/lib/format";
@@ -50,25 +49,15 @@ interface TooltipData {
   name: string;
 }
 
-/** Parse ISO timestamp to nanoseconds relative to a base instant. */
-function toNsOffset(iso: string, baseNs: bigint): number {
-  try {
-    const ns = Temporal.Instant.from(iso).epochNanoseconds;
-    return Number(ns - baseNs);
-  } catch {
-    return -1;
-  }
+/** Offset of a span's pre-parsed start epoch relative to a base instant. */
+function toNsOffset(startEpochNs: bigint, baseNs: bigint): number {
+  return Number(startEpochNs - baseNs);
 }
 
 function compareByStartTime(a: SpanData, b: SpanData): number {
-  try {
-    return Temporal.Instant.compare(
-      Temporal.Instant.from(a.startTime),
-      Temporal.Instant.from(b.startTime),
-    );
-  } catch {
-    return 0;
-  }
+  if (a.startEpochNs < b.startEpochNs) return -1;
+  if (a.startEpochNs > b.startEpochNs) return 1;
+  return 0;
 }
 
 export function buildTree(spans: SpanData[]): FlatSpan[] {
@@ -169,29 +158,20 @@ function WaterfallInner({
     // full trace range (min start → max end) even for multi-root Codex traces.
     // Anchoring the waterfall to trace.rootSpan would truncate long-running
     // sibling branches when the representative root is short.
-    try {
-      const start = Temporal.Instant.from(trace.startTime).epochNanoseconds;
-      if (trace.duration > 0) return { baseNs: start, totalNs: trace.duration };
-    } catch {
-      /* fall through */
-    }
+    if (trace.duration > 0) return { baseNs: trace.startEpochNs, totalNs: trace.duration };
     let minNs: bigint | null = null;
     let maxNs: bigint | null = null;
     for (const f of flatSpans) {
-      try {
-        const s = Temporal.Instant.from(f.span.startTime).epochNanoseconds;
-        const e = Temporal.Instant.from(f.span.endTime).epochNanoseconds;
-        if (minNs === null || s < minNs) minNs = s;
-        if (maxNs === null || e > maxNs) maxNs = e;
-      } catch {
-        /* skip */
-      }
+      const s = f.span.startEpochNs;
+      const e = f.span.endEpochNs;
+      if (minNs === null || s < minNs) minNs = s;
+      if (maxNs === null || e > maxNs) maxNs = e;
     }
     if (minNs !== null && maxNs !== null && maxNs > minNs) {
       return { baseNs: minNs, totalNs: Number(maxNs - minNs) };
     }
     return { baseNs: 0n, totalNs: 1 };
-  }, [trace.startTime, trace.duration, flatSpans]);
+  }, [trace.startEpochNs, trace.duration, flatSpans]);
 
   const barWidth = width - LABEL_WIDTH;
   const xScale = useMemo(
@@ -347,7 +327,7 @@ function WaterfallInner({
           ))}
 
           {visibleSpans.map((f, i) => {
-            const startOffset = toNsOffset(f.span.startTime, baseNs);
+            const startOffset = toNsOffset(f.span.startEpochNs, baseNs);
             const spanDurNs = f.span.duration > 0 ? f.span.duration : 0;
             const x = xScale(Math.max(startOffset, 0));
             const w = Math.max(xScale(spanDurNs) - xScale(0), MIN_BAR_WIDTH);

--- a/frontend/src/hooks/use-initial-load.ts
+++ b/frontend/src/hooks/use-initial-load.ts
@@ -3,6 +3,7 @@ import { useSetAtom } from "jotai";
 import { graphql } from "@/gql";
 import { gqlClient } from "@/lib/graphql";
 import { setMetricsAtom, setTotalCountsAtom, renderWindowMaxAtom } from "@/stores/telemetry";
+import { normalizeMetric } from "@/lib/normalize";
 import type { MetricData } from "@/types/telemetry";
 
 // Ring-buffer capacity config (traceCap/metricCap/logCap/maxDataPoints) was
@@ -80,7 +81,9 @@ export function useInitialLoad() {
         // every metric enters the buffer empty and fills in lazily — via a
         // detail view's use-metric-range-points fetch, or a WS delivery
         // merging in through addMetricAtom.
-        const metrics: MetricData[] = data.metrics.items.map((m) => ({ ...m, dataPoints: [] }));
+        const metrics: MetricData[] = data.metrics.items.map((m) =>
+          normalizeMetric({ ...m, dataPoints: [] }),
+        );
         setMetrics(metrics);
       } catch {
         // WebSocket will deliver data later.

--- a/frontend/src/hooks/use-log-list-page.ts
+++ b/frontend/src/hooks/use-log-list-page.ts
@@ -10,6 +10,7 @@ import {
 } from "@/stores/telemetry";
 import type { LogData } from "@/types/telemetry";
 import type { EventTimeWindow } from "@/lib/event-time-window";
+import { normalizeLog } from "@/lib/normalize";
 import {
   useSignalListPage,
   type FetchPageArgs,
@@ -76,7 +77,7 @@ export function useLogListPage(
         traceId,
       });
       return {
-        items: data.logs.items,
+        items: data.logs.items.map(normalizeLog),
         hasNextPage: data.logs.hasNextPage,
         endCursor: data.logs.endCursor ?? null,
       };

--- a/frontend/src/hooks/use-metric-list-search.ts
+++ b/frontend/src/hooks/use-metric-list-search.ts
@@ -3,6 +3,7 @@ import { useSetAtom } from "jotai";
 import { graphql } from "@/gql";
 import { gqlClient } from "@/lib/graphql";
 import { metricSearchResultAtom } from "@/stores/telemetry";
+import { normalizeMetric } from "@/lib/normalize";
 import type { MetricData } from "@/types/telemetry";
 
 const MetricsListQuery = graphql(`
@@ -46,7 +47,9 @@ export function useMetricListSearch(search: string): void {
       try {
         const data = await gqlClient.request(MetricsListQuery, { search });
         if (ignore) return;
-        const items: MetricData[] = data.metrics.items.map((m) => ({ ...m, dataPoints: [] }));
+        const items: MetricData[] = data.metrics.items.map((m) =>
+          normalizeMetric({ ...m, dataPoints: [] }),
+        );
         setSearchResult({ search, items });
       } catch {
         // Keep the previous result; the next search edit retries.

--- a/frontend/src/hooks/use-metric-range-points.ts
+++ b/frontend/src/hooks/use-metric-range-points.ts
@@ -9,6 +9,7 @@ import {
   type EventTimeWindow,
 } from "@/lib/event-time-window";
 import { useStableArray } from "@/hooks/use-stable-array";
+import { normalizeDataPoint } from "@/lib/normalize";
 import type { DataPoint, MetricData } from "@/types/telemetry";
 
 const MetricPointsQuery = graphql(`
@@ -73,7 +74,7 @@ export function useMetricRangePoints(metric: MetricData, window: EventTimeWindow
           ...queryBounds,
         });
         if (!cancelled) {
-          setSnapshot({ metricKey, points: data.metricPoints });
+          setSnapshot({ metricKey, points: data.metricPoints.map(normalizeDataPoint) });
         }
       } catch {
         // Fall back to whatever the live buffer already holds.
@@ -98,7 +99,7 @@ export function useMetricRangePoints(metric: MetricData, window: EventTimeWindow
   // MetricSummary, DataPointsTable — driven off this hook's return value)
   // skip re-rendering when the window's actual content didn't move.
   const windowed = useMemo(
-    () => filterPointsInEventWindow(merged, window, (dp) => dp.timestamp),
+    () => filterPointsInEventWindow(merged, window, (dp) => dp.epochNs),
     [merged, window],
   );
   return useStableArray(windowed, (dp) => dp.id);

--- a/frontend/src/hooks/use-trace-by-id.ts
+++ b/frontend/src/hooks/use-trace-by-id.ts
@@ -4,6 +4,7 @@ import { graphql } from "@/gql";
 import type { TraceByIdQuery } from "@/gql/graphql";
 import { gqlClient } from "@/lib/graphql";
 import { MS_TO_NS, toSpan } from "@/lib/span-mapping";
+import { normalizeTrace } from "@/lib/normalize";
 import { cacheTraceAtom } from "@/stores/telemetry";
 import type { SpanStatus, TraceData } from "@/types/telemetry";
 
@@ -37,7 +38,7 @@ interface LoadState {
 }
 
 function toTraceData(trace: NonNullable<TraceByIdQuery["trace"]>): TraceData {
-  return {
+  return normalizeTrace({
     traceId: trace.traceId,
     serviceName: trace.serviceName,
     spanCount: trace.spanCount,
@@ -51,8 +52,12 @@ function toTraceData(trace: NonNullable<TraceByIdQuery["trace"]>): TraceData {
           duration: trace.rootSpan.durationMs * MS_TO_NS,
         }
       : undefined,
+    // toSpan already normalizes each span; normalizeTrace's own per-span map
+    // below just re-derives the same epoch values from startTime/endTime
+    // (idempotent) rather than trusting them as pre-parsed, so this stays
+    // the single normalizeTrace call site for every TraceData construction.
     spans: trace.spans.map(toSpan),
-  };
+  });
 }
 
 async function loadTrace(traceId: string) {

--- a/frontend/src/hooks/use-trace-list-page.ts
+++ b/frontend/src/hooks/use-trace-list-page.ts
@@ -12,6 +12,7 @@ import {
 import type { EventTimeWindow } from "@/lib/event-time-window";
 import type { TraceData, SpanStatus } from "@/types/telemetry";
 import { MS_TO_NS } from "@/lib/span-mapping";
+import { normalizeTrace } from "@/lib/normalize";
 import {
   useSignalListPage,
   type FetchPageArgs,
@@ -50,7 +51,7 @@ function toTraceData({
   rootSpan,
   ...rest
 }: TracesPageQueryType["traces"]["items"][number]): TraceData {
-  return {
+  return normalizeTrace({
     ...rest,
     duration: durationMs * MS_TO_NS,
     rootSpan: rootSpan
@@ -64,7 +65,7 @@ function toTraceData({
     // Full span data is fetched lazily once a trace's detail view needs it —
     // see hooks/use-trace-spans.ts.
     spans: [],
-  };
+  });
 }
 
 // Fetches the traces tab page-by-page: browsing starts within `range`, then

--- a/frontend/src/hooks/use-websocket.test.tsx
+++ b/frontend/src/hooks/use-websocket.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vite-plus/test";
+import { renderHook } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { ReactNode } from "react";
+import { useWebSocket } from "./use-websocket";
+import { tracesAtom, metricsAtom, logsAtom } from "@/stores/telemetry";
+import { parseEpochNs } from "@/lib/normalize";
+
+// vi.mock's factory is hoisted above every top-level statement in this file,
+// so the mock socket/message-listener registry it needs must live inside
+// vi.hoisted rather than as an outer const the factory closes over.
+const { simulateMessage, listeners } = vi.hoisted(() => {
+  const listeners: Array<(msg: unknown) => void> = [];
+  return {
+    listeners,
+    simulateMessage: (msg: unknown) => {
+      for (const listener of listeners) listener(msg);
+    },
+  };
+});
+
+// A fake WsManager whose subscribe() immediately reports "connected" and
+// records the subscriber's onMessage — this test only exercises
+// useWebSocket's normalize-then-dispatch behavior, not WsManager's own
+// connect/reconnect lifecycle (see lib/websocket-manager.test.ts for that).
+vi.mock("@/lib/websocket-manager", () => ({
+  wsManager: {
+    subscribe(subscriber: { onStatus: (s: string) => void; onMessage: (msg: unknown) => void }) {
+      subscriber.onStatus("connected");
+      listeners.push(subscriber.onMessage);
+      return () => {
+        const idx = listeners.indexOf(subscriber.onMessage);
+        if (idx >= 0) listeners.splice(idx, 1);
+      };
+    },
+  },
+}));
+
+function renderWithStore() {
+  const store = createStore();
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  renderHook(() => useWebSocket(), { wrapper });
+  return store;
+}
+
+// This hook is the single place a WS delivery (still wire-shaped: ISO
+// timestamp strings, no epoch field — see types/telemetry.ts) gets
+// normalized before entering the store (see lib/normalize.ts's doc comment
+// on why every ingest entry point must route through it).
+describe("useWebSocket", () => {
+  it("normalizes a wire trace delivery into a view model with startEpochNs", () => {
+    const store = renderWithStore();
+
+    simulateMessage({
+      type: "traces",
+      data: {
+        traceId: "t1",
+        serviceName: "frontend",
+        spans: [],
+        spanCount: 1,
+        startTime: "2024-01-01T00:00:00.123456789Z",
+        duration: 1_000_000,
+      },
+    });
+
+    const trace = store.get(tracesAtom)[0];
+    expect(trace?.startEpochNs).toBe(parseEpochNs("2024-01-01T00:00:00.123456789Z"));
+  });
+
+  it("normalizes a wire metric delivery's data points into view models with epochNs", () => {
+    const store = renderWithStore();
+
+    simulateMessage({
+      type: "metrics",
+      data: {
+        name: "http.requests",
+        description: "",
+        unit: "",
+        type: "Sum",
+        serviceName: "frontend",
+        resource: {},
+        dataPoints: [
+          { id: "a", timestamp: "2024-01-01T00:00:00.500000000Z", value: 1, attributes: {} },
+        ],
+        pointCount: 1,
+        latestValue: 1,
+        receivedAt: "2024-01-01T00:00:00Z",
+      },
+    });
+
+    const point = store.get(metricsAtom)[0]?.dataPoints[0];
+    expect(point?.epochNs).toBe(parseEpochNs("2024-01-01T00:00:00.500000000Z"));
+  });
+
+  it("normalizes a wire log delivery into a view model with epochNs", () => {
+    const store = renderWithStore();
+
+    simulateMessage({
+      type: "logs",
+      data: {
+        id: "log-1",
+        timestamp: "2024-01-01T00:00:00.777777777Z",
+        observedTimestamp: "2024-01-01T00:00:00.777777777Z",
+        traceId: "",
+        spanId: "",
+        severityNumber: 9,
+        severityText: "INFO",
+        body: "hello",
+        serviceName: "frontend",
+        attributes: {},
+        resource: {},
+      },
+    });
+
+    const log = store.get(logsAtom)[0];
+    expect(log?.epochNs).toBe(parseEpochNs("2024-01-01T00:00:00.777777777Z"));
+  });
+});

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -7,7 +7,13 @@ import {
   addLogAtom,
   wsStatusAtom,
 } from "@/stores/telemetry";
-import type { TraceData, TraceDeleteData, MetricData, LogData } from "@/types/telemetry";
+import type {
+  TraceDataWire,
+  TraceDeleteData,
+  MetricDataWire,
+  LogDataWire,
+} from "@/types/telemetry";
+import { normalizeTrace, normalizeMetric, normalizeLog } from "@/lib/normalize";
 import { wsManager } from "@/lib/websocket-manager";
 
 // useWebSocket is a thin adapter that bridges the module-level WsManager to
@@ -25,19 +31,24 @@ export function useWebSocket(): void {
   useEffect(() => {
     const unsubscribe = wsManager.subscribe({
       onStatus: setWsStatus,
+      // The manager only JSON.parses the WS payload — it's still wire-shaped
+      // (ISO timestamp strings, no epoch fields). This is the single place
+      // that normalizes a live delivery before it reaches the store, so
+      // addTraceAtom/addMetricAtom/addLogAtom never see an un-normalized
+      // record (see lib/normalize.ts).
       onMessage: (msg) => {
         switch (msg.type) {
           case "traces":
-            addTrace(msg.data as TraceData);
+            addTrace(normalizeTrace(msg.data as TraceDataWire));
             break;
           case "trace-deletes":
             removeTrace((msg.data as TraceDeleteData).traceId);
             break;
           case "metrics":
-            addMetric(msg.data as MetricData);
+            addMetric(normalizeMetric(msg.data as MetricDataWire));
             break;
           case "logs":
-            addLog(msg.data as LogData);
+            addLog(normalizeLog(msg.data as LogDataWire));
             break;
         }
       },

--- a/frontend/src/lib/chart-time-range.test.ts
+++ b/frontend/src/lib/chart-time-range.test.ts
@@ -181,69 +181,105 @@ describe("isChartTimeRange", () => {
   });
 });
 
+// Every point carries a pre-parsed epoch-ns field (see lib/normalize.ts) —
+// these tests build that field directly with Temporal rather than going
+// through a view model, since chart-time-range.ts is agnostic to which
+// record type it's filtering.
+function ns(iso: string): bigint {
+  return Temporal.Instant.from(iso).epochNanoseconds;
+}
+
 describe("filterDataPointsInRange", () => {
   it("returns everything unfiltered for 'all'", () => {
-    const points = [{ timestamp: "2024-01-01T00:00:00Z" }, { timestamp: "2024-01-01T00:10:00Z" }];
+    const points = [
+      { epochNs: ns("2024-01-01T00:00:00Z") },
+      { epochNs: ns("2024-01-01T00:10:00Z") },
+    ];
 
-    expect(filterDataPointsInRange(points, "all")).toEqual(points);
+    expect(filterDataPointsInRange(points, "all", (p) => p.epochNs)).toEqual(points);
   });
 
   it("returns [] unchanged for an empty input", () => {
-    expect(filterDataPointsInRange([], "5m")).toEqual([]);
+    expect(filterDataPointsInRange([], "5m", (p: { epochNs: bigint }) => p.epochNs)).toEqual([]);
   });
 
-  it("anchors the window on the max timestamp, not wall-clock", () => {
-    const inWindow = { timestamp: "2024-01-01T00:19:00Z" };
-    const outOfWindow = { timestamp: "2024-01-01T00:00:00Z" };
-    const max = { timestamp: "2024-01-01T00:20:00Z" };
+  it("anchors the window on the max epoch, not wall-clock", () => {
+    const inWindow = { epochNs: ns("2024-01-01T00:19:00Z") };
+    const outOfWindow = { epochNs: ns("2024-01-01T00:00:00Z") };
+    const max = { epochNs: ns("2024-01-01T00:20:00Z") };
 
-    expect(filterDataPointsInRange([outOfWindow, inWindow, max], "5m")).toEqual([inWindow, max]);
+    expect(filterDataPointsInRange([outOfWindow, inWindow, max], "5m", (p) => p.epochNs)).toEqual([
+      inWindow,
+      max,
+    ]);
   });
 
   it("includes a point exactly at the window boundary", () => {
-    const max = { timestamp: "2024-01-01T00:05:00Z" };
-    const boundary = { timestamp: "2024-01-01T00:00:00Z" };
+    const max = { epochNs: ns("2024-01-01T00:05:00Z") };
+    const boundary = { epochNs: ns("2024-01-01T00:00:00Z") };
 
-    expect(filterDataPointsInRange([boundary, max], "5m")).toEqual([boundary, max]);
+    expect(filterDataPointsInRange([boundary, max], "5m", (p) => p.epochNs)).toEqual([
+      boundary,
+      max,
+    ]);
+  });
+
+  it("distinguishes points that differ only in sub-millisecond precision (ns precision preserved)", () => {
+    const earlier = { epochNs: ns("2024-01-01T00:00:00.000000001Z") };
+    const later = { epochNs: ns("2024-01-01T00:00:00.000000002Z") };
+
+    // A 0-width-in-ms range anchored on `later` still excludes `earlier`
+    // once the range is smaller than their 1ns gap in wall-clock terms —
+    // exercised here via "all" (no filtering) to assert the two epochs
+    // themselves are distinguishable, not collapsed to the same millisecond.
+    expect(later.epochNs - earlier.epochNs).toBe(1n);
+    expect(filterDataPointsInRange([earlier, later], "all", (p) => p.epochNs)).toEqual([
+      earlier,
+      later,
+    ]);
   });
 
   it("preserves extra fields on the filtered items", () => {
-    const points = [{ timestamp: "2024-01-01T00:00:00Z", value: 42 }];
+    const points = [{ epochNs: ns("2024-01-01T00:00:00Z"), value: 42 }];
 
-    expect(filterDataPointsInRange(points, "all")).toEqual(points);
+    expect(filterDataPointsInRange(points, "all", (p) => p.epochNs)).toEqual(points);
   });
 
-  it("parses each point's timestamp exactly once (single pass, not a max-finding pass plus a filter pass)", () => {
+  it("reads each point's epoch exactly once (single pass, not a max-finding pass plus a filter pass)", () => {
     const points = [
-      { timestamp: "2024-01-01T00:00:00Z" },
-      { timestamp: "2024-01-01T00:10:00Z" },
-      { timestamp: "2024-01-01T00:20:00Z" },
+      { epochNs: ns("2024-01-01T00:00:00Z") },
+      { epochNs: ns("2024-01-01T00:10:00Z") },
+      { epochNs: ns("2024-01-01T00:20:00Z") },
     ];
-    const getTimestamp = vi.fn((p: (typeof points)[number]) => p.timestamp);
+    const getEpochNs = vi.fn((p: (typeof points)[number]) => p.epochNs);
 
-    filterDataPointsInRange(points, "5m", getTimestamp);
+    filterDataPointsInRange(points, "5m", getEpochNs);
 
-    expect(getTimestamp).toHaveBeenCalledTimes(points.length);
+    expect(getEpochNs).toHaveBeenCalledTimes(points.length);
   });
 
-  describe("with an explicit getTimestamp selector", () => {
-    // Trace rows carry their instant under `startTime`, not `timestamp` (see
-    // types/telemetry.ts) — the trace/log list's live-tail display filter
-    // (stores/filters.ts) passes a selector rather than reshaping every row.
+  describe("with an explicit getEpochNs selector", () => {
+    // Trace rows carry their instant under `startEpochNs`, not `epochNs`
+    // (see types/telemetry.ts) — the trace/log list's live-tail display
+    // filter (stores/filters.ts) passes a selector rather than reshaping
+    // every row.
     it("anchors the window on the max value the selector returns", () => {
-      const inWindow = { startTime: "2024-01-01T00:19:00Z" };
-      const outOfWindow = { startTime: "2024-01-01T00:00:00Z" };
-      const max = { startTime: "2024-01-01T00:20:00Z" };
+      const inWindow = { startEpochNs: ns("2024-01-01T00:19:00Z") };
+      const outOfWindow = { startEpochNs: ns("2024-01-01T00:00:00Z") };
+      const max = { startEpochNs: ns("2024-01-01T00:20:00Z") };
 
       expect(
-        filterDataPointsInRange([outOfWindow, inWindow, max], "5m", (p) => p.startTime),
+        filterDataPointsInRange([outOfWindow, inWindow, max], "5m", (p) => p.startEpochNs),
       ).toEqual([inWindow, max]);
     });
 
     it("returns everything unfiltered for 'all'", () => {
-      const points = [{ startTime: "2024-01-01T00:00:00Z" }, { startTime: "2024-01-01T00:10:00Z" }];
+      const points = [
+        { startEpochNs: ns("2024-01-01T00:00:00Z") },
+        { startEpochNs: ns("2024-01-01T00:10:00Z") },
+      ];
 
-      expect(filterDataPointsInRange(points, "all", (p) => p.startTime)).toEqual(points);
+      expect(filterDataPointsInRange(points, "all", (p) => p.startEpochNs)).toEqual(points);
     });
   });
 });

--- a/frontend/src/lib/chart-time-range.ts
+++ b/frontend/src/lib/chart-time-range.ts
@@ -135,49 +135,43 @@ export function filterPointsInDomain<T extends { time: Date }>(
 // timestamped rows (DataPoint / AggregatePointData) instead of the chart's
 // {time: Date} shape — so callers computing range-scoped totals (stat tiles,
 // the data points table) can filter without going through the chart's
-// render pipeline. Uses Temporal, not Date.parse, per the project's
-// OTel-timestamp convention (Date truncates the nanosecond precision OTel
-// timestamps carry).
+// render pipeline.
 //
-// getTimestamp defaults to reading `.timestamp` (DataPoint/AggregatePoint's
-// shape); trace rows carry their instant under `startTime` instead, so the
-// trace/log list's live-tail display filter (components/traces/trace-list.tsx,
-// components/logs/log-list.tsx) passes an explicit selector rather than
-// reshaping every row just to satisfy this function's default field name.
-export function filterDataPointsInRange<T extends { timestamp: string }>(
-  points: T[],
-  range: ChartTimeRange,
-): T[];
+// getEpochNs is mandatory (no default field-name guess): every store view
+// model (TraceData/LogData/DataPoint — see types/telemetry.ts) already
+// carries a pre-parsed epoch-ns field via lib/normalize.ts, so callers pass a
+// trivial field accessor instead of a timestamp string this function would
+// have to re-parse. A caller with no such field (e.g. the ephemeral
+// AggregatePointData from a server-aggregated fetch) parses via
+// lib/normalize.ts's parseEpochNs at the call site instead — still the
+// single Temporal.Instant.from call site, just invoked explicitly rather
+// than implicitly by this function.
 export function filterDataPointsInRange<T>(
   points: T[],
   range: ChartTimeRange,
-  getTimestamp: (point: T) => string,
-): T[];
-export function filterDataPointsInRange<T>(
-  points: T[],
-  range: ChartTimeRange,
-  getTimestamp: (point: T) => string = (p) => (p as { timestamp: string }).timestamp,
+  getEpochNs: (point: T) => bigint,
 ): T[] {
   const rangeMs = rangeToMs(range);
   if (rangeMs === null || points.length === 0) return points;
+  const rangeNs = BigInt(rangeMs) * 1_000_000n;
 
-  // Single pass: parse each point's timestamp exactly once, caching the
-  // epoch value alongside it while tracking the max, then filter against the
-  // cached values instead of re-parsing every point a second time. Called on
-  // every WS message via stores/filters.ts's rangeFilteredTracesAtom/
-  // rangeFilteredLogsAtom over the full capped buffer, so halving the
-  // Temporal.Instant.from calls matters here.
-  let maxMs = -Infinity;
-  const withMs: { point: T; ms: number }[] = [];
+  // Single pass: read each point's epoch exactly once, caching it alongside
+  // the point while tracking the max, then filter against the cached values
+  // instead of reading every point a second time. Called on every WS message
+  // via stores/filters.ts's rangeFilteredTracesAtom/rangeFilteredLogsAtom
+  // over the full capped buffer.
+  const withNs: { point: T; ns: bigint }[] = [];
+  let maxNs: bigint | undefined;
   for (const point of points) {
-    const ms = Temporal.Instant.from(getTimestamp(point)).epochMilliseconds;
-    withMs.push({ point, ms });
-    if (ms > maxMs) maxMs = ms;
+    const ns = getEpochNs(point);
+    withNs.push({ point, ns });
+    if (maxNs === undefined || ns > maxNs) maxNs = ns;
   }
-  const minMs = maxMs - rangeMs;
+  // maxNs is always set here: the empty-input case already returned above.
+  const minNs = maxNs! - rangeNs;
   const result: T[] = [];
-  for (const { point, ms } of withMs) {
-    if (ms >= minMs) result.push(point);
+  for (const { point, ns } of withNs) {
+    if (ns >= minNs) result.push(point);
   }
   return result;
 }

--- a/frontend/src/lib/event-time-window.test.ts
+++ b/frontend/src/lib/event-time-window.test.ts
@@ -101,12 +101,12 @@ describe("event time window", () => {
       to: "2026-07-12T02:00:00Z",
     };
     const points = [
-      { timestamp: "2026-07-12T00:59:59Z" },
-      { timestamp: "2026-07-12T01:30:00Z" },
-      { timestamp: "2026-07-12T02:00:01Z" },
+      { epochNs: Temporal.Instant.from("2026-07-12T00:59:59Z").epochNanoseconds },
+      { epochNs: Temporal.Instant.from("2026-07-12T01:30:00Z").epochNanoseconds },
+      { epochNs: Temporal.Instant.from("2026-07-12T02:00:01Z").epochNanoseconds },
     ];
 
-    expect(filterPointsInEventWindow(points, window, (point) => point.timestamp)).toEqual([
+    expect(filterPointsInEventWindow(points, window, (point) => point.epochNs)).toEqual([
       points[1],
     ]);
     expect(eventWindowDomain([], window)).toEqual([

--- a/frontend/src/lib/event-time-window.ts
+++ b/frontend/src/lib/event-time-window.ts
@@ -104,16 +104,16 @@ export function eventWindowEquals(a: EventTimeWindow, b: EventTimeWindow): boole
 export function filterPointsInEventWindow<T>(
   points: T[],
   window: EventTimeWindow,
-  getTimestamp: (point: T) => string,
+  getEpochNs: (point: T) => bigint,
 ): T[] {
-  if (window.mode === "live") return filterDataPointsInRange(points, window.range, getTimestamp);
-  const from = Temporal.Instant.from(window.from);
-  const to = Temporal.Instant.from(window.to);
+  if (window.mode === "live") return filterDataPointsInRange(points, window.range, getEpochNs);
+  // window.from/to are parsed once here (not per point) — a window's bounds
+  // change far less often than the points filtered against them.
+  const fromNs = Temporal.Instant.from(window.from).epochNanoseconds;
+  const toNs = Temporal.Instant.from(window.to).epochNanoseconds;
   return points.filter((point) => {
-    const instant = Temporal.Instant.from(getTimestamp(point));
-    return (
-      Temporal.Instant.compare(instant, from) >= 0 && Temporal.Instant.compare(instant, to) <= 0
-    );
+    const ns = getEpochNs(point);
+    return ns >= fromNs && ns <= toNs;
   });
 }
 

--- a/frontend/src/lib/export.test.ts
+++ b/frontend/src/lib/export.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
-import { copyJsonToClipboard } from "./export";
+import { copyJsonToClipboard, downloadJson } from "./export";
 
 describe("copyJsonToClipboard", () => {
   const writeText = vi.fn();
@@ -23,5 +23,37 @@ describe("copyJsonToClipboard", () => {
     writeText.mockRejectedValue(new Error("denied"));
     const ok = await copyJsonToClipboard({ a: 1 });
     expect(ok).toBe(false);
+  });
+
+  // Store view models (TraceData/LogData/DataPoint) carry a derived bigint
+  // epoch field alongside their wire timestamp string — plain
+  // JSON.stringify throws on a bigint with no replacer.
+  it("does not throw on a record carrying a bigint field, and serializes it as a string", async () => {
+    const data = { traceId: "t1", startEpochNs: 1704067200123456789n };
+
+    const ok = await copyJsonToClipboard(data);
+
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalledWith(
+      JSON.stringify({ traceId: "t1", startEpochNs: "1704067200123456789" }, null, 2),
+    );
+  });
+});
+
+describe("downloadJson", () => {
+  it("does not throw on a record carrying a bigint field", () => {
+    const originalCreateObjectURL = URL.createObjectURL.bind(URL);
+    const originalRevokeObjectURL = URL.revokeObjectURL.bind(URL);
+    URL.createObjectURL = vi.fn(() => "blob:mock");
+    URL.revokeObjectURL = vi.fn();
+
+    try {
+      expect(() =>
+        downloadJson({ id: "log-1", epochNs: 1704067200123456789n }, "log-1.json"),
+      ).not.toThrow();
+    } finally {
+      URL.createObjectURL = originalCreateObjectURL;
+      URL.revokeObjectURL = originalRevokeObjectURL;
+    }
   });
 });

--- a/frontend/src/lib/export.ts
+++ b/frontend/src/lib/export.ts
@@ -1,6 +1,23 @@
+// Store view models (TraceData/LogData/DataPoint — see types/telemetry.ts)
+// carry derived bigint epoch fields alongside their wire ISO-string
+// timestamps; JSON.stringify throws on a bigint with no replacer. Both JSON
+// boundaries below copy/export whatever record a caller hands them
+// (trace-detail.tsx's CopyJsonButton/download, log-list.tsx's
+// CopyJsonButton), so this replacer — not per-caller field stripping — is
+// the one place that makes any record JSON-safe. Deliberately not a global
+// BigInt.prototype.toJSON patch, which would silently change how bigints
+// serialize everywhere in the app instead of just at this export boundary.
+function bigintSafeReplacer(_key: string, value: unknown): unknown {
+  return typeof value === "bigint" ? value.toString() : value;
+}
+
+function stringifyJson(data: unknown): string {
+  return JSON.stringify(data, bigintSafeReplacer, 2);
+}
+
 export async function copyJsonToClipboard(data: unknown): Promise<boolean> {
   try {
-    const json = JSON.stringify(data, null, 2);
+    const json = stringifyJson(data);
     await navigator.clipboard.writeText(json);
     return true;
   } catch {
@@ -9,7 +26,7 @@ export async function copyJsonToClipboard(data: unknown): Promise<boolean> {
 }
 
 export function downloadJson(data: unknown, filename: string): void {
-  const json = JSON.stringify(data, null, 2);
+  const json = stringifyJson(data);
   const blob = new Blob([json], { type: "application/json" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");

--- a/frontend/src/lib/metric-stats.test.ts
+++ b/frontend/src/lib/metric-stats.test.ts
@@ -9,6 +9,7 @@ import {
   type StatTilesInput,
 } from "./metric-stats";
 import { makeDataPoint, makeAggregatePoint, makeAggregateSeries } from "@/test/factories";
+import { parseEpochNs } from "@/lib/normalize";
 
 const MODEL_FACET = { attributes: ["model"], label: "model" };
 
@@ -282,7 +283,12 @@ describe("computeStatTiles — aggregate (facet active) path", () => {
     );
 
     expect(groups[0]?.points).toEqual([
-      { timestamp: "2024-01-01T00:10:00Z", value: 5, count: null },
+      {
+        timestamp: "2024-01-01T00:10:00Z",
+        epochNs: parseEpochNs("2024-01-01T00:10:00Z"),
+        value: 5,
+        count: null,
+      },
     ]);
   });
 });

--- a/frontend/src/lib/metric-stats.ts
+++ b/frontend/src/lib/metric-stats.ts
@@ -2,7 +2,7 @@ import type { DataPoint } from "@/types/telemetry";
 import type { MetricFacet } from "@/lib/metric-catalog";
 import { type ChartTimeRange, filterDataPointsInRange } from "@/lib/chart-time-range";
 import type { AggregateSeriesData } from "@/hooks/use-metric-aggregate-series";
-import { Temporal } from "temporal-polyfill";
+import { parseEpochNs } from "@/lib/normalize";
 
 /** Serialize attributes to a stable string key for grouping. */
 export function attrKey(attrs: Record<string, unknown>): string {
@@ -114,6 +114,7 @@ export function hasIncreaseStatTileSignal(dataPoints: DataPoint[]): boolean {
 
 interface StatTilePoint {
   timestamp: string;
+  epochNs: bigint;
   value: number;
   count?: number | null;
 }
@@ -129,12 +130,9 @@ export type StatTileMode = "increase" | "latest";
 
 function latestPoint(points: StatTilePoint[]): StatTilePoint | undefined {
   let latest: StatTilePoint | undefined;
-  let latestInstant: Temporal.Instant | undefined;
   for (const point of points) {
-    const instant = Temporal.Instant.from(point.timestamp);
-    if (!latestInstant || Temporal.Instant.compare(instant, latestInstant) > 0) {
+    if (!latest || point.epochNs > latest.epochNs) {
       latest = point;
-      latestInstant = instant;
     }
   }
   return latest;
@@ -188,13 +186,23 @@ export function statTileGroupsFromAggregate(
   const resolved = resolveFacetGroupColorIndex(aggregatedSeries, rangeDataPoints, facet);
   return aggregatedSeries.map((s, i) => {
     const { label, colorIndex } = resolved[i]!;
-    const windowed = filterDataPointsInRange(s.points, range);
+    // AggregatePointData is an ephemeral server-fetch result (not a store
+    // view model — see hooks/use-metric-aggregate-series.ts), so it has no
+    // pre-parsed epoch field; parseEpochNs is called explicitly here, the
+    // one sanctioned per-call-site exception to lib/normalize.ts owning
+    // every Temporal.Instant.from call (this array tops out around 150
+    // server-aggregated buckets, not the capped live buffer the trace/log
+    // filters run over). Parsed once per point, then reused for both the
+    // range filter and the returned points.
+    const withEpoch = s.points.map((p) => ({ ...p, epochNs: parseEpochNs(p.timestamp) }));
+    const windowed = filterDataPointsInRange(withEpoch, range, (p) => p.epochNs);
     return {
       key: label,
       label,
       colorIndex,
       points: windowed.map((p) => ({
         timestamp: p.timestamp,
+        epochNs: p.epochNs,
         value: p.value,
         count: p.count,
       })),
@@ -211,7 +219,9 @@ export function statTileGroupsFromRawPoints(
   range: ChartTimeRange,
 ): StatTileGroup[] {
   const order = facetGroupOrder(rangeDataPoints, facet);
-  const windowed = filterDataPointsInRange(rangeDataPoints, range);
+  // rangeDataPoints is already the store's DataPoint view model, so its
+  // epochNs is a pre-parsed field, not re-parsed here (see lib/normalize.ts).
+  const windowed = filterDataPointsInRange(rangeDataPoints, range, (dp) => dp.epochNs);
   const groups = new Map<string, StatTileGroup>();
   for (const dp of windowed) {
     const key = facetSeriesKey(dp.attributes, facet);
@@ -220,7 +230,12 @@ export function statTileGroupsFromRawPoints(
       group = { key, label: key || "(no attributes)", colorIndex: order.get(key) ?? 0, points: [] };
       groups.set(key, group);
     }
-    group.points.push({ timestamp: dp.timestamp, value: dp.value, count: dp.count });
+    group.points.push({
+      timestamp: dp.timestamp,
+      epochNs: dp.epochNs,
+      value: dp.value,
+      count: dp.count,
+    });
   }
   return [...groups.values()];
 }

--- a/frontend/src/lib/normalize.test.ts
+++ b/frontend/src/lib/normalize.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vite-plus/test";
+import {
+  parseEpochNs,
+  normalizeSpan,
+  normalizeTrace,
+  normalizeDataPoint,
+  normalizeMetric,
+  normalizeLog,
+} from "./normalize";
+import type {
+  SpanDataWire,
+  TraceDataWire,
+  DataPointWire,
+  MetricDataWire,
+  LogDataWire,
+} from "@/types/telemetry";
+
+describe("parseEpochNs", () => {
+  it("preserves full nanosecond precision (not truncated to milliseconds)", () => {
+    expect(parseEpochNs("2024-01-01T00:00:00.123456789Z")).toBe(1704067200123456789n);
+  });
+
+  it("round-trips back to the same instant", () => {
+    const iso = "2024-06-15T12:34:56.987654321Z";
+    const ns = parseEpochNs(iso);
+    expect(new Date(Number(ns / 1_000_000n)).toISOString()).toBe("2024-06-15T12:34:56.987Z");
+    expect(ns % 1_000_000n).toBe(987654321n % 1_000_000n);
+  });
+
+  it("distinguishes two instants that differ only in sub-millisecond precision", () => {
+    const a = parseEpochNs("2024-01-01T00:00:00.000000001Z");
+    const b = parseEpochNs("2024-01-01T00:00:00.000000002Z");
+    expect(a).not.toBe(b);
+    expect(b - a).toBe(1n);
+  });
+});
+
+function makeSpanWire(overrides: Partial<SpanDataWire> = {}): SpanDataWire {
+  return {
+    traceId: "t1",
+    spanId: "s1",
+    parentSpanId: "",
+    name: "GET /api",
+    kind: "Server",
+    serviceName: "frontend",
+    startTime: "2024-01-01T00:00:00.111111111Z",
+    endTime: "2024-01-01T00:00:01.222222222Z",
+    duration: 1_000_000,
+    statusCode: "Ok",
+    statusMessage: "",
+    attributes: {},
+    events: [],
+    resource: {},
+    ...overrides,
+  };
+}
+
+describe("normalizeSpan", () => {
+  it("attaches ns-precision startEpochNs/endEpochNs derived from startTime/endTime", () => {
+    const span = normalizeSpan(makeSpanWire());
+    expect(span.startEpochNs).toBe(parseEpochNs("2024-01-01T00:00:00.111111111Z"));
+    expect(span.endEpochNs).toBe(parseEpochNs("2024-01-01T00:00:01.222222222Z"));
+  });
+
+  it("preserves every wire field unchanged", () => {
+    const wire = makeSpanWire();
+    const span = normalizeSpan(wire);
+    expect(span).toMatchObject(wire);
+  });
+});
+
+function makeTraceWire(overrides: Partial<TraceDataWire> = {}): TraceDataWire {
+  return {
+    traceId: "t1",
+    spans: [],
+    serviceName: "frontend",
+    spanCount: 1,
+    startTime: "2024-01-01T00:00:00.500000000Z",
+    duration: 1_000_000,
+    ...overrides,
+  };
+}
+
+describe("normalizeTrace", () => {
+  it("attaches startEpochNs derived from startTime", () => {
+    const trace = normalizeTrace(makeTraceWire());
+    expect(trace.startEpochNs).toBe(parseEpochNs("2024-01-01T00:00:00.500000000Z"));
+  });
+
+  it("normalizes every nested span too", () => {
+    const trace = normalizeTrace(makeTraceWire({ spans: [makeSpanWire({ spanId: "a" })] }));
+    expect(trace.spans[0]?.startEpochNs).toBe(parseEpochNs(trace.spans[0]!.startTime));
+  });
+});
+
+function makeDataPointWire(overrides: Partial<DataPointWire> = {}): DataPointWire {
+  return {
+    id: "dp-1",
+    timestamp: "2024-01-01T00:00:00.999999999Z",
+    value: 1,
+    attributes: {},
+    ...overrides,
+  };
+}
+
+describe("normalizeDataPoint", () => {
+  it("attaches ns-precision epochNs derived from timestamp", () => {
+    const dp = normalizeDataPoint(makeDataPointWire());
+    expect(dp.epochNs).toBe(parseEpochNs("2024-01-01T00:00:00.999999999Z"));
+  });
+});
+
+describe("normalizeMetric", () => {
+  it("normalizes every data point in the wire metric's dataPoints array", () => {
+    const wire: MetricDataWire = {
+      name: "http.requests",
+      description: "",
+      unit: "",
+      type: "Sum",
+      serviceName: "frontend",
+      resource: {},
+      dataPoints: [makeDataPointWire({ id: "a" }), makeDataPointWire({ id: "b" })],
+      pointCount: 2,
+      latestValue: 1,
+      receivedAt: "2024-01-01T00:00:00Z",
+    };
+
+    const metric = normalizeMetric(wire);
+
+    expect(metric.dataPoints.map((p) => p.id)).toEqual(["a", "b"]);
+    expect(metric.dataPoints.every((p) => typeof p.epochNs === "bigint")).toBe(true);
+  });
+});
+
+describe("normalizeLog", () => {
+  it("attaches ns-precision epochNs derived from timestamp", () => {
+    const wire: LogDataWire = {
+      id: "log-1",
+      timestamp: "2024-01-01T00:00:00.333333333Z",
+      observedTimestamp: "2024-01-01T00:00:00.333333333Z",
+      traceId: "",
+      spanId: "",
+      severityNumber: 9,
+      severityText: "INFO",
+      body: "hello",
+      serviceName: "frontend",
+      attributes: {},
+      resource: {},
+    };
+
+    const log = normalizeLog(wire);
+
+    expect(log.epochNs).toBe(parseEpochNs("2024-01-01T00:00:00.333333333Z"));
+  });
+});

--- a/frontend/src/lib/normalize.ts
+++ b/frontend/src/lib/normalize.ts
@@ -1,0 +1,62 @@
+import { Temporal } from "temporal-polyfill";
+import type {
+  SpanDataWire,
+  SpanData,
+  TraceDataWire,
+  TraceData,
+  DataPointWire,
+  DataPoint,
+  MetricDataWire,
+  MetricData,
+  LogDataWire,
+  LogData,
+} from "@/types/telemetry";
+
+// The single call site for parsing an OTel ISO-8601 timestamp string into
+// epoch nanoseconds. Temporal.Instant.from (never Date.parse, which truncates
+// to millisecond precision — see CLAUDE.md) preserves the full ns precision
+// OTel emits. Every normalize* function below routes through this, and every
+// other module reads the resulting epoch field off a view model instead of
+// re-parsing the same ISO string on every sort/filter/chart recompute — the
+// whole point of this module (see stores/telemetry.ts's sort and
+// stores/filters.ts's range filter, previously ~4-10ms per recompute over the
+// full buffer).
+export function parseEpochNs(iso: string): bigint {
+  return Temporal.Instant.from(iso).epochNanoseconds;
+}
+
+// normalizeSpan is the only place that converts a wire SpanData (GraphQL
+// fragment or WS payload) into the view model spans/waterfall code (and
+// stores/telemetry.ts's mergeSpans/mergeTrace) actually consume.
+export function normalizeSpan(span: SpanDataWire): SpanData {
+  return {
+    ...span,
+    startEpochNs: parseEpochNs(span.startTime),
+    endEpochNs: parseEpochNs(span.endTime),
+  };
+}
+
+// normalizeTrace is the only entry point that should produce a TraceData —
+// every ingest path (WS deliveries via hooks/use-websocket.ts, the
+// traces-list/trace-by-id GraphQL fetches, test/factories.ts's makeTrace)
+// must route through this so a trace can never enter the store missing
+// startEpochNs.
+export function normalizeTrace(trace: TraceDataWire): TraceData {
+  return {
+    ...trace,
+    spans: trace.spans.map(normalizeSpan),
+    startEpochNs: parseEpochNs(trace.startTime),
+  };
+}
+
+export function normalizeDataPoint(point: DataPointWire): DataPoint {
+  return { ...point, epochNs: parseEpochNs(point.timestamp) };
+}
+
+export function normalizeMetric(metric: MetricDataWire): MetricData {
+  return { ...metric, dataPoints: metric.dataPoints.map(normalizeDataPoint) };
+}
+
+export function normalizeLog(log: LogDataWire): LogData {
+  return { ...log, epochNs: parseEpochNs(log.timestamp) };
+}

--- a/frontend/src/lib/span-mapping.ts
+++ b/frontend/src/lib/span-mapping.ts
@@ -1,6 +1,7 @@
 import { graphql } from "@/gql";
 import type { SpanFieldsFragment } from "@/gql/graphql";
 import type { SpanData, SpanStatus } from "@/types/telemetry";
+import { normalizeSpan } from "@/lib/normalize";
 
 // GraphQL reports span duration as durationMs; SpanData's `duration` field is
 // nanosecond-precision (matching the OTel wire format internal/broadcast
@@ -34,5 +35,9 @@ export const SpanFieldsFragmentDoc = graphql(`
 `);
 
 export function toSpan({ durationMs, statusCode, ...rest }: SpanFieldsFragment): SpanData {
-  return { ...rest, statusCode: statusCode as SpanStatus, duration: durationMs * MS_TO_NS };
+  return normalizeSpan({
+    ...rest,
+    statusCode: statusCode as SpanStatus,
+    duration: durationMs * MS_TO_NS,
+  });
 }

--- a/frontend/src/stores/filters.test.ts
+++ b/frontend/src/stores/filters.test.ts
@@ -285,6 +285,24 @@ describe("filteredLogsAtom", () => {
     expect(store.get(filteredLogsAtom).map((log) => log.id)).toEqual(["current"]);
   });
 
+  it("excludes a log 1ns before the fixed window's lower bound (ns precision preserved)", () => {
+    const store = createStore();
+    store.set(logsAtom, [
+      makeLog({ id: "just-before", timestamp: "2024-01-01T00:59:59.999999999Z" }),
+      makeLog({ id: "at-boundary", timestamp: "2024-01-01T01:00:00.000000000Z" }),
+    ]);
+    store.set(logListWindowAtom, {
+      mode: "fixed",
+      from: "2024-01-01T01:00:00.000000000Z",
+      to: "2024-01-01T02:00:00Z",
+    });
+
+    // A millisecond-truncating comparison (e.g. Date.parse) would round
+    // "just-before" up to the same millisecond as the boundary and wrongly
+    // include it; the epoch-ns field must exclude it.
+    expect(store.get(filteredLogsAtom).map((log) => log.id)).toEqual(["at-boundary"]);
+  });
+
   it("filters by body text", () => {
     const store = createStore();
     store.set(logsAtom, [makeLog({ body: "error occurred" }), makeLog({ body: "all ok" })]);

--- a/frontend/src/stores/filters.ts
+++ b/frontend/src/stores/filters.ts
@@ -1,7 +1,7 @@
 import { atom } from "jotai";
 import type { Atom, PrimitiveAtom } from "jotai";
-import { Temporal } from "temporal-polyfill";
 import { filterDataPointsInRange } from "@/lib/chart-time-range";
+import { parseEpochNs } from "@/lib/normalize";
 import { eventWindowBounds } from "@/lib/event-time-window";
 import {
   tracesAtom,
@@ -64,12 +64,12 @@ export const traceSearchAtom = atom("");
 // mirrors the metric chart's rolling window (see metric-detail.tsx's
 // windowedDataPoints) and keeps re-deriving the true visible window as new
 // data arrives.
-function inEventWindow(timestamp: string, from: string | undefined, to: string): boolean {
-  const instant = Temporal.Instant.from(timestamp);
-  return (
-    (!from || Temporal.Instant.compare(instant, Temporal.Instant.from(from)) >= 0) &&
-    Temporal.Instant.compare(instant, Temporal.Instant.from(to)) < 0
-  );
+//
+// fromNs/toNs are parsed once by the caller (outside the per-row filter),
+// not per row — epochNs itself is already a pre-parsed view-model field (see
+// lib/normalize.ts), so this whole check is pure bigint comparison.
+function inEventWindow(epochNs: bigint, fromNs: bigint | undefined, toNs: bigint): boolean {
+  return (fromNs === undefined || epochNs >= fromNs) && epochNs < toNs;
 }
 
 const rangeFilteredTracesAtom = atom((get) => {
@@ -79,7 +79,7 @@ const rangeFilteredTracesAtom = atom((get) => {
   if (window.mode === "live") {
     if (window.range === "all") return traces;
     const inRangeIds = new Set(
-      filterDataPointsInRange(traces, window.range, (trace) => trace.startTime).map(
+      filterDataPointsInRange(traces, window.range, (trace) => trace.startEpochNs).map(
         (trace) => trace.traceId,
       ),
     );
@@ -88,8 +88,10 @@ const rangeFilteredTracesAtom = atom((get) => {
     );
   }
   const { from, to } = eventWindowBounds(window);
+  const fromNs = from === undefined ? undefined : parseEpochNs(from);
+  const toNs = parseEpochNs(to);
   return traces.filter(
-    (trace) => loadedOlderIds.has(trace.traceId) || inEventWindow(trace.startTime, from, to),
+    (trace) => loadedOlderIds.has(trace.traceId) || inEventWindow(trace.startEpochNs, fromNs, toNs),
   );
 });
 
@@ -126,12 +128,16 @@ const rangeFilteredLogsAtom = atom((get) => {
   const loadedOlderIds = get(loadedOlderLogIdsAtom);
   if (window.mode === "live") {
     if (window.range === "all") return logs;
-    const inRangeIds = new Set(filterDataPointsInRange(logs, window.range).map((log) => log.id));
+    const inRangeIds = new Set(
+      filterDataPointsInRange(logs, window.range, (log) => log.epochNs).map((log) => log.id),
+    );
     return logs.filter((log) => loadedOlderIds.has(log.id) || inRangeIds.has(log.id));
   }
   const { from, to } = eventWindowBounds(window);
+  const fromNs = from === undefined ? undefined : parseEpochNs(from);
+  const toNs = parseEpochNs(to);
   return get(logsAtom).filter(
-    (log) => loadedOlderIds.has(log.id) || inEventWindow(log.timestamp, from, to),
+    (log) => loadedOlderIds.has(log.id) || inEventWindow(log.epochNs, fromNs, toNs),
   );
 });
 

--- a/frontend/src/stores/telemetry.test.ts
+++ b/frontend/src/stores/telemetry.test.ts
@@ -41,6 +41,7 @@ import {
   selectedLogIdAtom,
 } from "./navigation";
 import { makeMetric, makeDataPoint, makeTrace, makeLog, makeSpan } from "@/test/factories";
+import { parseEpochNs } from "@/lib/normalize";
 
 describe("addMetricAtom", () => {
   it("merges data points by id, dropping re-delivered duplicates", () => {
@@ -244,6 +245,29 @@ describe("header badge totals (traceCountAtom/metricCountAtom/logCountAtom)", ()
 
     expect(store.get(tracesAtom).map((trace) => trace.traceId)).toEqual(["stable", "moving"]);
     expect(store.get(tracesAtom)[1].startTime).toBe("2024-01-01T00:00:00Z");
+    // Regression guard: startEpochNs is a derived field mergeTrace must keep
+    // in lockstep with startTime — a stale spread would leave it pointing at
+    // the pre-merge instant even though startTime moved, silently breaking
+    // every consumer that reads the epoch instead of re-parsing startTime
+    // (newestTraceStartFirst's sort, stores/filters.ts's range filter).
+    expect(store.get(tracesAtom)[1].startEpochNs).toBe(parseEpochNs("2024-01-01T00:00:00Z"));
+  });
+
+  it("orders traces that differ only in sub-millisecond precision (ns precision preserved through the sort)", () => {
+    const store = createStore();
+    store.set(
+      addTraceAtom,
+      makeTrace({ traceId: "a", startTime: "2024-01-01T00:00:00.000000001Z" }),
+    );
+    store.set(
+      addTraceAtom,
+      makeTrace({ traceId: "b", startTime: "2024-01-01T00:00:00.000000002Z" }),
+    );
+
+    // "b" is 1ns newer than "a" — a millisecond-truncating comparison (e.g.
+    // Date.parse) would see these as simultaneous and could return either
+    // order; the epoch-ns field must keep them correctly ordered.
+    expect(store.get(tracesAtom).map((trace) => trace.traceId)).toEqual(["b", "a"]);
   });
 
   it("appendTracesAtom (Load more) does not increment the badge — those rows are already in the total", () => {

--- a/frontend/src/stores/telemetry.ts
+++ b/frontend/src/stores/telemetry.ts
@@ -1,6 +1,5 @@
 import { atom } from "jotai";
 import type { Atom, PrimitiveAtom, WritableAtom } from "jotai";
-import { Temporal } from "temporal-polyfill";
 import type {
   TraceData,
   TraceRootSpan,
@@ -95,13 +94,15 @@ function mergeSearchValues(
   return [...new Set([...existing, ...incoming])];
 }
 
+// Compares pre-parsed epoch-ns fields (see lib/normalize.ts) instead of
+// re-parsing startTime on every sort — this runs on every WS delivery over
+// the whole capped trace buffer, so the parse cost used to matter.
 function newestTraceStartFirst(traces: TraceData[]): TraceData[] {
-  return traces.toSorted((a, b) =>
-    Temporal.Instant.compare(
-      Temporal.Instant.from(b.startTime),
-      Temporal.Instant.from(a.startTime),
-    ),
-  );
+  return traces.toSorted((a, b) => {
+    if (b.startEpochNs > a.startEpochNs) return 1;
+    if (b.startEpochNs < a.startEpochNs) return -1;
+    return 0;
+  });
 }
 
 // Write-only: add single item from WebSocket
@@ -190,10 +191,10 @@ function isBetterRoot(
 function mergeTrace(existing: TraceData, incoming: TraceData): TraceData | null {
   const spans = mergeSpans(existing.spans, incoming.spans);
   const rootChanged = isBetterRoot(existing.rootSpan, incoming.rootSpan);
-  // OTel timestamps are nanosecond-precision ISO strings; compare via
-  // Temporal.Instant to avoid Date's millisecond truncation.
-  const incomingStart = Temporal.Instant.from(incoming.startTime).epochNanoseconds;
-  const existingStart = Temporal.Instant.from(existing.startTime).epochNanoseconds;
+  // Both sides are already-normalized view models (see lib/normalize.ts), so
+  // this reads their pre-parsed startEpochNs instead of re-parsing startTime.
+  const incomingStart = incoming.startEpochNs;
+  const existingStart = existing.startEpochNs;
   if (
     spans.length === existing.spans.length &&
     !rootChanged &&
@@ -203,6 +204,12 @@ function mergeTrace(existing: TraceData, incoming: TraceData): TraceData | null 
   ) {
     return null;
   }
+
+  // Multi-root traces can grow past the originally-reported root span
+  // duration. Always retain the complete observed time range — and keep
+  // startEpochNs in lockstep with startTime so a stale epoch can never
+  // survive a merge (the bug this derived field's staleness risk is about).
+  const startsEarlier = incomingStart < existingStart;
 
   return {
     ...existing,
@@ -214,9 +221,8 @@ function mergeTrace(existing: TraceData, incoming: TraceData): TraceData | null 
     spanCount: Math.max(existing.spanCount, incoming.spanCount),
     rootSpan: rootChanged ? incoming.rootSpan : existing.rootSpan,
     serviceName: rootChanged ? incoming.serviceName : existing.serviceName,
-    // Multi-root traces can grow past the originally-reported root span
-    // duration. Always retain the complete observed time range.
-    startTime: incomingStart < existingStart ? incoming.startTime : existing.startTime,
+    startTime: startsEarlier ? incoming.startTime : existing.startTime,
+    startEpochNs: startsEarlier ? incoming.startEpochNs : existing.startEpochNs,
     duration: Math.max(existing.duration, incoming.duration),
   };
 }

--- a/frontend/src/test/factories.ts
+++ b/frontend/src/test/factories.ts
@@ -1,5 +1,12 @@
 import type { SpanData, TraceData, LogData, MetricData, DataPoint } from "@/types/telemetry";
 import type { AggregatePointData, AggregateSeriesData } from "@/hooks/use-metric-aggregate-series";
+import {
+  normalizeSpan,
+  normalizeTrace,
+  normalizeLog,
+  normalizeDataPoint,
+  normalizeMetric,
+} from "@/lib/normalize";
 
 // A convenient row count for list-rendering tests to set
 // stores/telemetry.ts's renderWindowMaxAtom to and build fixture lists
@@ -7,8 +14,13 @@ import type { AggregatePointData, AggregateSeriesData } from "@/hooks/use-metric
 // round number comfortably larger than any test's assertions need.
 export const TEST_RENDER_WINDOW_MAX = 500;
 
+// Every factory below builds its wire-shaped defaults, merges in overrides,
+// then runs the result through lib/normalize.ts's normalize* function — the
+// same function every real ingest entry point uses — so a test can never
+// construct a record with a stale/missing epoch field, and overriding
+// startTime/timestamp always re-derives the matching epoch automatically.
 export function makeSpan(overrides: Partial<SpanData> = {}): SpanData {
-  return {
+  return normalizeSpan({
     traceId: "t1",
     spanId: "s1",
     parentSpanId: "",
@@ -24,19 +36,19 @@ export function makeSpan(overrides: Partial<SpanData> = {}): SpanData {
     events: [],
     resource: {},
     ...overrides,
-  };
+  });
 }
 
 // Converts a makeSpan()-shaped SpanData back into the GraphQL SpanFields
 // fragment shape (durationMs instead of duration) a mocked gqlClient.request
 // response needs — the inverse of lib/span-mapping.ts's toSpan.
 export function toQuerySpan(span: SpanData) {
-  const { duration, ...rest } = span;
+  const { duration, startEpochNs: _startEpochNs, endEpochNs: _endEpochNs, ...rest } = span;
   return { ...rest, durationMs: duration / 1_000_000 };
 }
 
 export function makeTrace(overrides: Partial<TraceData> = {}): TraceData {
-  return {
+  return normalizeTrace({
     traceId: "t1",
     spans: [makeSpan()],
     spanCount: 1,
@@ -44,11 +56,11 @@ export function makeTrace(overrides: Partial<TraceData> = {}): TraceData {
     startTime: "2024-01-01T00:00:00Z",
     duration: 1_000_000,
     ...overrides,
-  };
+  });
 }
 
 export function makeLog(overrides: Partial<LogData> = {}): LogData {
-  return {
+  return normalizeLog({
     id: "log-1",
     timestamp: "2024-01-01T00:00:00Z",
     observedTimestamp: "2024-01-01T00:00:00Z",
@@ -61,21 +73,21 @@ export function makeLog(overrides: Partial<LogData> = {}): LogData {
     attributes: {},
     resource: {},
     ...overrides,
-  };
+  });
 }
 
 export function makeDataPoint(overrides: Partial<DataPoint> = {}): DataPoint {
-  return {
+  return normalizeDataPoint({
     id: "dp-1",
     timestamp: "2024-01-01T00:00:00Z",
     value: 0,
     attributes: {},
     ...overrides,
-  };
+  });
 }
 
 export function makeMetric(overrides: Partial<MetricData> = {}): MetricData {
-  return {
+  return normalizeMetric({
     name: "http.requests",
     type: "Sum",
     unit: "",
@@ -87,7 +99,7 @@ export function makeMetric(overrides: Partial<MetricData> = {}): MetricData {
     latestValue: null,
     receivedAt: "2024-01-01T00:00:00Z",
     ...overrides,
-  };
+  });
 }
 
 export function makeAggregatePoint(

--- a/frontend/src/types/telemetry.ts
+++ b/frontend/src/types/telemetry.ts
@@ -8,7 +8,10 @@ export interface SpanEvent {
 // it as a union so exhaustiveness checks in the UI catch missing cases.
 export type SpanStatus = "Unset" | "Ok" | "Error";
 
-export interface SpanData {
+// Wire shape: exactly what arrives over the WebSocket / GraphQL, before
+// lib/normalize.ts parses its ISO-8601 timestamp fields into the epoch-ns
+// fields the view model below adds.
+export interface SpanDataWire {
   traceId: string;
   spanId: string;
   parentSpanId: string;
@@ -23,6 +26,17 @@ export interface SpanData {
   attributes: Record<string, unknown>;
   events: SpanEvent[];
   resource: Record<string, unknown>;
+}
+
+// View model: SpanDataWire plus the epoch-nanosecond fields the waterfall's
+// sort/offset math (components/traces/span-waterfall.tsx) compares against.
+// Required (not optional) so a new ingest entry point that forgets to run
+// lib/normalize.ts's normalizeSpan fails to compile, instead of silently
+// falling back to a per-comparison Temporal.Instant.from parse — see that
+// module's doc comment for the full rationale.
+export interface SpanData extends SpanDataWire {
+  startEpochNs: bigint;
+  endEpochNs: bigint;
 }
 
 // Trace list/detail-header display fields for the trace's representative
@@ -42,14 +56,14 @@ export interface TraceRootSpan {
   duration: number;
 }
 
-export interface TraceData {
+export interface TraceDataWire {
   traceId: string;
   rootSpan?: TraceRootSpan;
   // Empty until the trace detail view lazily fetches it (see
   // hooks/use-trace-spans.ts). Both list queries and live WebSocket updates
   // carry summary fields only, avoiding a TraceByID query per committed
   // trace. Never derive count/duration from this array.
-  spans: SpanData[];
+  spans: SpanDataWire[];
   serviceName: string;
   // Lightweight values from spans in the latest WebSocket batch, used to
   // preserve live search without shipping full span detail.
@@ -59,12 +73,22 @@ export interface TraceData {
   duration: number;
 }
 
+export interface TraceData extends Omit<TraceDataWire, "spans"> {
+  spans: SpanData[];
+  // Parsed once at the ingest boundary (lib/normalize.ts's normalizeTrace) so
+  // stores/telemetry.ts's newestTraceStartFirst sort and stores/filters.ts's
+  // range filter compare bigints instead of re-parsing startTime on every
+  // recompute. mergeTrace must keep this in sync whenever startTime changes —
+  // see that function's doc comment.
+  startEpochNs: bigint;
+}
+
 // Distribution-only fields are null for Gauge/Sum. See schema.graphql for
 // semantics of value/count/sum/min/max across metric types.
 // The cumulative family carries the exporter's raw running total for
 // cumulative inputs, or a query-window accumulation for delta inputs. The
 // backend derives both from persisted raw observations at read time.
-export interface DataPoint {
+export interface DataPointWire {
   // Stable, globally unique identity (UUIDv7) assigned by the backend at
   // ingestion. Use it as the React key: it survives client-buffer eviction and
   // reconnects, unlike timestamp/attributes (which can collide) or array index.
@@ -81,7 +105,11 @@ export interface DataPoint {
   attributes: Record<string, unknown>;
 }
 
-export interface MetricData {
+export interface DataPoint extends DataPointWire {
+  epochNs: bigint;
+}
+
+export interface MetricDataWire {
   name: string;
   description: string;
   unit: string;
@@ -93,7 +121,7 @@ export interface MetricData {
   // the initial metrics-list load only fetches pointCount/latestValue below
   // (issue #162), never the full series, to avoid an N-metric fetch of every
   // group's entire retained history just to render list rows.
-  dataPoints: DataPoint[];
+  dataPoints: DataPointWire[];
   // Cheap server-computed summary fields the metrics LIST renders instead of
   // dataPoints.length / dataPoints.at(-1)?.value (see MetricList) — kept
   // current across a WS delivery by addMetricAtom's genuinely-new-points
@@ -104,7 +132,11 @@ export interface MetricData {
   receivedAt: string;
 }
 
-export interface LogData {
+export interface MetricData extends Omit<MetricDataWire, "dataPoints"> {
+  dataPoints: DataPoint[];
+}
+
+export interface LogDataWire {
   // Stable, globally unique identity (UUIDv7) assigned by the backend at
   // ingestion. Log records have no natural id, so use this as the React key:
   // it stays put as new logs are prepended, unlike an array index.
@@ -121,9 +153,15 @@ export interface LogData {
   resource: Record<string, unknown>;
 }
 
+export interface LogData extends LogDataWire {
+  epochNs: bigint;
+}
+
 export interface WsMessage {
   type: "traces" | "trace-deletes" | "metrics" | "logs";
-  data: TraceData | TraceDeleteData | MetricData | LogData;
+  // Wire shapes: hooks/use-websocket.ts is the single place that normalizes
+  // these into view models before writing them into the store.
+  data: TraceDataWire | TraceDeleteData | MetricDataWire | LogDataWire;
 }
 
 export interface TraceDeleteData {


### PR DESCRIPTION
## Summary

Telemetry records in the store mirrored their wire shapes, keeping timestamps as ISO strings — so the newest-first trace sort re-parsed via `Temporal.Instant.from` on every comparison (~2×n·log n parses per recompute) and the range filters re-parsed every row. Measured on buffers at cap: 3.9ms per trace-sort recompute (1000 traces) and 9.7ms per log range-filter pass (5000 logs), dropping to 0.03ms / 0.12ms once parsing happens exactly once per record.

Instead of caching, this normalizes at the ingest boundary:

- **Wire / view-model type split** (`types/telemetry.ts`): `*Wire` interfaces are the raw WS/GraphQL shapes; the store's `TraceData`/`SpanData`/`LogData`/`DataPoint` extend them with **required** `startEpochNs`/`endEpochNs`/`epochNs: bigint` fields. Required, not optional — a new ingest path that forgets to normalize fails to compile instead of silently regressing.
- **Single parse site** (`lib/normalize.ts`): `parseEpochNs` is the only `Temporal.Instant.from` call for record parsing (ns precision preserved per the repo convention); `normalize{Trace,Span,Log,Metric,DataPoint}` are routed through by every entry point — WS messages, all GraphQL fetch hooks, and the test factories (so tests can't construct un-normalized records either). One sanctioned exception: server-aggregated chart series (`AggregatePointData`, ~150 ephemeral buckets, not a store record) parse per point explicitly.
- **Mutation integrity**: `mergeTrace` propagates `startEpochNs` together with `startTime`, with a staleness regression test.
- **Consumers compare bigints**: trace sort, log/trace range filters (window bounds hoisted out of the row loop), chart range filtering (now takes an explicit `getEpochNs` selector), event-window filtering, stat tiles, and the span waterfall's sort/offset math.
- **JSON boundary** (`lib/export.ts`): copy/download go through one bigint-safe `stringify` helper (no global `BigInt.prototype.toJSON` patch). Note: exported/copied JSON now includes the derived epoch fields as strings alongside the original ISO timestamps.

No user-visible behavior change intended beyond that note. This supersedes the WeakMap epoch-cache approach previously explored in #184.

## Test plan

- [x] 456/456 frontend tests + full `mise run check` / `mise run test` (backend untouched). New coverage: normalize round-trip at ns precision, sub-ms ordering through sort and filters, `mergeTrace` epoch-staleness regression, bigint-safe export
- [x] e2e smoke (`mise run e2e-env`, seeded data): logs at 0.5ms spacing render in correct sub-ms order; trace waterfall renders; **Copy JSON succeeds** (would previously throw on bigint); metric detail chart renders — no console/error overlay