### PR TITLE
refactor(cli): extract reusable runtime from commands

### DIFF
--- a/cmd/otelop/banner.go
+++ b/cmd/otelop/banner.go
@@ -3,7 +3,8 @@ package main
 import (
 	"fmt"
 	"io"
-	"net"
+
+	"github.com/mashiro/otelop/internal/netutil"
 )
 
 const (
@@ -22,26 +23,11 @@ func writeBanner(w io.Writer, suffix string, rows bannerRows) {
 	_, _ = fmt.Fprintln(w)
 }
 
-// resolveLoopback converts a listen address (e.g. "0.0.0.0:4317") to a
-// connectable loopback address (e.g. "localhost:4317"). Shared by the banner
-// renderer, self-telemetry setup, and the GraphQL client so they all agree
-// on what "localhost" means.
-func resolveLoopback(listenAddr string) (string, error) {
-	host, port, err := net.SplitHostPort(listenAddr)
-	if err != nil {
-		return "", err
-	}
-	if host == "" || host == "0.0.0.0" || host == "::" {
-		host = "localhost"
-	}
-	return host + ":" + port, nil
-}
-
-// webUIDisplay is resolveLoopback with an "on error, fall back to the raw
+// webUIDisplay is netutil.Loopback with an "on error, fall back to the raw
 // address" safety net for cosmetic output where a parse error shouldn't
 // replace the address with an empty string.
 func webUIDisplay(addr string) string {
-	display, err := resolveLoopback(addr)
+	display, err := netutil.Loopback(addr)
 	if err != nil {
 		return addr
 	}

--- a/cmd/otelop/main.go
+++ b/cmd/otelop/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -17,20 +16,13 @@ func main() {
 		Usage:   "Browser-based OpenTelemetry viewer",
 		Version: version,
 		Commands: []*cli.Command{
-			startCommand(),
-			restartCommand(),
+			startCommand(version),
+			restartCommand(version),
 			stopCommand(),
 			statusCommand(),
 			infoCommand(),
 			logsCommand(),
-			{
-				Name:  "version",
-				Usage: "Print version",
-				Action: func(_ context.Context, _ *cli.Command) error {
-					fmt.Println(version)
-					return nil
-				},
-			},
+			versionCommand(version),
 		},
 	}
 

--- a/cmd/otelop/restart.go
+++ b/cmd/otelop/restart.go
@@ -13,16 +13,18 @@ import (
 
 const restartStopTimeout = 10 * time.Second
 
-func restartCommand() *cli.Command {
-	cmd := startCommand()
+func restartCommand(version string) *cli.Command {
+	cmd := startCommand(version)
 	cmd.Name = "restart"
 	cmd.Usage = "Stop the running otelop server and start it again"
-	cmd.Action = runRestart
+	cmd.Action = func(ctx context.Context, cmd *cli.Command) error {
+		return runRestart(ctx, cmd, version)
+	}
 	cmd.Description = "Stops any running otelop daemon and re-runs `start` with the current flags, env vars, and config file values."
 	return cmd
 }
 
-func runRestart(ctx context.Context, cmd *cli.Command) error {
+func runRestart(ctx context.Context, cmd *cli.Command, version string) error {
 	// The daemon child re-execs itself with the same argv, so without this
 	// guard it would re-enter runRestart, see no running daemon, and call
 	// runStart from the wrong layer. Skip the stop in the child and let
@@ -32,7 +34,7 @@ func runRestart(ctx context.Context, cmd *cli.Command) error {
 			return err
 		}
 	}
-	return runStart(ctx, cmd)
+	return runStart(ctx, cmd, version)
 }
 
 // stopForRestart is the quiet variant of stop. It only prints a message when

--- a/cmd/otelop/start.go
+++ b/cmd/otelop/start.go
@@ -2,48 +2,23 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
-	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/urfave/cli/v3"
-	"go.opentelemetry.io/collector/otelcol"
-	"go.opentelemetry.io/contrib/bridges/otelslog"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/metric"
 
-	otelop "github.com/mashiro/otelop"
-	"github.com/mashiro/otelop/internal/broadcast"
-	"github.com/mashiro/otelop/internal/collector"
 	"github.com/mashiro/otelop/internal/config"
 	"github.com/mashiro/otelop/internal/daemon"
-	otelopexporter "github.com/mashiro/otelop/internal/exporter"
-	otelopgraphql "github.com/mashiro/otelop/internal/graphql"
-	"github.com/mashiro/otelop/internal/logger"
-	"github.com/mashiro/otelop/internal/selftelemetry"
-	"github.com/mashiro/otelop/internal/server"
-	"github.com/mashiro/otelop/internal/storage"
-	ws "github.com/mashiro/otelop/internal/websocket"
+	otelruntime "github.com/mashiro/otelop/internal/runtime"
 )
 
-func startCommand() *cli.Command {
-	// Load the TOML config file once at command-construction time. Its
-	// values become each flag's Default, so the resolved precedence is:
-	//   CLI flag > env var (Sources) > config file (Default) > built-in.
-	// A missing file is silently treated as "all defaults". A parse error
-	// is fatal at the next runtime call, surfaced from runStart.
+func startCommand(version string) *cli.Command {
 	cfg, cfgPath, cfgErr := config.Load()
 
 	return &cli.Command{
@@ -56,11 +31,7 @@ func startCommand() *cli.Command {
 			return nil, nil
 		},
 		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:    "foreground",
-				Aliases: []string{"f"},
-				Usage:   "run in the foreground instead of detaching",
-			},
+			&cli.BoolFlag{Name: "foreground", Aliases: []string{"f"}, Usage: "run in the foreground instead of detaching"},
 			&cli.StringFlag{Name: "http", Value: cfg.HTTPAddr, Usage: "Web UI + REST API listen address", Sources: cli.EnvVars("OTELOP_HTTP")},
 			&cli.StringFlag{Name: "otlp-grpc", Value: cfg.OTLPGRPCAddr, Usage: "OTLP gRPC receiver endpoint", Sources: cli.EnvVars("OTELOP_OTLP_GRPC")},
 			&cli.StringFlag{Name: "otlp-http", Value: cfg.OTLPHTTPAddr, Usage: "OTLP HTTP receiver endpoint", Sources: cli.EnvVars("OTELOP_OTLP_HTTP")},
@@ -79,74 +50,54 @@ func startCommand() *cli.Command {
 			&cli.StringFlag{Name: "log-level", Value: cfg.LogLevel, Usage: "log level (debug|info|warn|error)", Sources: cli.EnvVars("OTELOP_LOG_LEVEL")},
 			&cli.BoolFlag{Name: "debug", Value: cfg.Debug, Usage: "export otelop's own telemetry to itself", Sources: cli.EnvVars("OTELOP_DEBUG")},
 		},
-		Action:      runStart,
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			return runStart(ctx, cmd, version)
+		},
 		Description: fmt.Sprintf("Reads defaults from %s when present. Override with environment variables (OTELOP_HTTP, OTELOP_OTLP_GRPC, ...) or CLI flags.", cfgPath),
 	}
 }
 
-type proxyAuthOptions struct {
-	Type     string
-	Token    string
-	Username string
-	Password string
-	Headers  map[string]string
-}
-
 type startOptions struct {
-	HTTPAddr        string
-	OTLPGRPCAddr    string
-	OTLPHTTPAddr    string
-	AllowedHosts    []string
-	ProxyURL        string
-	ProxyProtocol   string
-	ProxyAuth       proxyAuthOptions
-	StoragePath     string
-	Retention       string
-	MaxSize         string
-	RenderWindowMax int
-	LogLevel        string
-	Debug           bool
-	Foreground      bool
+	runtime    otelruntime.Options
+	foreground bool
 }
 
-func optionsFromCmd(cmd *cli.Command) startOptions {
+func optionsFromCmd(cmd *cli.Command, version string) startOptions {
 	return startOptions{
-		HTTPAddr:      cmd.String("http"),
-		OTLPGRPCAddr:  cmd.String("otlp-grpc"),
-		OTLPHTTPAddr:  cmd.String("otlp-http"),
-		AllowedHosts:  splitCSV(cmd.String("allowed-hosts")),
-		ProxyURL:      strings.TrimSpace(cmd.String("proxy-url")),
-		ProxyProtocol: normalizeProxyProtocol(cmd.String("proxy-protocol")),
-		ProxyAuth: proxyAuthOptions{
-			Type:     normalizeProxyAuthType(cmd.String("proxy-auth-type")),
-			Token:    cmd.String("proxy-auth-token"),
-			Username: cmd.String("proxy-auth-username"),
-			Password: cmd.String("proxy-auth-password"),
-			Headers:  parseHeaderArgs(cmd.StringSlice("proxy-header")),
+		runtime: otelruntime.Options{
+			Version:         version,
+			HTTPAddr:        cmd.String("http"),
+			OTLPGRPCAddr:    cmd.String("otlp-grpc"),
+			OTLPHTTPAddr:    cmd.String("otlp-http"),
+			AllowedHosts:    splitCSV(cmd.String("allowed-hosts")),
+			ProxyURL:        strings.TrimSpace(cmd.String("proxy-url")),
+			ProxyProtocol:   strings.ToLower(strings.TrimSpace(cmd.String("proxy-protocol"))),
+			StoragePath:     strings.TrimSpace(cmd.String("storage-path")),
+			Retention:       cmd.String("retention"),
+			MaxSize:         cmd.String("max-size"),
+			RenderWindowMax: cmd.Int("render-window-max"),
+			LogLevel:        cmd.String("log-level"),
+			Debug:           cmd.Bool("debug"),
+			ProxyAuth: otelruntime.ProxyAuthOptions{
+				Type:     strings.ToLower(strings.TrimSpace(cmd.String("proxy-auth-type"))),
+				Token:    cmd.String("proxy-auth-token"),
+				Username: cmd.String("proxy-auth-username"),
+				Password: cmd.String("proxy-auth-password"),
+				Headers:  parseHeaderArgs(cmd.StringSlice("proxy-header")),
+			},
 		},
-		StoragePath:     strings.TrimSpace(cmd.String("storage-path")),
-		Retention:       cmd.String("retention"),
-		MaxSize:         cmd.String("max-size"),
-		RenderWindowMax: cmd.Int("render-window-max"),
-		LogLevel:        cmd.String("log-level"),
-		Debug:           cmd.Bool("debug"),
-		Foreground:      cmd.Bool("foreground"),
+		foreground: cmd.Bool("foreground"),
 	}
 }
 
-// splitCSV splits a comma-separated flag/env value (e.g. --allowed-hosts,
-// OTELOP_ALLOWED_HOSTS) into its trimmed, non-empty entries. Returns nil for
-// an empty/all-whitespace input so callers see the same "no entries" shape
-// TOML's native array gives for an omitted key.
 func splitCSV(v string) []string {
 	fields := strings.Split(v, ",")
 	out := make([]string, 0, len(fields))
 	for _, f := range fields {
 		f = strings.TrimSpace(f)
-		if f == "" {
-			continue
+		if f != "" {
+			out = append(out, f)
 		}
-		out = append(out, f)
 	}
 	if len(out) == 0 {
 		return nil
@@ -154,52 +105,41 @@ func splitCSV(v string) []string {
 	return out
 }
 
-func runStart(ctx context.Context, cmd *cli.Command) error {
-	opts := optionsFromCmd(cmd)
-	if err := validateProxyOptions(opts); err != nil {
+func runStart(ctx context.Context, cmd *cli.Command, version string) error {
+	opts := optionsFromCmd(cmd, version)
+	if err := otelruntime.Validate(opts.runtime); err != nil {
 		return err
 	}
-	if err := validateRenderWindowMax(opts.RenderWindowMax); err != nil {
-		return err
-	}
-	if !daemon.IsDaemonChild() && !opts.Foreground {
+	if !daemon.IsDaemonChild() && !opts.foreground {
 		return runDaemonParent(ctx)
 	}
-	return runServer(ctx, opts)
+	return runServer(ctx, opts.runtime)
 }
 
-// runServer runs the HTTP server, collector, and self-telemetry, then
-// blocks until SIGINT/SIGTERM. When invoked by the detached daemon child it
-// also persists metadata and signals the parent via the inherited pipe.
-func runServer(ctx context.Context, opts startOptions) error {
+func runServer(ctx context.Context, opts otelruntime.Options) error {
 	ready := daemon.ReadyPipe()
-	rt, err := bootstrap(ctx, opts)
+	rt, err := otelruntime.Start(ctx, opts)
 	if err != nil {
 		daemon.SignalError(ready, err)
 		return err
 	}
-	defer rt.shutdown()
+	defer rt.Shutdown()
 
 	if ready != nil {
 		meta := daemon.Metadata{
 			PID:           os.Getpid(),
-			StartedAt:     rt.startedAt,
+			StartedAt:     rt.StartedAt(),
 			HTTPAddr:      opts.HTTPAddr,
 			OTLPGRPCAddr:  opts.OTLPGRPCAddr,
 			OTLPHTTPAddr:  opts.OTLPHTTPAddr,
-			ProxyURL:      redactURL(opts.ProxyURL),
+			ProxyURL:      otelruntime.RedactURL(opts.ProxyURL),
 			ProxyProtocol: opts.ProxyProtocol,
-			Version:       version,
+			Version:       opts.Version,
 		}
 		if err := daemon.WriteMetadata(meta); err != nil {
 			daemon.SignalError(ready, err)
 			return err
 		}
-		// Acquire an advisory flock on the metadata file and hold the fd
-		// for the rest of the process lifetime. `otelop status`/`stop`
-		// probe this lock to distinguish a live daemon from stale
-		// metadata, which makes the check immune to PID recycling after a
-		// crash.
 		lockFile, err := daemon.LockMetadata()
 		if err != nil {
 			_ = daemon.RemoveState()
@@ -210,10 +150,10 @@ func runServer(ctx context.Context, opts startOptions) error {
 		defer func() { _ = daemon.RemoveState() }()
 		daemon.SignalReady(ready)
 	} else {
-		rt.printBanner(os.Stderr, opts)
+		printStartBanner(os.Stderr, opts)
 	}
 
-	rt.waitForSignal(ctx)
+	waitForShutdown(ctx, rt.Done())
 	return nil
 }
 
@@ -254,211 +194,12 @@ func runDaemonParent(ctx context.Context) error {
 	return nil
 }
 
-type runtime struct {
-	cancel            context.CancelFunc
-	startedAt         time.Time
-	storage           *storage.Storage
-	hub               *ws.Hub
-	srv               *server.Server
-	col               *otelcol.Collector
-	shutdownTelemetry func(context.Context) error
-}
-
-func bootstrap(ctx context.Context, opts startOptions) (*runtime, error) {
-	level, err := logger.ParseLevel(opts.LogLevel)
-	if err != nil {
-		return nil, err
-	}
-	logger.Setup(level)
-
-	ctx, cancel := context.WithCancel(ctx)
-
-	rt := &runtime{
-		cancel: cancel,
-		// Round(0) drops the monotonic reading so uptime spans system sleep.
-		startedAt: time.Now().Round(0),
-	}
-
-	rt.hub = ws.NewHub()
-	go rt.hub.Run(ctx)
-
-	storagePath, retention, maxSize, err := resolveStorageOptions(opts)
-	if err != nil {
-		rt.shutdown()
-		return nil, err
-	}
-
-	// st is declared before Open so the OnCommitBatch closure below can capture a
-	// reference to the very Storage it will be attached to (broadcast.New
-	// needs *storage.Storage to query back through). Safe because Open never
-	// invokes OnCommitBatch synchronously during construction — only later, from
-	// the writer goroutine, once st is already assigned.
-	var st *storage.Storage
-	onAdd := func(ctx context.Context, sig broadcast.SignalType, data any) {
-		rt.hub.BroadcastContext(ctx, ws.Message{Type: sig, Data: data})
-	}
-	st, err = storage.Open(ctx, storage.Options{
-		Path:      storagePath,
-		Retention: retention,
-		MaxSize:   maxSize,
-		OnCommitBatch: func(deliveries []storage.CommitDelivery) {
-			broadcast.NewBatch(st, onAdd, func() bool { return rt.hub.ClientCount() > 0 })(deliveries)
-		},
-	})
-	if err != nil {
-		rt.shutdown()
-		return nil, fmt.Errorf("open storage %s: %w", storagePath, err)
-	}
-	rt.storage = st
-
-	runtimeInfo := otelopgraphql.RuntimeInfo{
-		Version:          version,
-		StartedAt:        rt.startedAt,
-		HTTPAddr:         opts.HTTPAddr,
-		OTLPGRPCAddr:     opts.OTLPGRPCAddr,
-		OTLPHTTPAddr:     opts.OTLPHTTPAddr,
-		ProxyURL:         redactURL(opts.ProxyURL),
-		ProxyProtocol:    opts.ProxyProtocol,
-		Debug:            opts.Debug,
-		LogLevel:         opts.LogLevel,
-		Retention:        retention,
-		StoragePath:      storagePath,
-		RetentionDisplay: opts.Retention,
-		MaxSizeDisplay:   opts.MaxSize,
-		RenderWindowMax:  opts.RenderWindowMax,
-	}
-	rt.srv = server.New(rt.storage, rt.hub, otelop.FrontendFS(), runtimeInfo, opts.AllowedHosts)
-
-	// Eager listen so port conflicts surface before we signal ready.
-	if err := rt.srv.Listen(ctx); err != nil {
-		rt.shutdown()
-		return nil, fmt.Errorf("bind %s: %w", opts.HTTPAddr, err)
-	}
-	go func() {
-		if err := rt.srv.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			slog.Error("HTTP server error", "error", err)
-			rt.cancel()
-		}
-	}()
-
-	selfTelemetryEndpoint := ""
-	if opts.Debug {
-		ep, err := resolveLoopback(opts.OTLPGRPCAddr)
-		if err != nil {
-			rt.shutdown()
-			return nil, fmt.Errorf("invalid otlp-grpc address: %w", err)
-		}
-		selfTelemetryEndpoint = ep
-	}
-
-	slog.Debug("starting collector", "grpc", opts.OTLPGRPCAddr, "http", opts.OTLPHTTPAddr)
-	col, err := collector.New(otelopexporter.NewFactory(rt.storage), collector.Config{
-		GRPCEndpoint:          opts.OTLPGRPCAddr,
-		HTTPEndpoint:          opts.OTLPHTTPAddr,
-		ProxyURL:              opts.ProxyURL,
-		ProxyProtocol:         opts.ProxyProtocol,
-		ProxyHeaders:          buildProxyHeaders(opts.ProxyAuth),
-		LogLevel:              opts.LogLevel,
-		SelfTelemetryEndpoint: selfTelemetryEndpoint,
-	})
-	if err != nil {
-		rt.shutdown()
-		return nil, fmt.Errorf("failed to create collector: %w", err)
-	}
-	rt.col = col
-
-	colErrCh := make(chan error, 1)
-	go func() {
-		if err := col.Run(ctx); err != nil {
-			colErrCh <- err
-		}
-		close(colErrCh)
-	}()
-
-	if err := waitCollectorReady(ctx, col, colErrCh); err != nil {
-		rt.shutdown()
-		return nil, err
-	}
-
-	// Once ready, nothing else reads colErrCh — without this, a post-ready
-	// Run failure (e.g. the OTLP listener dying) would go unnoticed and
-	// `otelop status` would keep reporting "running" while ingestion is
-	// silently dead. rt.cancel() unwinds waitForSignal, which triggers the
-	// deferred rt.shutdown() in runServer.
-	go watchCollectorErrors(colErrCh, rt.cancel, slog.Default())
-
-	if opts.Debug {
-		slog.Debug("starting self-telemetry", "endpoint", selfTelemetryEndpoint)
-		result, err := selftelemetry.Setup(ctx, selfTelemetryEndpoint)
-		if err != nil {
-			rt.shutdown()
-			return nil, fmt.Errorf("failed to setup self-telemetry: %w", err)
-		}
-		rt.shutdownTelemetry = result.Shutdown
-
-		otelHandler := otelslog.NewHandler("otelop", otelslog.WithLoggerProvider(result.LoggerProvider))
-		logger.Setup(level, otelHandler)
-
-		if err := registerMetrics(rt.storage, rt.hub); err != nil {
-			rt.shutdown()
-			return nil, fmt.Errorf("failed to register metrics: %w", err)
-		}
-	}
-
-	return rt, nil
-}
-
-// waitCollectorReady blocks until col reports StateRunning, an error is
-// observed on errCh, or the budget elapses. Replaces the old 500 ms blind
-// sleep — successful binds now return in ~10-50 ms.
-func waitCollectorReady(ctx context.Context, col *otelcol.Collector, errCh <-chan error) error {
-	const budget = 2 * time.Second
-	const tick = 10 * time.Millisecond
-	deadline := time.NewTimer(budget)
-	defer deadline.Stop()
-	ticker := time.NewTicker(tick)
-	defer ticker.Stop()
-	for {
-		select {
-		case err, ok := <-errCh:
-			if !ok {
-				return errors.New("collector exited before becoming ready")
-			}
-			if err != nil {
-				return fmt.Errorf("collector failed to start: %w", err)
-			}
-		case <-ticker.C:
-		case <-deadline.C:
-			return fmt.Errorf("collector did not become ready within %s", budget)
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-		if col.GetState() == otelcol.StateRunning {
-			return nil
-		}
-	}
-}
-
-// watchCollectorErrors observes errCh for a collector failure that happens
-// after waitCollectorReady already returned success, and cancels the daemon
-// so the failure isn't silent. errCh is only ever populated when col.Run
-// returns a non-nil error; a clean shutdown (col.Shutdown() making Run
-// return nil) closes it without sending, which is a no-op here.
-func watchCollectorErrors(errCh <-chan error, cancel context.CancelFunc, logger *slog.Logger) {
-	err, ok := <-errCh
-	if !ok || err == nil {
-		return
-	}
-	logger.Error("collector stopped unexpectedly, shutting down", "error", err)
-	cancel()
-}
-
-func (r *runtime) printBanner(w io.Writer, opts startOptions) {
+func printStartBanner(w io.Writer, opts otelruntime.Options) {
 	suffix := ""
 	if opts.Debug {
 		suffix = " (debug)"
 	}
-	storagePath, err := resolveStoragePath(opts.StoragePath)
+	storagePath, err := otelruntime.ResolveStoragePath(opts.StoragePath)
 	if err != nil {
 		storagePath = opts.StoragePath
 	}
@@ -471,219 +212,16 @@ func (r *runtime) printBanner(w io.Writer, opts startOptions) {
 	})
 }
 
-// resolveStoragePath returns the DuckDB file location: raw if non-empty,
-// otherwise config.DefaultStoragePath()'s XDG-derived default.
-func resolveStoragePath(raw string) (string, error) {
-	if raw != "" {
-		return raw, nil
+func waitForShutdown(ctx context.Context, runtimeDone <-chan struct{}) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	select {
+	case <-sigCh:
+	case <-ctx.Done():
+	case <-runtimeDone:
 	}
-	return config.DefaultStoragePath()
-}
-
-// resolveStorageOptions turns the CLI-level startOptions.StoragePath/Retention/MaxSize
-// strings into the (path, retention, maxSize) triple internal/storage.Options
-// wants, resolving the XDG default path and creating its parent directory
-// (internal/storage.Open does not create directories itself) when no
-// explicit --storage-path was given.
-func resolveStorageOptions(opts startOptions) (path string, retention time.Duration, maxSize int64, err error) {
-	path, err = resolveStoragePath(opts.StoragePath)
-	if err != nil {
-		return "", 0, 0, fmt.Errorf("resolve storage path: %w", err)
-	}
-	if path != "" {
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			return "", 0, 0, fmt.Errorf("create storage directory: %w", err)
-		}
-	}
-	retention, err = config.ParseRetention(opts.Retention)
-	if err != nil {
-		return "", 0, 0, err
-	}
-	maxSize, err = config.ParseMaxSize(opts.MaxSize)
-	if err != nil {
-		return "", 0, 0, err
-	}
-	return path, retention, maxSize, nil
-}
-
-// validateRenderWindowMax rejects a non-positive --render-window-max/
-// OTELOP_RENDER_WINDOW_MAX value at startup: the frontend mounts exactly this
-// many <tr> rows at once in the traces/metrics/logs tables (no virtualization
-// library — frontend/src/hooks/use-render-window.ts), so anything less than 1
-// would leave those tables permanently empty.
-func validateRenderWindowMax(v int) error {
-	if v < 1 {
-		return fmt.Errorf("render-window-max must be >= 1, got %d", v)
-	}
-	return nil
-}
-
-func normalizeProxyProtocol(v string) string {
-	return strings.ToLower(strings.TrimSpace(v))
-}
-
-func normalizeProxyAuthType(v string) string {
-	return strings.ToLower(strings.TrimSpace(v))
-}
-
-func validateProxyOptions(opts startOptions) error {
-	if opts.ProxyURL == "" && opts.ProxyProtocol == "" {
-		if opts.ProxyAuth.Type != "" || hasProxyAuthFields(opts.ProxyAuth) {
-			return errors.New("proxy auth requires --proxy-url and --proxy-protocol")
-		}
-		return nil
-	}
-	if opts.ProxyURL == "" {
-		return errors.New("proxy-protocol requires --proxy-url")
-	}
-	if opts.ProxyProtocol == "" {
-		return errors.New("proxy-url requires --proxy-protocol (grpc|http)")
-	}
-	u, err := url.Parse(opts.ProxyURL)
-	if err != nil {
-		return fmt.Errorf("invalid proxy-url: %w", err)
-	}
-	if u.User != nil {
-		return errors.New("proxy-url must not contain embedded credentials; use --proxy-auth-* instead")
-	}
-	if err := validateProxyAuth(opts.ProxyAuth); err != nil {
-		return err
-	}
-	switch opts.ProxyProtocol {
-	case "grpc":
-		if err := validateGRPCProxyURL(u, opts.ProxyURL); err != nil {
-			return err
-		}
-		return validateNoSelfProxy(u, opts.ProxyURL, opts.OTLPGRPCAddr, "grpc")
-	case "http":
-		if err := validateHTTPProxyURL(u, opts.ProxyURL); err != nil {
-			return err
-		}
-		return validateNoSelfProxy(u, opts.ProxyURL, opts.OTLPHTTPAddr, "http")
-	default:
-		return fmt.Errorf("invalid proxy-protocol %q: want grpc or http", opts.ProxyProtocol)
-	}
-}
-
-func validateGRPCProxyURL(u *url.URL, raw string) error {
-	if u.Scheme == "" {
-		if raw == "" || strings.Contains(raw, "/") {
-			return fmt.Errorf("invalid proxy-url %q for grpc: want host:port or http(s)://host:port", raw)
-		}
-		return nil
-	}
-	switch strings.ToLower(u.Scheme) {
-	case "http", "https":
-		if u.Host == "" {
-			return fmt.Errorf("invalid proxy-url %q for grpc: missing host", raw)
-		}
-		return nil
-	default:
-		return fmt.Errorf("invalid proxy-url %q for grpc: unsupported scheme %q", raw, u.Scheme)
-	}
-}
-
-func validateHTTPProxyURL(u *url.URL, raw string) error {
-	if u.Scheme == "" || u.Host == "" {
-		return fmt.Errorf("invalid proxy-url %q for http: want http://host:port or https://host:port", raw)
-	}
-	switch strings.ToLower(u.Scheme) {
-	case "http", "https":
-		return nil
-	default:
-		return fmt.Errorf("invalid proxy-url %q for http: unsupported scheme %q", raw, u.Scheme)
-	}
-}
-
-func validateProxyAuth(auth proxyAuthOptions) error {
-	switch auth.Type {
-	case "":
-		if hasProxyAuthFields(auth) {
-			return errors.New("proxy auth fields require --proxy-auth-type")
-		}
-		return nil
-	case "bearer":
-		if auth.Token == "" {
-			return errors.New("proxy-auth-type bearer requires --proxy-auth-token")
-		}
-		if auth.Username != "" || auth.Password != "" || len(auth.Headers) > 0 {
-			return errors.New("proxy-auth-type bearer only supports --proxy-auth-token")
-		}
-	case "basic":
-		if auth.Username == "" || auth.Password == "" {
-			return errors.New("proxy-auth-type basic requires --proxy-auth-username and --proxy-auth-password")
-		}
-		if auth.Token != "" || len(auth.Headers) > 0 {
-			return errors.New("proxy-auth-type basic only supports username/password")
-		}
-	case "headers":
-		if len(auth.Headers) == 0 {
-			return errors.New("proxy-auth-type headers requires at least one --proxy-header")
-		}
-		if auth.Token != "" || auth.Username != "" || auth.Password != "" {
-			return errors.New("proxy-auth-type headers only supports --proxy-header")
-		}
-	default:
-		return fmt.Errorf("invalid proxy-auth-type %q: want bearer, basic, or headers", auth.Type)
-	}
-	return nil
-}
-
-func validateNoSelfProxy(u *url.URL, proxyURL, listenAddr, protocol string) error {
-	target, err := comparableProxyHostPort(u, proxyURL, protocol)
-	if err != nil {
-		return err
-	}
-	local, err := normalizeHostPort(listenAddr)
-	if err != nil {
-		return err
-	}
-	if target == local {
-		return fmt.Errorf("proxy-url %q points back to otelop's own OTLP %s listener %q", proxyURL, protocol, listenAddr)
-	}
-	return nil
-}
-
-func comparableProxyHostPort(u *url.URL, proxyURL, protocol string) (string, error) {
-	if protocol == "grpc" && u.Scheme == "" {
-		return normalizeHostPort(proxyURL)
-	}
-	return normalizeHostPort(u.Host)
-}
-
-func normalizeHostPort(addr string) (string, error) {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return "", err
-	}
-	host = strings.ToLower(strings.Trim(host, "[]"))
-	switch host {
-	case "", "0.0.0.0", "::", "::1", "127.0.0.1", "localhost":
-		host = "localhost"
-	}
-	return net.JoinHostPort(host, port), nil
-}
-
-func hasProxyAuthFields(auth proxyAuthOptions) bool {
-	return auth.Token != "" || auth.Username != "" || auth.Password != "" || len(auth.Headers) > 0
-}
-
-func buildProxyHeaders(auth proxyAuthOptions) map[string]string {
-	switch auth.Type {
-	case "bearer":
-		return map[string]string{"Authorization": "Bearer " + auth.Token}
-	case "basic":
-		token := base64.StdEncoding.EncodeToString([]byte(auth.Username + ":" + auth.Password))
-		return map[string]string{"Authorization": "Basic " + token}
-	case "headers":
-		out := make(map[string]string, len(auth.Headers))
-		for k, v := range auth.Headers {
-			out[k] = v
-		}
-		return out
-	default:
-		return nil
-	}
+	slog.Info("shutting down...")
 }
 
 func parseHeaderArgs(args []string) map[string]string {
@@ -692,19 +230,11 @@ func parseHeaderArgs(args []string) map[string]string {
 	}
 	out := make(map[string]string, len(args))
 	for _, arg := range args {
-		if arg == "" {
-			continue
-		}
 		k, v, ok := strings.Cut(arg, "=")
-		if !ok {
-			continue
-		}
 		k = strings.TrimSpace(k)
-		v = strings.TrimSpace(v)
-		if k == "" {
-			continue
+		if ok && k != "" {
+			out[k] = strings.TrimSpace(v)
 		}
-		out[k] = v
 	}
 	if len(out) == 0 {
 		return nil
@@ -713,9 +243,6 @@ func parseHeaderArgs(args []string) map[string]string {
 }
 
 func headerPairs(headers map[string]string) []string {
-	if len(headers) == 0 {
-		return nil
-	}
 	keys := make([]string, 0, len(headers))
 	for k := range headers {
 		keys = append(keys, k)
@@ -728,105 +255,9 @@ func headerPairs(headers map[string]string) []string {
 	return out
 }
 
-func redactURL(raw string) string {
-	if raw == "" {
-		return ""
-	}
-	u, err := url.Parse(raw)
-	if err != nil || u.User == nil {
-		return raw
-	}
-	u.User = url.UserPassword("REDACTED", "REDACTED")
-	return u.String()
-}
-
 func formatProxyStatus(proxyURL, proxyProtocol string) string {
 	if proxyURL == "" || proxyProtocol == "" {
 		return "disabled"
 	}
 	return fmt.Sprintf("%s %s", strings.ToUpper(proxyProtocol), proxyURL)
-}
-
-func (r *runtime) waitForSignal(ctx context.Context) {
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	select {
-	case <-sigCh:
-	case <-ctx.Done():
-	}
-	slog.Info("shutting down...")
-}
-
-func (r *runtime) shutdown() {
-	if r == nil {
-		return
-	}
-	shutdownCtx := context.Background()
-	if r.shutdownTelemetry != nil {
-		if err := r.shutdownTelemetry(shutdownCtx); err != nil {
-			slog.Error("self-telemetry shutdown error", "error", err)
-		}
-	}
-	if r.col != nil {
-		r.col.Shutdown()
-	}
-	if r.srv != nil {
-		if err := r.srv.Shutdown(shutdownCtx); err != nil {
-			slog.Error("HTTP server shutdown error", "error", err)
-		}
-	}
-	if r.storage != nil {
-		if err := r.storage.Close(); err != nil {
-			slog.Error("storage shutdown error", "error", err)
-		}
-	}
-	if r.cancel != nil {
-		r.cancel()
-	}
-}
-
-func registerMetrics(s *storage.Storage, hub *ws.Hub) error {
-	meter := otel.Meter("otelop")
-	if err := s.RegisterTelemetry(meter); err != nil {
-		return err
-	}
-
-	traceGauge, err := meter.Int64ObservableGauge("otelop.store.traces",
-		metric.WithDescription("Number of traces in the store"),
-	)
-	if err != nil {
-		return err
-	}
-	metricGauge, err := meter.Int64ObservableGauge("otelop.store.metrics",
-		metric.WithDescription("Number of metric series in the store"),
-	)
-	if err != nil {
-		return err
-	}
-	logGauge, err := meter.Int64ObservableGauge("otelop.store.logs",
-		metric.WithDescription("Number of log entries in the store"),
-	)
-	if err != nil {
-		return err
-	}
-	if _, err := meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
-		traces, metrics, logs, err := s.Counts(ctx)
-		if err != nil {
-			return err
-		}
-		o.ObserveInt64(traceGauge, int64(traces))
-		o.ObserveInt64(metricGauge, int64(metrics))
-		o.ObserveInt64(logGauge, int64(logs))
-		return nil
-	}, traceGauge, metricGauge, logGauge); err != nil {
-		return err
-	}
-	_, err = meter.Int64ObservableGauge("otelop.websocket.clients",
-		metric.WithDescription("Number of connected WebSocket clients"),
-		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
-			o.Observe(int64(hub.ClientCount()))
-			return nil
-		}),
-	)
-	return err
 }

--- a/cmd/otelop/start_test.go
+++ b/cmd/otelop/start_test.go
@@ -1,91 +1,9 @@
 package main
 
 import (
-	"bytes"
-	"errors"
-	"log/slog"
 	"slices"
-	"strings"
 	"testing"
-	"time"
 )
-
-func TestValidateProxyOptions_RejectsSelfProxy(t *testing.T) {
-	opts := startOptions{
-		OTLPGRPCAddr:  "0.0.0.0:4317",
-		OTLPHTTPAddr:  "0.0.0.0:4318",
-		ProxyURL:      "http://127.0.0.1:4317",
-		ProxyProtocol: "grpc",
-	}
-	err := validateProxyOptions(opts)
-	if err == nil || !strings.Contains(err.Error(), "points back to otelop's own OTLP grpc listener") {
-		t.Fatalf("validateProxyOptions error = %v", err)
-	}
-}
-
-func TestValidateProxyOptions_RejectsCredentialsInURL(t *testing.T) {
-	opts := startOptions{
-		OTLPGRPCAddr:  "0.0.0.0:4317",
-		OTLPHTTPAddr:  "0.0.0.0:4318",
-		ProxyURL:      "https://user:pass@example.com:4318",
-		ProxyProtocol: "http",
-	}
-	err := validateProxyOptions(opts)
-	if err == nil || !strings.Contains(err.Error(), "must not contain embedded credentials") {
-		t.Fatalf("validateProxyOptions error = %v", err)
-	}
-}
-
-func TestValidateProxyOptions_BearerAuth(t *testing.T) {
-	opts := startOptions{
-		OTLPGRPCAddr:  "0.0.0.0:4317",
-		OTLPHTTPAddr:  "0.0.0.0:4318",
-		ProxyURL:      "https://collector.example.com:4318",
-		ProxyProtocol: "http",
-		ProxyAuth: proxyAuthOptions{
-			Type:  "bearer",
-			Token: "token",
-		},
-	}
-	if err := validateProxyOptions(opts); err != nil {
-		t.Fatalf("validateProxyOptions: %v", err)
-	}
-}
-
-func TestValidateRenderWindowMax_RejectsLessThanOne(t *testing.T) {
-	for _, v := range []int{0, -1, -500} {
-		if err := validateRenderWindowMax(v); err == nil {
-			t.Errorf("validateRenderWindowMax(%d) = nil, want error", v)
-		}
-	}
-}
-
-func TestValidateRenderWindowMax_AcceptsPositive(t *testing.T) {
-	for _, v := range []int{1, 500, 10_000} {
-		if err := validateRenderWindowMax(v); err != nil {
-			t.Errorf("validateRenderWindowMax(%d) = %v, want nil", v, err)
-		}
-	}
-}
-
-func TestBuildProxyHeaders(t *testing.T) {
-	headers := buildProxyHeaders(proxyAuthOptions{
-		Type:     "basic",
-		Username: "alice",
-		Password: "secret",
-	})
-	got := headers["Authorization"]
-	if got != "Basic YWxpY2U6c2VjcmV0" {
-		t.Fatalf("Authorization = %q", got)
-	}
-}
-
-func TestRedactURL(t *testing.T) {
-	got := redactURL("https://user:pass@example.com:4318")
-	if got != "https://REDACTED:REDACTED@example.com:4318" {
-		t.Fatalf("redactURL = %q", got)
-	}
-}
 
 func TestSplitCSV(t *testing.T) {
 	tests := []struct {
@@ -106,60 +24,5 @@ func TestSplitCSV(t *testing.T) {
 				t.Errorf("splitCSV(%q) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
-	}
-}
-
-func TestWatchCollectorErrors_CancelsOnPostReadyFailure(t *testing.T) {
-	ch := make(chan error, 1)
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, nil))
-	canceled := make(chan struct{})
-	cancel := func() { close(canceled) }
-
-	ch <- errors.New("boom")
-	close(ch)
-
-	done := make(chan struct{})
-	go func() {
-		watchCollectorErrors(ch, cancel, logger)
-		close(done)
-	}()
-
-	select {
-	case <-canceled:
-	case <-time.After(time.Second):
-		t.Fatal("cancel was not called after a post-ready collector error")
-	}
-	<-done
-
-	if !strings.Contains(buf.String(), "boom") {
-		t.Errorf("log output = %q, want it to mention the collector error", buf.String())
-	}
-}
-
-func TestWatchCollectorErrors_NoOpOnCleanShutdown(t *testing.T) {
-	// col.Run returning nil (e.g. rt.shutdown() calling col.Shutdown()) closes
-	// the channel without ever sending — that's expected daemon shutdown, not
-	// a failure, so cancel must not be invoked again.
-	ch := make(chan error)
-	close(ch)
-
-	canceled := false
-	cancel := func() { canceled = true }
-
-	done := make(chan struct{})
-	go func() {
-		watchCollectorErrors(ch, cancel, slog.Default())
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("watchCollectorErrors did not return on channel close")
-	}
-
-	if canceled {
-		t.Error("cancel was called on a clean collector shutdown")
 	}
 }

--- a/cmd/otelop/status.go
+++ b/cmd/otelop/status.go
@@ -13,6 +13,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/mashiro/otelop/internal/daemon"
+	"github.com/mashiro/otelop/internal/netutil"
 )
 
 func statusCommand() *cli.Command {
@@ -98,7 +99,7 @@ func runStatus(ctx context.Context, cmd *cli.Command) error {
 }
 
 func queryStatus(ctx context.Context, httpAddr string) (*statusPayload, error) {
-	endpoint, err := resolveLoopback(httpAddr)
+	endpoint, err := netutil.Loopback(httpAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/otelop/version.go
+++ b/cmd/otelop/version.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v3"
+)
+
+func versionCommand(version string) *cli.Command {
+	return &cli.Command{
+		Name:  "version",
+		Usage: "Print version",
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			_, err := fmt.Fprintln(cmd.Writer, version)
+			return err
+		},
+	}
+}

--- a/internal/netutil/address.go
+++ b/internal/netutil/address.go
@@ -1,0 +1,15 @@
+package netutil
+
+import "net"
+
+// Loopback converts a listen address into an address a local client can use.
+func Loopback(listenAddr string) (string, error) {
+	host, port, err := net.SplitHostPort(listenAddr)
+	if err != nil {
+		return "", err
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "localhost"
+	}
+	return host + ":" + port, nil
+}

--- a/internal/netutil/address_test.go
+++ b/internal/netutil/address_test.go
@@ -1,10 +1,8 @@
-package main
+package netutil
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestResolveLoopback(t *testing.T) {
+func TestLoopback(t *testing.T) {
 	tests := []struct {
 		input   string
 		want    string
@@ -21,12 +19,12 @@ func TestResolveLoopback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got, err := resolveLoopback(tt.input)
+			got, err := Loopback(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("resolveLoopback(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				t.Fatalf("Loopback(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 			}
 			if got != tt.want {
-				t.Errorf("resolveLoopback(%q) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("Loopback(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/runtime/options.go
+++ b/internal/runtime/options.go
@@ -1,0 +1,250 @@
+package runtime
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mashiro/otelop/internal/config"
+)
+
+type ProxyAuthOptions struct {
+	Type     string
+	Token    string
+	Username string
+	Password string
+	Headers  map[string]string
+}
+
+type Options struct {
+	Version         string
+	HTTPAddr        string
+	OTLPGRPCAddr    string
+	OTLPHTTPAddr    string
+	AllowedHosts    []string
+	ProxyURL        string
+	ProxyProtocol   string
+	ProxyAuth       ProxyAuthOptions
+	StoragePath     string
+	Retention       string
+	MaxSize         string
+	RenderWindowMax int
+	LogLevel        string
+	Debug           bool
+}
+
+// Validate checks whether opts can be used to start an otelop runtime.
+func Validate(opts Options) error {
+	if opts.RenderWindowMax < 1 {
+		return fmt.Errorf("render-window-max must be >= 1, got %d", opts.RenderWindowMax)
+	}
+	return validateProxyOptions(opts)
+}
+
+func validateProxyOptions(opts Options) error {
+	if opts.ProxyURL == "" && opts.ProxyProtocol == "" {
+		if opts.ProxyAuth.Type != "" || hasProxyAuthFields(opts.ProxyAuth) {
+			return errors.New("proxy auth requires --proxy-url and --proxy-protocol")
+		}
+		return nil
+	}
+	if opts.ProxyURL == "" {
+		return errors.New("proxy-protocol requires --proxy-url")
+	}
+	if opts.ProxyProtocol == "" {
+		return errors.New("proxy-url requires --proxy-protocol (grpc|http)")
+	}
+	u, err := url.Parse(opts.ProxyURL)
+	if err != nil {
+		return fmt.Errorf("invalid proxy-url: %w", err)
+	}
+	if u.User != nil {
+		return errors.New("proxy-url must not contain embedded credentials; use --proxy-auth-* instead")
+	}
+	if err := validateProxyAuth(opts.ProxyAuth); err != nil {
+		return err
+	}
+	switch opts.ProxyProtocol {
+	case "grpc":
+		if err := validateGRPCProxyURL(u, opts.ProxyURL); err != nil {
+			return err
+		}
+		return validateNoSelfProxy(u, opts.ProxyURL, opts.OTLPGRPCAddr, "grpc")
+	case "http":
+		if err := validateHTTPProxyURL(u, opts.ProxyURL); err != nil {
+			return err
+		}
+		return validateNoSelfProxy(u, opts.ProxyURL, opts.OTLPHTTPAddr, "http")
+	default:
+		return fmt.Errorf("invalid proxy-protocol %q: want grpc or http", opts.ProxyProtocol)
+	}
+}
+
+func validateGRPCProxyURL(u *url.URL, raw string) error {
+	if u.Scheme == "" {
+		if raw == "" || strings.Contains(raw, "/") {
+			return fmt.Errorf("invalid proxy-url %q for grpc: want host:port or http(s)://host:port", raw)
+		}
+		return nil
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		if u.Host == "" {
+			return fmt.Errorf("invalid proxy-url %q for grpc: missing host", raw)
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid proxy-url %q for grpc: unsupported scheme %q", raw, u.Scheme)
+	}
+}
+
+func validateHTTPProxyURL(u *url.URL, raw string) error {
+	if u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("invalid proxy-url %q for http: want http://host:port or https://host:port", raw)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		return nil
+	default:
+		return fmt.Errorf("invalid proxy-url %q for http: unsupported scheme %q", raw, u.Scheme)
+	}
+}
+
+func validateProxyAuth(auth ProxyAuthOptions) error {
+	switch auth.Type {
+	case "":
+		if hasProxyAuthFields(auth) {
+			return errors.New("proxy auth fields require --proxy-auth-type")
+		}
+		return nil
+	case "bearer":
+		if auth.Token == "" {
+			return errors.New("proxy-auth-type bearer requires --proxy-auth-token")
+		}
+		if auth.Username != "" || auth.Password != "" || len(auth.Headers) > 0 {
+			return errors.New("proxy-auth-type bearer only supports --proxy-auth-token")
+		}
+	case "basic":
+		if auth.Username == "" || auth.Password == "" {
+			return errors.New("proxy-auth-type basic requires --proxy-auth-username and --proxy-auth-password")
+		}
+		if auth.Token != "" || len(auth.Headers) > 0 {
+			return errors.New("proxy-auth-type basic only supports username/password")
+		}
+	case "headers":
+		if len(auth.Headers) == 0 {
+			return errors.New("proxy-auth-type headers requires at least one --proxy-header")
+		}
+		if auth.Token != "" || auth.Username != "" || auth.Password != "" {
+			return errors.New("proxy-auth-type headers only supports --proxy-header")
+		}
+	default:
+		return fmt.Errorf("invalid proxy-auth-type %q: want bearer, basic, or headers", auth.Type)
+	}
+	return nil
+}
+
+func validateNoSelfProxy(u *url.URL, proxyURL, listenAddr, protocol string) error {
+	target, err := comparableProxyHostPort(u, proxyURL, protocol)
+	if err != nil {
+		return err
+	}
+	local, err := normalizeHostPort(listenAddr)
+	if err != nil {
+		return err
+	}
+	if target == local {
+		return fmt.Errorf("proxy-url %q points back to otelop's own OTLP %s listener %q", proxyURL, protocol, listenAddr)
+	}
+	return nil
+}
+
+func comparableProxyHostPort(u *url.URL, proxyURL, protocol string) (string, error) {
+	if protocol == "grpc" && u.Scheme == "" {
+		return normalizeHostPort(proxyURL)
+	}
+	return normalizeHostPort(u.Host)
+}
+
+func normalizeHostPort(addr string) (string, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", err
+	}
+	host = strings.ToLower(strings.Trim(host, "[]"))
+	switch host {
+	case "", "0.0.0.0", "::", "::1", "127.0.0.1", "localhost":
+		host = "localhost"
+	}
+	return net.JoinHostPort(host, port), nil
+}
+
+func hasProxyAuthFields(auth ProxyAuthOptions) bool {
+	return auth.Token != "" || auth.Username != "" || auth.Password != "" || len(auth.Headers) > 0
+}
+
+func buildProxyHeaders(auth ProxyAuthOptions) map[string]string {
+	switch auth.Type {
+	case "bearer":
+		return map[string]string{"Authorization": "Bearer " + auth.Token}
+	case "basic":
+		token := base64.StdEncoding.EncodeToString([]byte(auth.Username + ":" + auth.Password))
+		return map[string]string{"Authorization": "Basic " + token}
+	case "headers":
+		out := make(map[string]string, len(auth.Headers))
+		for k, v := range auth.Headers {
+			out[k] = v
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// ResolveStoragePath returns the configured DuckDB path or its XDG default.
+func ResolveStoragePath(raw string) (string, error) {
+	if raw != "" {
+		return raw, nil
+	}
+	return config.DefaultStoragePath()
+}
+
+func resolveStorageOptions(opts Options) (path string, retention time.Duration, maxSize int64, err error) {
+	path, err = ResolveStoragePath(opts.StoragePath)
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("resolve storage path: %w", err)
+	}
+	if path != "" {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return "", 0, 0, fmt.Errorf("create storage directory: %w", err)
+		}
+	}
+	retention, err = config.ParseRetention(opts.Retention)
+	if err != nil {
+		return "", 0, 0, err
+	}
+	maxSize, err = config.ParseMaxSize(opts.MaxSize)
+	if err != nil {
+		return "", 0, 0, err
+	}
+	return path, retention, maxSize, nil
+}
+
+// RedactURL removes credentials before a proxy URL is persisted or displayed.
+func RedactURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		return raw
+	}
+	u.User = url.UserPassword("REDACTED", "REDACTED")
+	return u.String()
+}

--- a/internal/runtime/options_test.go
+++ b/internal/runtime/options_test.go
@@ -1,0 +1,74 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateProxyOptionsRejectsSelfProxy(t *testing.T) {
+	opts := Options{
+		OTLPGRPCAddr:  "0.0.0.0:4317",
+		OTLPHTTPAddr:  "0.0.0.0:4318",
+		ProxyURL:      "http://127.0.0.1:4317",
+		ProxyProtocol: "grpc",
+	}
+	err := validateProxyOptions(opts)
+	if err == nil || !strings.Contains(err.Error(), "points back to otelop's own OTLP grpc listener") {
+		t.Fatalf("validateProxyOptions error = %v", err)
+	}
+}
+
+func TestValidateProxyOptionsRejectsCredentialsInURL(t *testing.T) {
+	opts := Options{
+		OTLPGRPCAddr:  "0.0.0.0:4317",
+		OTLPHTTPAddr:  "0.0.0.0:4318",
+		ProxyURL:      "https://user:pass@example.com:4318",
+		ProxyProtocol: "http",
+	}
+	err := validateProxyOptions(opts)
+	if err == nil || !strings.Contains(err.Error(), "must not contain embedded credentials") {
+		t.Fatalf("validateProxyOptions error = %v", err)
+	}
+}
+
+func TestValidateProxyOptionsBearerAuth(t *testing.T) {
+	opts := Options{
+		OTLPGRPCAddr:  "0.0.0.0:4317",
+		OTLPHTTPAddr:  "0.0.0.0:4318",
+		ProxyURL:      "https://collector.example.com:4318",
+		ProxyProtocol: "http",
+		ProxyAuth: ProxyAuthOptions{
+			Type:  "bearer",
+			Token: "token",
+		},
+	}
+	if err := validateProxyOptions(opts); err != nil {
+		t.Fatalf("validateProxyOptions: %v", err)
+	}
+}
+
+func TestValidateRejectsInvalidRenderWindow(t *testing.T) {
+	for _, v := range []int{0, -1, -500} {
+		if err := Validate(Options{RenderWindowMax: v}); err == nil {
+			t.Errorf("Validate(RenderWindowMax=%d) = nil, want error", v)
+		}
+	}
+}
+
+func TestBuildProxyHeaders(t *testing.T) {
+	headers := buildProxyHeaders(ProxyAuthOptions{
+		Type:     "basic",
+		Username: "alice",
+		Password: "secret",
+	})
+	if got := headers["Authorization"]; got != "Basic YWxpY2U6c2VjcmV0" {
+		t.Fatalf("Authorization = %q", got)
+	}
+}
+
+func TestRedactURL(t *testing.T) {
+	got := RedactURL("https://user:pass@example.com:4318")
+	if got != "https://REDACTED:REDACTED@example.com:4318" {
+		t.Fatalf("RedactURL = %q", got)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,0 +1,293 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/otelcol"
+	"go.opentelemetry.io/contrib/bridges/otelslog"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+
+	otelop "github.com/mashiro/otelop"
+	"github.com/mashiro/otelop/internal/broadcast"
+	"github.com/mashiro/otelop/internal/collector"
+	otelopexporter "github.com/mashiro/otelop/internal/exporter"
+	otelopgraphql "github.com/mashiro/otelop/internal/graphql"
+	"github.com/mashiro/otelop/internal/logger"
+	"github.com/mashiro/otelop/internal/netutil"
+	"github.com/mashiro/otelop/internal/selftelemetry"
+	"github.com/mashiro/otelop/internal/server"
+	"github.com/mashiro/otelop/internal/storage"
+	ws "github.com/mashiro/otelop/internal/websocket"
+)
+
+// Runtime owns a running otelop server and its collector, storage, and telemetry.
+type Runtime struct {
+	cancel            context.CancelFunc
+	startedAt         time.Time
+	done              <-chan struct{}
+	storage           *storage.Storage
+	hub               *ws.Hub
+	srv               *server.Server
+	col               *otelcol.Collector
+	shutdownTelemetry func(context.Context) error
+	shutdownOnce      sync.Once
+}
+
+// Start validates opts and starts all otelop runtime components.
+func Start(ctx context.Context, opts Options) (*Runtime, error) {
+	if err := Validate(opts); err != nil {
+		return nil, err
+	}
+	level, err := logger.ParseLevel(opts.LogLevel)
+	if err != nil {
+		return nil, err
+	}
+	logger.Setup(level)
+
+	ctx, cancel := context.WithCancel(ctx)
+	rt := &Runtime{
+		cancel:    cancel,
+		done:      ctx.Done(),
+		startedAt: time.Now().Round(0),
+	}
+
+	rt.hub = ws.NewHub()
+	go rt.hub.Run(ctx)
+
+	storagePath, retention, maxSize, err := resolveStorageOptions(opts)
+	if err != nil {
+		rt.Shutdown()
+		return nil, err
+	}
+
+	var st *storage.Storage
+	onAdd := func(ctx context.Context, sig broadcast.SignalType, data any) {
+		rt.hub.BroadcastContext(ctx, ws.Message{Type: sig, Data: data})
+	}
+	st, err = storage.Open(ctx, storage.Options{
+		Path:      storagePath,
+		Retention: retention,
+		MaxSize:   maxSize,
+		OnCommitBatch: func(deliveries []storage.CommitDelivery) {
+			broadcast.NewBatch(st, onAdd, func() bool { return rt.hub.ClientCount() > 0 })(deliveries)
+		},
+	})
+	if err != nil {
+		rt.Shutdown()
+		return nil, fmt.Errorf("open storage %s: %w", storagePath, err)
+	}
+	rt.storage = st
+
+	runtimeInfo := otelopgraphql.RuntimeInfo{
+		Version:          opts.Version,
+		StartedAt:        rt.startedAt,
+		HTTPAddr:         opts.HTTPAddr,
+		OTLPGRPCAddr:     opts.OTLPGRPCAddr,
+		OTLPHTTPAddr:     opts.OTLPHTTPAddr,
+		ProxyURL:         RedactURL(opts.ProxyURL),
+		ProxyProtocol:    opts.ProxyProtocol,
+		Debug:            opts.Debug,
+		LogLevel:         opts.LogLevel,
+		Retention:        retention,
+		StoragePath:      storagePath,
+		RetentionDisplay: opts.Retention,
+		MaxSizeDisplay:   opts.MaxSize,
+		RenderWindowMax:  opts.RenderWindowMax,
+	}
+	rt.srv = server.New(rt.storage, rt.hub, otelop.FrontendFS(), runtimeInfo, opts.AllowedHosts)
+
+	if err := rt.srv.Listen(ctx); err != nil {
+		rt.Shutdown()
+		return nil, fmt.Errorf("bind %s: %w", opts.HTTPAddr, err)
+	}
+	go func() {
+		if err := rt.srv.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("HTTP server error", "error", err)
+			rt.cancel()
+		}
+	}()
+
+	selfTelemetryEndpoint := ""
+	if opts.Debug {
+		selfTelemetryEndpoint, err = netutil.Loopback(opts.OTLPGRPCAddr)
+		if err != nil {
+			rt.Shutdown()
+			return nil, fmt.Errorf("invalid otlp-grpc address: %w", err)
+		}
+	}
+
+	slog.Debug("starting collector", "grpc", opts.OTLPGRPCAddr, "http", opts.OTLPHTTPAddr)
+	col, err := collector.New(otelopexporter.NewFactory(rt.storage), collector.Config{
+		GRPCEndpoint:          opts.OTLPGRPCAddr,
+		HTTPEndpoint:          opts.OTLPHTTPAddr,
+		ProxyURL:              opts.ProxyURL,
+		ProxyProtocol:         opts.ProxyProtocol,
+		ProxyHeaders:          buildProxyHeaders(opts.ProxyAuth),
+		LogLevel:              opts.LogLevel,
+		SelfTelemetryEndpoint: selfTelemetryEndpoint,
+	})
+	if err != nil {
+		rt.Shutdown()
+		return nil, fmt.Errorf("failed to create collector: %w", err)
+	}
+	rt.col = col
+
+	colErrCh := make(chan error, 1)
+	go func() {
+		if err := col.Run(ctx); err != nil {
+			colErrCh <- err
+		}
+		close(colErrCh)
+	}()
+
+	if err := waitCollectorReady(ctx, col, colErrCh); err != nil {
+		rt.Shutdown()
+		return nil, err
+	}
+	go watchCollectorErrors(colErrCh, rt.cancel, slog.Default())
+
+	if opts.Debug {
+		slog.Debug("starting self-telemetry", "endpoint", selfTelemetryEndpoint)
+		result, err := selftelemetry.Setup(ctx, selfTelemetryEndpoint)
+		if err != nil {
+			rt.Shutdown()
+			return nil, fmt.Errorf("failed to setup self-telemetry: %w", err)
+		}
+		rt.shutdownTelemetry = result.Shutdown
+
+		otelHandler := otelslog.NewHandler("otelop", otelslog.WithLoggerProvider(result.LoggerProvider))
+		logger.Setup(level, otelHandler)
+
+		if err := registerMetrics(rt.storage, rt.hub); err != nil {
+			rt.Shutdown()
+			return nil, fmt.Errorf("failed to register metrics: %w", err)
+		}
+	}
+
+	return rt, nil
+}
+
+func (r *Runtime) StartedAt() time.Time { return r.startedAt }
+
+func (r *Runtime) Done() <-chan struct{} { return r.done }
+
+// Shutdown stops every component owned by the runtime.
+func (r *Runtime) Shutdown() {
+	if r == nil {
+		return
+	}
+	r.shutdownOnce.Do(func() {
+		shutdownCtx := context.Background()
+		if r.shutdownTelemetry != nil {
+			if err := r.shutdownTelemetry(shutdownCtx); err != nil {
+				slog.Error("self-telemetry shutdown error", "error", err)
+			}
+		}
+		if r.col != nil {
+			r.col.Shutdown()
+		}
+		if r.srv != nil {
+			if err := r.srv.Shutdown(shutdownCtx); err != nil {
+				slog.Error("HTTP server shutdown error", "error", err)
+			}
+		}
+		if r.storage != nil {
+			if err := r.storage.Close(); err != nil {
+				slog.Error("storage shutdown error", "error", err)
+			}
+		}
+		if r.cancel != nil {
+			r.cancel()
+		}
+	})
+}
+
+func waitCollectorReady(ctx context.Context, col *otelcol.Collector, errCh <-chan error) error {
+	const budget = 2 * time.Second
+	const tick = 10 * time.Millisecond
+	deadline := time.NewTimer(budget)
+	defer deadline.Stop()
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+	for {
+		select {
+		case err, ok := <-errCh:
+			if !ok {
+				return errors.New("collector exited before becoming ready")
+			}
+			if err != nil {
+				return fmt.Errorf("collector failed to start: %w", err)
+			}
+		case <-ticker.C:
+		case <-deadline.C:
+			return fmt.Errorf("collector did not become ready within %s", budget)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		if col.GetState() == otelcol.StateRunning {
+			return nil
+		}
+	}
+}
+
+func watchCollectorErrors(errCh <-chan error, cancel context.CancelFunc, logger *slog.Logger) {
+	err, ok := <-errCh
+	if !ok || err == nil {
+		return
+	}
+	logger.Error("collector stopped unexpectedly, shutting down", "error", err)
+	cancel()
+}
+
+func registerMetrics(s *storage.Storage, hub *ws.Hub) error {
+	meter := otel.Meter("otelop")
+	if err := s.RegisterTelemetry(meter); err != nil {
+		return err
+	}
+
+	traceGauge, err := meter.Int64ObservableGauge("otelop.store.traces",
+		metric.WithDescription("Number of traces in the store"),
+	)
+	if err != nil {
+		return err
+	}
+	metricGauge, err := meter.Int64ObservableGauge("otelop.store.metrics",
+		metric.WithDescription("Number of metric series in the store"),
+	)
+	if err != nil {
+		return err
+	}
+	logGauge, err := meter.Int64ObservableGauge("otelop.store.logs",
+		metric.WithDescription("Number of log entries in the store"),
+	)
+	if err != nil {
+		return err
+	}
+	if _, err := meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
+		traces, metrics, logs, err := s.Counts(ctx)
+		if err != nil {
+			return err
+		}
+		o.ObserveInt64(traceGauge, int64(traces))
+		o.ObserveInt64(metricGauge, int64(metrics))
+		o.ObserveInt64(logGauge, int64(logs))
+		return nil
+	}, traceGauge, metricGauge, logGauge); err != nil {
+		return err
+	}
+	_, err = meter.Int64ObservableGauge("otelop.websocket.clients",
+		metric.WithDescription("Number of connected WebSocket clients"),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			o.Observe(int64(hub.ClientCount()))
+			return nil
+		}),
+	)
+	return err
+}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1,0 +1,58 @@
+package runtime
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWatchCollectorErrorsCancelsOnFailure(t *testing.T) {
+	ch := make(chan error, 1)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	canceled := make(chan struct{})
+	cancel := func() { close(canceled) }
+
+	ch <- errors.New("boom")
+	close(ch)
+
+	done := make(chan struct{})
+	go func() {
+		watchCollectorErrors(ch, cancel, logger)
+		close(done)
+	}()
+
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("cancel was not called after a collector error")
+	}
+	<-done
+	if !strings.Contains(buf.String(), "boom") {
+		t.Errorf("log output = %q, want it to mention the collector error", buf.String())
+	}
+}
+
+func TestWatchCollectorErrorsNoOpOnCleanShutdown(t *testing.T) {
+	ch := make(chan error)
+	close(ch)
+	canceled := false
+
+	done := make(chan struct{})
+	go func() {
+		watchCollectorErrors(ch, func() { canceled = true }, slog.Default())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watchCollectorErrors did not return on channel close")
+	}
+	if canceled {
+		t.Error("cancel was called on a clean collector shutdown")
+	}
+}


### PR DESCRIPTION
## Summary
- keep command definitions, flag parsing, daemon control, and CLI rendering in cmd/otelop
- extract the reusable server, collector, storage, and self-telemetry lifecycle into internal/runtime
- extract shared loopback address resolution into internal/netutil
- validate runtime options before daemonization while retaining validation in runtime.Start
- split the version command into its own file

## Verification
- mise run check
- mise run test