### PR TITLE
perf(frontend): batch WebSocket deliveries into throttled store updates

### DIFF
--- a/frontend/src/hooks/use-websocket.test.tsx
+++ b/frontend/src/hooks/use-websocket.test.tsx
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi } from "vite-plus/test";
-import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
+import { renderHook, act } from "@testing-library/react";
 import { createStore, Provider } from "jotai";
 import type { ReactNode } from "react";
 import { useWebSocket } from "./use-websocket";
 import { tracesAtom, metricsAtom, logsAtom } from "@/stores/telemetry";
 import { parseEpochNs } from "@/lib/normalize";
+import { makeTrace } from "@/test/factories";
 
 // vi.mock's factory is hoisted above every top-level statement in this file,
 // so the mock socket/message-listener registry it needs must live inside
@@ -41,8 +42,53 @@ function renderWithStore() {
   const wrapper = ({ children }: { children: ReactNode }) => (
     <Provider store={store}>{children}</Provider>
   );
-  renderHook(() => useWebSocket(), { wrapper });
-  return store;
+  const view = renderHook(() => useWebSocket(), { wrapper });
+  return { store, ...view };
+}
+
+// Wire-shaped (pre-normalize) fixtures — these tests exercise the hook's
+// batching/throttle behavior, not normalize.ts, so only the fields normalize
+// actually reads need real values.
+function wireTrace(traceId: string) {
+  return {
+    traceId,
+    serviceName: "frontend",
+    spans: [],
+    spanCount: 1,
+    startTime: "2024-01-01T00:00:00Z",
+    duration: 1_000_000,
+  };
+}
+
+function wireLog(id: string) {
+  return {
+    id,
+    timestamp: "2024-01-01T00:00:00Z",
+    observedTimestamp: "2024-01-01T00:00:00Z",
+    traceId: "",
+    spanId: "",
+    severityNumber: 9,
+    severityText: "INFO",
+    body: id,
+    serviceName: "frontend",
+    attributes: {},
+    resource: {},
+  };
+}
+
+function wireMetric(name: string) {
+  return {
+    name,
+    description: "",
+    unit: "",
+    type: "Sum",
+    serviceName: "frontend",
+    resource: {},
+    dataPoints: [],
+    pointCount: 0,
+    latestValue: null,
+    receivedAt: "2024-01-01T00:00:00Z",
+  };
 }
 
 // This hook is the single place a WS delivery (still wire-shaped: ISO
@@ -51,7 +97,7 @@ function renderWithStore() {
 // on why every ingest entry point must route through it).
 describe("useWebSocket", () => {
   it("normalizes a wire trace delivery into a view model with startEpochNs", () => {
-    const store = renderWithStore();
+    const { store } = renderWithStore();
 
     simulateMessage({
       type: "traces",
@@ -70,7 +116,7 @@ describe("useWebSocket", () => {
   });
 
   it("normalizes a wire metric delivery's data points into view models with epochNs", () => {
-    const store = renderWithStore();
+    const { store } = renderWithStore();
 
     simulateMessage({
       type: "metrics",
@@ -95,7 +141,7 @@ describe("useWebSocket", () => {
   });
 
   it("normalizes a wire log delivery into a view model with epochNs", () => {
-    const store = renderWithStore();
+    const { store } = renderWithStore();
 
     simulateMessage({
       type: "logs",
@@ -116,5 +162,197 @@ describe("useWebSocket", () => {
 
     const log = store.get(logsAtom)[0];
     expect(log?.epochNs).toBe(parseEpochNs("2024-01-01T00:00:00.777777777Z"));
+  });
+});
+
+// The hook applies a leading-edge + trailing throttle around the batch
+// atoms (stores/telemetry.ts's addTracesAtom/addMetricsAtom/addLogsAtom): an
+// idle tab's first message is applied synchronously (no added latency for a
+// sparse trickle), which also opens a 50ms window; anything that arrives
+// while the window is open queues and flushes together, and the window
+// keeps re-opening every 50ms as long as messages keep arriving, closing
+// only once a tick finds nothing queued.
+describe("useWebSocket batching", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("applies the first message of an idle window synchronously, without waiting for a timer", () => {
+    const { store } = renderWithStore();
+
+    act(() => {
+      simulateMessage({ type: "traces", data: wireTrace("t1") });
+    });
+
+    expect(store.get(tracesAtom).map((t) => t.traceId)).toEqual(["t1"]);
+  });
+
+  it("queues messages that arrive while the window is open and flushes them as one batched write", () => {
+    const { store } = renderWithStore();
+    let traceWrites = 0;
+    store.sub(tracesAtom, () => {
+      traceWrites++;
+    });
+
+    act(() => {
+      simulateMessage({ type: "traces", data: wireTrace("t1") }); // leading — dispatched immediately
+      simulateMessage({ type: "traces", data: wireTrace("t2") }); // queued
+      simulateMessage({ type: "traces", data: wireTrace("t3") }); // queued
+    });
+    expect(traceWrites).toBe(1);
+    expect(store.get(tracesAtom).map((t) => t.traceId)).toEqual(["t1"]);
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    // t2 and t3 land in a single additional store write, not two.
+    expect(traceWrites).toBe(2);
+    expect(
+      store
+        .get(tracesAtom)
+        .map((t) => t.traceId)
+        .toSorted(),
+    ).toEqual(["t1", "t2", "t3"]);
+  });
+
+  it("keeps flushing every 50ms while a stream is sustained, then closes the window once a tick is empty", () => {
+    const { store } = renderWithStore();
+
+    act(() => {
+      simulateMessage({ type: "logs", data: wireLog("a") }); // leading
+    });
+    expect(store.get(logsAtom).map((l) => l.id)).toEqual(["a"]);
+
+    act(() => {
+      simulateMessage({ type: "logs", data: wireLog("b") }); // queued
+      vi.advanceTimersByTime(50); // flushes "b", window stays open
+    });
+    expect(store.get(logsAtom).map((l) => l.id)).toEqual(["b", "a"]);
+
+    act(() => {
+      simulateMessage({ type: "logs", data: wireLog("c") }); // queued
+      vi.advanceTimersByTime(50); // flushes "c", window stays open
+    });
+    expect(store.get(logsAtom).map((l) => l.id)).toEqual(["c", "b", "a"]);
+
+    // Nothing arrives during this tick — the window closes.
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    // The next message arrives after the window closed, so it's leading
+    // again: applied immediately, not held for another 50ms tick.
+    act(() => {
+      simulateMessage({ type: "logs", data: wireLog("d") });
+    });
+    expect(store.get(logsAtom).map((l) => l.id)).toEqual(["d", "c", "b", "a"]);
+  });
+
+  it("routes metrics deliveries through the batched path", () => {
+    const { store } = renderWithStore();
+
+    act(() => {
+      simulateMessage({ type: "metrics", data: wireMetric("m1") }); // leading
+      simulateMessage({ type: "metrics", data: wireMetric("m2") }); // queued
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(
+      store
+        .get(metricsAtom)
+        .map((m) => m.name)
+        .toSorted(),
+    ).toEqual(["m1", "m2"]);
+  });
+
+  it("preserves add -> delete -> add order for the same trace within one flush (a global group-by-type would get this wrong)", () => {
+    const { store } = renderWithStore();
+
+    act(() => {
+      simulateMessage({ type: "traces", data: wireTrace("leading") }); // leading, opens the window
+      simulateMessage({ type: "traces", data: wireTrace("t1") }); // queued run 1: traces
+      simulateMessage({ type: "trace-deletes", data: { traceId: "t1" } }); // queued run 2: trace-deletes
+      simulateMessage({ type: "traces", data: wireTrace("t1") }); // queued run 3: traces (re-added)
+      vi.advanceTimersByTime(50);
+    });
+
+    // Splitting the queue only at type boundaries (not a global group-by)
+    // keeps this arrival order: add, delete, add — so t1 ends up present.
+    // A global group-by-type would batch both trace adds ahead of the
+    // delete and lose t1.
+    expect(
+      store
+        .get(tracesAtom)
+        .map((t) => t.traceId)
+        .toSorted(),
+    ).toEqual(["leading", "t1"]);
+  });
+
+  it("preserves arrival order across interleaved message types within one flush", () => {
+    const { store } = renderWithStore();
+
+    act(() => {
+      simulateMessage({ type: "logs", data: wireLog("leading") }); // leading
+      simulateMessage({ type: "logs", data: wireLog("a") }); // queued run 1: logs
+      simulateMessage({ type: "logs", data: wireLog("b") }); // queued run 1: logs
+      simulateMessage({ type: "traces", data: wireTrace("t1") }); // queued run 2: traces
+      simulateMessage({ type: "logs", data: wireLog("c") }); // queued run 3: logs
+      vi.advanceTimersByTime(50);
+    });
+
+    // Logs prepend newest-first: within the contiguous [a, b] run "b" ends
+    // up first; "c" arrived in a later run (after the trace message) so it
+    // prepends on top of that.
+    expect(store.get(logsAtom).map((l) => l.id)).toEqual(["c", "b", "a", "leading"]);
+    expect(store.get(tracesAtom).map((t) => t.traceId)).toEqual(["t1"]);
+  });
+
+  it("clears the pending flush timer on unmount and never flushes the still-queued messages", () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const { store, unmount } = renderWithStore();
+
+    act(() => {
+      simulateMessage({ type: "logs", data: wireLog("a") }); // leading, opens the window
+      simulateMessage({ type: "logs", data: wireLog("b") }); // queued, never flushed
+    });
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(store.get(logsAtom).map((l) => l.id)).toEqual(["a"]);
+    clearTimeoutSpy.mockRestore();
+  });
+});
+
+describe("useWebSocket batching — trace merge seeded before the hook mounts", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("a queued delete removes a trace that already existed before this flush window", () => {
+    const { store } = renderWithStore();
+    store.set(tracesAtom, [makeTrace({ traceId: "t1" })]);
+
+    act(() => {
+      simulateMessage({ type: "traces", data: wireTrace("t2") }); // leading
+      simulateMessage({ type: "trace-deletes", data: { traceId: "t2" } }); // queued
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(store.get(tracesAtom).map((t) => t.traceId)).toEqual(["t1"]);
   });
 });

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -1,10 +1,10 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useSetAtom } from "jotai";
 import {
-  addTraceAtom,
+  addTracesAtom,
   removeTraceAtom,
-  addMetricAtom,
-  addLogAtom,
+  addMetricsAtom,
+  addLogsAtom,
   wsStatusAtom,
 } from "@/stores/telemetry";
 import type {
@@ -12,9 +12,23 @@ import type {
   TraceDeleteData,
   MetricDataWire,
   LogDataWire,
+  WsMessage,
 } from "@/types/telemetry";
 import { normalizeTrace, normalizeMetric, normalizeLog } from "@/lib/normalize";
 import { wsManager } from "@/lib/websocket-manager";
+
+// A live tab can receive a WS message per span/metric-point/log-line;
+// writing straight to jotai on every single message forces a full
+// array-rebuild + sort + derived-atom recompute + React reconcile per
+// message (see stores/telemetry.ts's addTracesAtom/addMetricsAtom/
+// addLogsAtom doc comments). This throttles that chain to at most one flush
+// per WS_FLUSH_INTERVAL_MS — 50ms sits comfortably under the ~100ms
+// threshold where UI updates start reading as laggy, and caps flushes at
+// 20/s regardless of message rate during a burst. The window is
+// leading-edge (see below): the very first message after idle is applied
+// synchronously, so a sparse trickle of messages never pays this interval
+// as extra latency — only a sustained burst does.
+const WS_FLUSH_INTERVAL_MS = 50;
 
 // useWebSocket is a thin adapter that bridges the module-level WsManager to
 // this component's jotai atoms. The actual WebSocket lifecycle (connect,
@@ -23,36 +37,99 @@ import { wsManager } from "@/lib/websocket-manager";
 // fresh socket on every mount.
 export function useWebSocket(): void {
   const setWsStatus = useSetAtom(wsStatusAtom);
-  const addTrace = useSetAtom(addTraceAtom);
+  const addTraces = useSetAtom(addTracesAtom);
   const removeTrace = useSetAtom(removeTraceAtom);
-  const addMetric = useSetAtom(addMetricAtom);
-  const addLog = useSetAtom(addLogAtom);
+  const addMetrics = useSetAtom(addMetricsAtom);
+  const addLogs = useSetAtom(addLogsAtom);
+
+  // Refs (not state) because queueing/flushing must not itself trigger a
+  // re-render — only the eventual batched atom write should. timerRef
+  // doubles as the window-open/closed flag: non-null means a flush window is
+  // currently open (leading message already dispatched, or a previous tick
+  // kept it open), null means the next message should be treated as leading.
+  const queueRef = useRef<WsMessage[]>([]);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    // The manager only JSON.parses the WS payload — it's still wire-shaped
+    // (ISO timestamp strings, no epoch fields). This is the single place
+    // that normalizes a live delivery before it reaches the store, so
+    // addTracesAtom/addMetricsAtom/addLogsAtom never see an un-normalized
+    // record (see lib/normalize.ts).
+    function dispatchRun(type: WsMessage["type"], run: WsMessage[]) {
+      switch (type) {
+        case "traces":
+          addTraces(run.map((m) => normalizeTrace(m.data as TraceDataWire)));
+          break;
+        case "trace-deletes":
+          for (const m of run) removeTrace((m.data as TraceDeleteData).traceId);
+          break;
+        case "metrics":
+          addMetrics(run.map((m) => normalizeMetric(m.data as MetricDataWire)));
+          break;
+        case "logs":
+          addLogs(run.map((m) => normalizeLog(m.data as LogDataWire)));
+          break;
+      }
+    }
+
+    // Coalesces contiguous runs of the same message type into one batched
+    // write each, but doesn't group by type globally — that would reorder a
+    // delete relative to an add for the same trace that arrived between two
+    // same-type runs (e.g. add, delete, add). Splitting only at type
+    // boundaries preserves arrival order while still batching the common
+    // case: a burst of same-type deliveries.
+    function dispatchQueue(queue: WsMessage[]) {
+      let i = 0;
+      while (i < queue.length) {
+        const type = queue[i].type;
+        let j = i;
+        while (j < queue.length && queue[j].type === type) j++;
+        dispatchRun(type, queue.slice(i, j));
+        i = j;
+      }
+    }
+
+    // Runs WS_FLUSH_INTERVAL_MS after the window opened (by the leading
+    // message or the previous tick). An empty queue means nothing arrived
+    // during this tick, so the window closes — the next message is treated
+    // as leading again. A nonempty queue flushes and re-arms the timer,
+    // keeping the window open for another tick so a sustained burst is
+    // capped at one flush per interval instead of queuing without bound.
+    function tick() {
+      const queue = queueRef.current;
+      queueRef.current = [];
+      if (queue.length === 0) {
+        timerRef.current = null;
+        return;
+      }
+      dispatchQueue(queue);
+      timerRef.current = setTimeout(tick, WS_FLUSH_INTERVAL_MS);
+    }
+
     const unsubscribe = wsManager.subscribe({
       onStatus: setWsStatus,
-      // The manager only JSON.parses the WS payload — it's still wire-shaped
-      // (ISO timestamp strings, no epoch fields). This is the single place
-      // that normalizes a live delivery before it reaches the store, so
-      // addTraceAtom/addMetricAtom/addLogAtom never see an un-normalized
-      // record (see lib/normalize.ts).
       onMessage: (msg) => {
-        switch (msg.type) {
-          case "traces":
-            addTrace(normalizeTrace(msg.data as TraceDataWire));
-            break;
-          case "trace-deletes":
-            removeTrace((msg.data as TraceDeleteData).traceId);
-            break;
-          case "metrics":
-            addMetric(normalizeMetric(msg.data as MetricDataWire));
-            break;
-          case "logs":
-            addLog(normalizeLog(msg.data as LogDataWire));
-            break;
+        if (timerRef.current === null) {
+          // Leading edge: the window was closed, so this message applies
+          // immediately instead of waiting out a flush interval it doesn't
+          // need to share with anything else. Opening the window now gives
+          // whatever arrives next a chance to batch instead of each also
+          // dispatching synchronously.
+          dispatchRun(msg.type, [msg]);
+          timerRef.current = setTimeout(tick, WS_FLUSH_INTERVAL_MS);
+        } else {
+          queueRef.current.push(msg);
         }
       },
     });
-    return unsubscribe;
-  }, [setWsStatus, addTrace, removeTrace, addMetric, addLog]);
+
+    return () => {
+      unsubscribe();
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [setWsStatus, addTraces, removeTrace, addMetrics, addLogs]);
 }

--- a/frontend/src/stores/telemetry.test.ts
+++ b/frontend/src/stores/telemetry.test.ts
@@ -3,10 +3,13 @@ import { createStore } from "jotai";
 import {
   metricsAtom,
   addMetricAtom,
+  addMetricsAtom,
   addTraceAtom,
+  addTracesAtom,
   cacheTraceAtom,
   removeTraceAtom,
   addLogAtom,
+  addLogsAtom,
   bufferCapsAtom,
   tracesAtom,
   logsAtom,
@@ -652,5 +655,227 @@ describe("appendLogsAtom", () => {
     store.set(setLogsAtom, [makeLog({ id: "new-page" })]);
 
     expect(store.get(loadedOlderLogIdsAtom)).toEqual(new Set());
+  });
+});
+
+// hooks/use-websocket.ts applies a whole WS flush window's worth of
+// deliveries through these atoms in one store update instead of one atom
+// call per message (see that file's doc comment on why: an unbounded
+// per-message write during a burst forces a full array-rebuild + sort +
+// derived-atom recompute + React reconcile per message). addTraceAtom/
+// addMetricAtom/addLogAtom above are kept as thin single-item wrappers so
+// existing single-delivery call sites (and their tests) keep working
+// unchanged.
+describe("addTracesAtom", () => {
+  it("applies a whole batch against one working array, sorting/capping once at the end", () => {
+    const store = createStore();
+
+    store.set(addTracesAtom, [
+      makeTrace({ traceId: "later", startTime: "2024-01-01T00:20:00Z" }),
+      makeTrace({ traceId: "earlier", startTime: "2024-01-01T00:10:00Z" }),
+    ]);
+
+    expect(store.get(tracesAtom).map((t) => t.traceId)).toEqual(["later", "earlier"]);
+  });
+
+  it("merges a later batch entry into an earlier entry for the same traceId within one batch", () => {
+    const store = createStore();
+
+    store.set(addTracesAtom, [
+      makeTrace({ traceId: "t1", spanCount: 1, spans: [] }),
+      makeTrace({ traceId: "t1", spanCount: 2, spans: [makeSpan({ spanId: "s2" })] }),
+    ]);
+
+    const traces = store.get(tracesAtom);
+    expect(traces).toHaveLength(1);
+    expect(traces[0].spanCount).toBe(2);
+  });
+
+  it("increments newTraceCountAtom once per genuinely-new trace in the batch, not per merge", () => {
+    const store = createStore();
+    store.set(setTotalCountsAtom, { traceCount: 0, metricCount: 0, logCount: 0 });
+    store.set(tracesAtom, [makeTrace({ traceId: "existing", spanCount: 1 })]);
+
+    store.set(addTracesAtom, [
+      makeTrace({ traceId: "existing", spanCount: 2, spans: [makeSpan({ spanId: "s2" })] }),
+      makeTrace({ traceId: "new-a" }),
+      makeTrace({ traceId: "new-b" }),
+    ]);
+
+    expect(store.get(newTraceCountAtom)).toBe(2);
+    expect(store.get(traceCountAtom)).toBe(2);
+  });
+
+  it("caps the buffer once after the whole batch, keeping the newest by start time", () => {
+    const store = createStore();
+    store.set(bufferCapsAtom, { traceCap: 2, metricCap: 10, logCap: 10, maxDataPoints: 10 });
+    store.set(tracesAtom, [makeTrace({ traceId: "a", startTime: "2024-01-01T00:10:00Z" })]);
+
+    store.set(addTracesAtom, [
+      makeTrace({ traceId: "b", startTime: "2024-01-01T00:20:00Z" }),
+      makeTrace({ traceId: "c", startTime: "2024-01-01T00:30:00Z" }),
+    ]);
+
+    expect(store.get(tracesAtom).map((t) => t.traceId)).toEqual(["c", "b"]);
+  });
+
+  it("is a no-op for an empty batch", () => {
+    const store = createStore();
+    const traces = [makeTrace({ traceId: "a" })];
+    store.set(tracesAtom, traces);
+
+    store.set(addTracesAtom, []);
+
+    expect(store.get(tracesAtom)).toBe(traces);
+  });
+
+  it("addTraceAtom (single-item) produces the same result as a one-element addTracesAtom batch", () => {
+    const single = createStore();
+    const batch = createStore();
+    const trace = makeTrace({ traceId: "t1" });
+
+    single.set(addTraceAtom, trace);
+    batch.set(addTracesAtom, [trace]);
+
+    expect(single.get(tracesAtom)).toEqual(batch.get(tracesAtom));
+  });
+});
+
+describe("addMetricsAtom", () => {
+  it("updates an existing group and inserts a new group in one batch", () => {
+    const store = createStore();
+    store.set(metricsAtom, [
+      makeMetric({ name: "existing", dataPoints: [makeDataPoint({ id: "a" })] }),
+    ]);
+
+    store.set(addMetricsAtom, [
+      makeMetric({ name: "existing", dataPoints: [makeDataPoint({ id: "b" })] }),
+      makeMetric({ name: "brand-new", dataPoints: [makeDataPoint({ id: "c" })] }),
+    ]);
+
+    const metrics = store.get(metricsAtom);
+    expect(metrics.map((m) => m.name)).toEqual(["brand-new", "existing"]);
+    expect(metrics.find((m) => m.name === "existing")?.dataPoints.map((p) => p.id)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("prepends new groups in the same order a sequence of single addMetricAtom calls would produce", () => {
+    const single = createStore();
+    const batch = createStore();
+    const first = makeMetric({ name: "m1" });
+    const second = makeMetric({ name: "m2" });
+
+    single.set(addMetricAtom, first);
+    single.set(addMetricAtom, second);
+    batch.set(addMetricsAtom, [first, second]);
+
+    expect(batch.get(metricsAtom).map((m) => m.name)).toEqual(
+      single.get(metricsAtom).map((m) => m.name),
+    );
+    expect(batch.get(metricsAtom).map((m) => m.name)).toEqual(["m2", "m1"]);
+  });
+
+  it("merges a second occurrence of the same key within one batch into the first occurrence's (new) entry", () => {
+    const store = createStore();
+
+    store.set(addMetricsAtom, [
+      makeMetric({ name: "m", dataPoints: [makeDataPoint({ id: "a" })] }),
+      makeMetric({ name: "m", dataPoints: [makeDataPoint({ id: "b" })] }),
+    ]);
+
+    const metrics = store.get(metricsAtom);
+    expect(metrics).toHaveLength(1);
+    expect(metrics[0].dataPoints.map((p) => p.id)).toEqual(["a", "b"]);
+  });
+
+  it("increments newMetricCountAtom once per genuinely-new group in the batch", () => {
+    const store = createStore();
+    store.set(setTotalCountsAtom, { traceCount: 0, metricCount: 0, logCount: 0 });
+
+    store.set(addMetricsAtom, [makeMetric({ name: "m1" }), makeMetric({ name: "m2" })]);
+
+    expect(store.get(newMetricCountAtom)).toBe(2);
+  });
+
+  it("caps the buffer once after the whole batch", () => {
+    const store = createStore();
+    store.set(bufferCapsAtom, { traceCap: 10, metricCap: 1, logCap: 10, maxDataPoints: 10 });
+
+    store.set(addMetricsAtom, [makeMetric({ name: "m1" }), makeMetric({ name: "m2" })]);
+
+    expect(store.get(metricsAtom)).toHaveLength(1);
+  });
+
+  it("is a no-op for an empty batch", () => {
+    const store = createStore();
+    const metrics = [makeMetric({ name: "m" })];
+    store.set(metricsAtom, metrics);
+
+    store.set(addMetricsAtom, []);
+
+    expect(store.get(metricsAtom)).toBe(metrics);
+  });
+
+  it("addMetricAtom (single-item) produces the same result as a one-element addMetricsAtom batch", () => {
+    const single = createStore();
+    const batch = createStore();
+    const metric = makeMetric({ name: "m" });
+
+    single.set(addMetricAtom, metric);
+    batch.set(addMetricsAtom, [metric]);
+
+    expect(single.get(metricsAtom)).toEqual(batch.get(metricsAtom));
+  });
+});
+
+describe("addLogsAtom", () => {
+  it("prepends a whole batch in one store write, newest (last-arriving) first", () => {
+    const store = createStore();
+    store.set(logsAtom, [makeLog({ id: "existing" })]);
+
+    store.set(addLogsAtom, [makeLog({ id: "a" }), makeLog({ id: "b" })]);
+
+    expect(store.get(logsAtom).map((l) => l.id)).toEqual(["b", "a", "existing"]);
+  });
+
+  it("increments newLogCountAtom by the batch size", () => {
+    const store = createStore();
+    store.set(setTotalCountsAtom, { traceCount: 0, metricCount: 0, logCount: 0 });
+
+    store.set(addLogsAtom, [makeLog({ id: "a" }), makeLog({ id: "b" }), makeLog({ id: "c" })]);
+
+    expect(store.get(newLogCountAtom)).toBe(3);
+  });
+
+  it("caps the buffer once after the whole batch", () => {
+    const store = createStore();
+    store.set(bufferCapsAtom, { traceCap: 10, metricCap: 10, logCap: 1, maxDataPoints: 10 });
+
+    store.set(addLogsAtom, [makeLog({ id: "a" }), makeLog({ id: "b" })]);
+
+    expect(store.get(logsAtom).map((l) => l.id)).toEqual(["b"]);
+  });
+
+  it("is a no-op for an empty batch", () => {
+    const store = createStore();
+    const logs = [makeLog({ id: "a" })];
+    store.set(logsAtom, logs);
+
+    store.set(addLogsAtom, []);
+
+    expect(store.get(logsAtom)).toBe(logs);
+  });
+
+  it("addLogAtom (single-item) produces the same result as a one-element addLogsAtom batch", () => {
+    const single = createStore();
+    const batch = createStore();
+    const log = makeLog({ id: "log-1" });
+
+    single.set(addLogAtom, log);
+    batch.set(addLogsAtom, [log]);
+
+    expect(single.get(logsAtom)).toEqual(batch.get(logsAtom));
   });
 });

--- a/frontend/src/stores/telemetry.ts
+++ b/frontend/src/stores/telemetry.ts
@@ -11,6 +11,7 @@ import type {
 import {
   activeTabAtom,
   metricKeyEquals,
+  metricKeyToString,
   selectedLogIdAtom,
   selectedMetricKeyAtom,
   selectedTraceIdAtom,
@@ -105,25 +106,47 @@ function newestTraceStartFirst(traces: TraceData[]): TraceData[] {
   });
 }
 
-// Write-only: add single item from WebSocket
-export const addTraceAtom = atom(null, (get, set, newTrace: TraceData) => {
+// Write-only: apply a whole WebSocket flush window's worth of trace
+// deliveries in a single store update (hooks/use-websocket.ts batches
+// messages that arrive within its flush window instead of writing one at a
+// time — see that file's doc comment). Processing the batch against one
+// working array and re-sorting/slicing once, instead of once per item,
+// avoids an O(n log n) re-sort of the whole capped buffer per message during
+// a burst.
+export const addTracesAtom = atom(null, (get, set, newTraces: TraceData[]) => {
+  if (newTraces.length === 0) return;
   const current = get(tracesAtom);
   const maxTraces = get(bufferCapsAtom).traceCap;
-  const idx = current.findIndex((t) => t.traceId === newTrace.traceId);
-  if (idx >= 0) {
-    const existing = current[idx];
-    const merged = mergeTrace(existing, newTrace);
-    if (!merged) return;
-    const updated = [...current];
-    updated[idx] = merged;
-    set(tracesAtom, newestTraceStartFirst(updated));
-  } else {
-    // A brand-new trace, never merged into an existing one — the header
-    // badge's "genuinely new" signal (see totalTraceCountAtom).
-    set(newTraceCountAtom, (n) => n + 1);
-    const next = newestTraceStartFirst([...current, newTrace]);
-    set(tracesAtom, next.length > maxTraces ? next.slice(0, maxTraces) : next);
+  const indexById = new Map(current.map((t, i) => [t.traceId, i]));
+  const working = current.slice();
+  let addedCount = 0;
+  let changed = false;
+  for (const newTrace of newTraces) {
+    const idx = indexById.get(newTrace.traceId);
+    if (idx !== undefined) {
+      const merged = mergeTrace(working[idx], newTrace);
+      if (!merged) continue;
+      working[idx] = merged;
+      changed = true;
+    } else {
+      // A brand-new trace, never merged into an existing one — the header
+      // badge's "genuinely new" signal (see totalTraceCountAtom).
+      addedCount++;
+      indexById.set(newTrace.traceId, working.length);
+      working.push(newTrace);
+      changed = true;
+    }
   }
+  if (!changed) return;
+  if (addedCount > 0) set(newTraceCountAtom, (n) => n + addedCount);
+  const next = newestTraceStartFirst(working);
+  set(tracesAtom, next.length > maxTraces ? next.slice(0, maxTraces) : next);
+});
+
+// Write-only: add a single item from WebSocket. A thin wrapper over the
+// batch path above so single-item callers (and tests) keep a simple API.
+export const addTraceAtom = atom(null, (_get, set, newTrace: TraceData) => {
+  set(addTracesAtom, [newTrace]);
 });
 
 // Inserts a trace fetched explicitly by ID without treating an already-retained
@@ -258,49 +281,90 @@ export function mergeDataPoints(existing: DataPoint[], incoming: DataPoint[]): D
 // widens by exactly the genuinely-new-point delta (a re-delivered point
 // mergeDataPoints already dedupes must not double count), and latestValue
 // only moves when that delta is nonzero, to the newest point's value.
-export const addMetricAtom = atom(null, (get, set, newMetric: MetricData) => {
+// Write-only: apply a whole WebSocket flush window's worth of metric
+// deliveries in a single store update (see addTracesAtom's doc comment for
+// why hooks/use-websocket.ts batches before writing). Existing groups are
+// updated in place against one working array; brand-new groups are
+// collected separately and prepended in the same reverse-arrival order a
+// sequence of single addMetricAtom calls would produce (each single call
+// prepends to the front), so batching this doesn't change the resulting
+// order.
+interface MetricLocation {
+  arr: "working" | "new";
+  idx: number;
+}
+
+export const addMetricsAtom = atom(null, (get, set, newMetrics: MetricData[]) => {
+  if (newMetrics.length === 0) return;
   const current = get(metricsAtom);
   const maxMetrics = get(bufferCapsAtom).metricCap;
-  const idx = current.findIndex((m) => metricKeyEquals(m, newMetric));
-  if (idx >= 0) {
-    const existing = current[idx];
-    const merged = mergeDataPoints(existing.dataPoints, newMetric.dataPoints);
-    const addedCount = merged.length - existing.dataPoints.length;
-    const updated = [...current];
-    updated[idx] = {
-      ...existing,
-      dataPoints: merged.slice(-get(bufferCapsAtom).maxDataPoints),
-      pointCount: existing.pointCount + addedCount,
-      latestValue: addedCount > 0 ? merged[merged.length - 1].value : existing.latestValue,
-      receivedAt: newMetric.receivedAt,
-    };
-    set(metricsAtom, updated);
-  } else {
-    // A brand-new (serviceName, name) group — the header badge's
-    // "genuinely new" signal (see totalMetricCountAtom); config.metricCount
-    // counts groups the same way (storage.Counts), so this mirrors it.
-    set(newMetricCountAtom, (n) => n + 1);
-    const next = [
-      {
+  const maxDataPoints = get(bufferCapsAtom).maxDataPoints;
+  const working = current.slice();
+  const newGroups: MetricData[] = [];
+  const locationByKey = new Map<string, MetricLocation>(
+    current.map((m, i) => [metricKeyToString(m), { arr: "working", idx: i }]),
+  );
+  let addedGroupCount = 0;
+  for (const newMetric of newMetrics) {
+    const key = metricKeyToString(newMetric);
+    const loc = locationByKey.get(key);
+    if (loc) {
+      // Also handles a metric key appearing more than once within this one
+      // batch: the second occurrence merges into the first occurrence's
+      // (possibly brand-new, `arr: "new"`) entry instead of being treated as
+      // a second brand-new group.
+      const arr = loc.arr === "working" ? working : newGroups;
+      const existing = arr[loc.idx];
+      const merged = mergeDataPoints(existing.dataPoints, newMetric.dataPoints);
+      const addedCount = merged.length - existing.dataPoints.length;
+      arr[loc.idx] = {
+        ...existing,
+        dataPoints: merged.slice(-maxDataPoints),
+        pointCount: existing.pointCount + addedCount,
+        latestValue: addedCount > 0 ? merged[merged.length - 1].value : existing.latestValue,
+        receivedAt: newMetric.receivedAt,
+      };
+    } else {
+      // A brand-new (serviceName, name) group — the header badge's
+      // "genuinely new" signal (see totalMetricCountAtom); config.metricCount
+      // counts groups the same way (storage.Counts), so this mirrors it.
+      addedGroupCount++;
+      locationByKey.set(key, { arr: "new", idx: newGroups.length });
+      newGroups.push({
         ...newMetric,
         pointCount: newMetric.dataPoints.length,
         latestValue: newMetric.dataPoints.at(-1)?.value ?? null,
-      },
-      ...current,
-    ];
-    set(metricsAtom, next.length > maxMetrics ? next.slice(0, maxMetrics) : next);
+      });
+    }
   }
+  if (addedGroupCount > 0) set(newMetricCountAtom, (n) => n + addedGroupCount);
+  const next = [...newGroups.reverse(), ...working];
+  set(metricsAtom, next.length > maxMetrics ? next.slice(0, maxMetrics) : next);
 });
 
-export const addLogAtom = atom(null, (get, set, newLog: LogData) => {
+export const addMetricAtom = atom(null, (_get, set, newMetric: MetricData) => {
+  set(addMetricsAtom, [newMetric]);
+});
+
+// Write-only: apply a whole WebSocket flush window's worth of log deliveries
+// in a single store update (see addTracesAtom's doc comment). Reversing the
+// batch before prepending mirrors what a sequence of single addLogAtom calls
+// would produce (each prepends to the front, so the last-arriving log of the
+// batch ends up first) while only writing logsAtom/newLogCountAtom once.
+export const addLogsAtom = atom(null, (get, set, newLogs: LogData[]) => {
+  if (newLogs.length === 0) return;
   const maxLogs = get(bufferCapsAtom).logCap;
   // Every log is a genuinely new row — there's no merge-into-existing
   // concept for logs (unlike traces/metrics), so this always increments.
-  set(newLogCountAtom, (n) => n + 1);
+  set(newLogCountAtom, (n) => n + newLogs.length);
   set(logsAtom, (prev) => {
-    const next = [newLog, ...prev];
+    const next = [...newLogs.toReversed(), ...prev];
     return next.length > maxLogs ? next.slice(0, maxLogs) : next;
   });
+});
+
+export const addLogAtom = atom(null, (_get, set, newLog: LogData) => {
+  set(addLogsAtom, [newLog]);
 });
 
 // Server-reported totals as of the initial load (config.traceCount/


### PR DESCRIPTION
## Summary

The backend broadcasts one WS message per record (`internal/broadcast/broadcast.go`), and the frontend wrote each message straight to jotai — a full array rebuild + sort + derived-atom recompute + React reconcile per record. Profiled at 100 records/s over a capped 5000-log buffer, the main thread sat at 80% busy even after #191.

This batches deliveries with a **leading-edge + trailing throttle** (`use-websocket.ts`):

- **Idle → first message applies synchronously** — sparse traffic pays *zero* added latency; the live-tail feel is unchanged.
- The leading message opens a 50ms window; messages arriving inside it queue and flush together, re-arming every 50ms while traffic continues (≤20 flushes/s regardless of message rate); an empty tick closes the window so the next message is leading again.
- Flushes split only at message-type boundaries, preserving add→delete→add ordering per trace.
- New batch atoms (`addTracesAtom`/`addMetricsAtom`/`addLogsAtom`) apply a whole flush against one working array with a single sort/cap slice at the end (traces use an id→index map); the single-item atoms remain as thin wrappers, so existing call sites and tests are untouched.

## Measured effect (Chrome trace, 10s stream over a 5000-log buffer, isolated e2e env)

| condition | main-thread busy / 10s |
|---|---|
| pre-#191 main @100 rec/s | 9,652 ms (96% — near saturation) |
| current main (#191) @100 rec/s | 7,992 ms (80%) |
| **this PR @100 rec/s** | **6,192 ms (62%)** — −23% vs main |
| **this PR @500 rec/s** | **6,721 ms (67%)** — 5× the traffic for +9% busy |

The last row is the structural win: cost is now bounded by the flush cap, not the message rate — pre-batching, 500 rec/s extrapolates far past saturation.

## Test plan

- [x] 482/482 frontend tests (26 new): leading message applies without waiting the interval; in-window messages coalesce into one batched write; sustained stream flushes every 50ms and the window closes on an empty tick; add→delete→add ordering preserved; unmount clears the timer; batch atoms (ordering, caps, newTraceCount, single-item wrapper compat)
- [x] `pnpm fix` clean; profiles above collected on this branch via `mise run e2e-env`