### PR TITLE
fix(metrics): preserve chart meaning across time windows

### DIFF
--- a/internal/graphql/metric_resolver.go
+++ b/internal/graphql/metric_resolver.go
@@ -33,21 +33,31 @@ func (r *MetricResolver) ReceivedAt() gql.Time { return gql.Time{Time: r.m.LastS
 
 func (r *MetricResolver) Resource() JSONMap { return attrsToJSON(r.m.Resource) }
 
-// filteredPoints fetches every derived point in [from, to) and drops
-// baseline observations (storage.FilterDerivedPoints — the same rule
-// internal/broadcast's WebSocket path applies) so the GraphQL surface
-// matches what the WebSocket path ever broadcasts and what the old store
-// package used to return.
+// filteredPoints includes one older observation while deriving cumulative
+// metrics, then removes it from the result. Without that predecessor, the
+// first counter point in every selected chart window becomes a fresh
+// baseline and disappears.
 func (r *MetricResolver) filteredPoints(ctx context.Context) ([]storage.DerivedPoint, error) {
 	r.once.Do(func() {
-		points, err := r.storage.MetricPoints(ctx, r.m.ServiceName, r.m.MetricName, r.from, r.to)
+		points, err := r.storage.MetricPointsWithPredecessors(ctx, r.m.ServiceName, r.m.MetricName, r.from, r.to)
 		if err != nil {
 			r.err = err
 			return
 		}
-		r.points = storage.FilterDerivedPoints(points)
+		r.points = filterDerivedPointsInWindow(points, r.from, r.to)
 	})
 	return r.points, r.err
+}
+
+func filterDerivedPointsInWindow(points []storage.DerivedPoint, from, to time.Time) []storage.DerivedPoint {
+	derived := storage.FilterDerivedPoints(points)
+	out := make([]storage.DerivedPoint, 0, len(derived))
+	for _, point := range derived {
+		if !point.TS.Before(from) && point.TS.Before(to) {
+			out = append(out, point)
+		}
+	}
+	return out
 }
 
 func (r *MetricResolver) LatestValue() *float64 { return r.m.LatestValue }

--- a/internal/graphql/resolver.go
+++ b/internal/graphql/resolver.go
@@ -295,17 +295,17 @@ type MetricPointsArgs struct {
 }
 
 // MetricPoints is the single-metric counterpart to metrics { dataPoints }
-// (issue #162): it calls the same storage.MetricPoints + storage.FilterDerivedPoints
+// (issue #162): it calls the same predecessor-aware derivation
 // path MetricResolver.DataPoints does, so a metric detail view can fetch just
 // the group it's displaying instead of the whole metrics page to extract one
 // group client-side (see hooks/use-metric-range-points.ts).
 func (r *Resolver) MetricPoints(ctx context.Context, args MetricPointsArgs) ([]*DataPointResolver, error) {
 	from, to := r.resolveWindow(args.From, args.To)
-	points, err := r.storage.MetricPoints(ctx, args.ServiceName, args.Name, from, to)
+	points, err := r.storage.MetricPointsWithPredecessors(ctx, args.ServiceName, args.Name, from, to)
 	if err != nil {
 		return nil, err
 	}
-	filtered := storage.FilterDerivedPoints(points)
+	filtered := filterDerivedPointsInWindow(points, from, to)
 	out := make([]*DataPointResolver, len(filtered))
 	for i := range filtered {
 		out[i] = &DataPointResolver{dp: filtered[i]}

--- a/internal/graphql/schema.graphql
+++ b/internal/graphql/schema.graphql
@@ -59,10 +59,11 @@ type Query {
   """
   Facet-aggregated series for one (serviceName, name) metric: every
   attribute-series is delta/cumulative-derived first (the same derivation
-  `metrics.dataPoints` uses), THEN summed within each distinct combination of
-  groupBy attribute values and bucketed into bucketSeconds-wide time windows —
-  the server-side fix for a chart line that would otherwise zigzag between
-  multiple raw series sharing a facet value. from/to default to the full
+  `metrics.dataPoints` uses), then bucketed and combined within each distinct
+  combination of groupBy attribute values. Gauge samples are averaged within
+  each underlying series before series are summed; Sum deltas are summed. This
+  is the server-side fix for chart lines that would otherwise zigzag between
+  multiple raw series or inflate as bucket widths grow. from/to default to the full
   retention window, matching the other list queries. bucketSeconds is
   optional: omitted or null auto-sizes the bucket to target ~150 buckets
   across the metric's actual data extent within from/to, rather than the
@@ -76,8 +77,10 @@ type Query {
   single-metric counterpart to `metrics { dataPoints }`, added (issue #162)
   so a metric detail view can fetch just the metric it's displaying instead
   of the whole metrics page to extract one group client-side. Applies the
-  identical NULL-baseline filtering `metrics.dataPoints` does. from/to
-  default to the full retention window, matching the other list queries.
+  identical NULL-baseline filtering `metrics.dataPoints` does. Cumulative
+  metrics use the immediately preceding point to derive the first in-window
+  delta without returning that predecessor. from/to default to the full
+  retention window, matching the other list queries.
   """
   metricPoints(serviceName: String!, name: String!, from: Time, to: Time): [DataPoint!]!
 
@@ -304,7 +307,8 @@ total only makes sense per series, not summed across a facet group over time.
 type AggregatePoint {
   timestamp: Time!
   """
-  Gauge/Sum: summed per-window delta across every series in the group.
+  Gauge: sum of each underlying series' sample mean within the bucket.
+  Sum: summed per-window delta across every series in the group.
   Histogram/Summary/ExponentialHistogram: summed-sum / summed-count (0 when
   the summed count is 0), so the metric's declared unit still applies
   directly.

--- a/internal/graphql/schema_test.go
+++ b/internal/graphql/schema_test.go
@@ -462,9 +462,9 @@ func TestMetricPoints_ReturnsDerivedPointsForOneGroup(t *testing.T) {
 	}
 }
 
-// TestMetricPoints_RespectsFromTo verifies the query's time-range args are
-// plumbed through to storage.MetricPoints rather than always fetching the
-// full retention window.
+// TestMetricPoints_RespectsFromTo verifies the query uses the immediately
+// preceding counter point to derive the first in-window delta without
+// returning that out-of-window predecessor.
 func TestMetricPoints_RespectsFromTo(t *testing.T) {
 	s := newTestStorage(t)
 	ctx := context.Background()
@@ -484,14 +484,11 @@ func TestMetricPoints_RespectsFromTo(t *testing.T) {
 	})
 
 	points := data["metricPoints"].([]any)
-	// from/to excludes the t0 observation entirely, so the t0+1h point is the
-	// only row the window ever sees — with no in-window predecessor to lag
-	// against, it's a fresh (filtered) baseline within this window, same as
-	// storage's TestMetricPoints_TimeRangeFiltering. This proves from/to
-	// actually reached storage.MetricPoints: an unbounded query would have
-	// included the t0 point and derived a non-baseline value=1 for this one.
-	if len(points) != 0 {
-		t.Fatalf("metricPoints len = %d, want 0 (windowed out the earlier point this delta needs)", len(points))
+	if len(points) != 1 {
+		t.Fatalf("metricPoints len = %d, want 1 derived in-window point", len(points))
+	}
+	if value := points[0].(map[string]any)["value"].(float64); value != 1 {
+		t.Fatalf("metricPoints value = %v, want 1 (2-1 from predecessor)", value)
 	}
 }
 

--- a/internal/storage/query_metric.go
+++ b/internal/storage/query_metric.go
@@ -392,7 +392,7 @@ func decodeSeriesKeys(raw any) []uint64 {
 const metricDerivedFormula = `
 derived AS (
 	SELECT
-		request_index, id, ts, attrs_json, metric_type,
+		request_index, id, series_key, ts, attrs_json, metric_type,
 		CASE
 			WHEN metric_type = 'Sum' AND temporality = 'cumulative' AND is_monotonic THEN
 				CASE WHEN lag(value) OVER w IS NULL THEN NULL
@@ -485,7 +485,7 @@ const metricPointsQuery = metricDerivedCTE + metricPointsSelect
 // metricPointsWithPredecessorsQuery adds the immediately preceding point for
 // each series represented in the requested window. Broadcast derivation needs
 // those rows for lag() but must not assume any maximum collection interval.
-const metricPointsWithPredecessorsQuery = `
+const metricPointsWithPredecessorsCTE = `
 WITH target_series AS (
 	SELECT series_key, metric_type, temporality, is_monotonic, attributes::VARCHAR AS attrs_json
 	FROM metric_series
@@ -525,7 +525,9 @@ points AS (
 	)
 	WHERE predecessor_rank = 1
 ),
-` + metricDerivedFormula + metricPointsSelect
+` + metricDerivedFormula
+
+const metricPointsWithPredecessorsQuery = metricPointsWithPredecessorsCTE + metricPointsSelect
 
 const metricPointsWithPredecessorsBatchQuery = `
 WITH requested(request_index, service_name, metric_name, from_ns, to_ns) AS (VALUES %s),

--- a/internal/storage/query_metric_aggregate.go
+++ b/internal/storage/query_metric_aggregate.go
@@ -15,10 +15,11 @@ import (
 // the facet-aggregated counterpart to DerivedPoint. Unlike DerivedPoint it
 // carries no Cumulative field: a running total only makes sense per series,
 // not summed across a facet group over time (see docs/design/duckdb-storage.md
-// and the task this implements). Value is the scalar sum for Gauge/Sum
-// metrics, or the summed-sum/summed-count mean for distributions; Count/Sum
-// mirror the per-bucket summed deltas for distributions (nil for Gauge/Sum);
-// Min/Max are the per-bucket min/max across every contributing series.
+// and the task this implements). Value is the sum of each series' sample mean
+// for Gauge metrics, the scalar delta sum for Sum metrics, or the
+// summed-sum/summed-count mean for distributions; Count/Sum mirror the
+// per-bucket summed deltas for distributions (nil for Gauge/Sum); Min/Max are
+// the per-bucket min/max across every contributing series.
 type AggregatePoint struct {
 	TS    time.Time
 	Value *float64
@@ -41,9 +42,12 @@ type AggregateSeries struct {
 // fallback window.
 const metricAggregateTargetBuckets = 150
 
-// MetricAggregate sums metricDerivedCTE's per-series derivation (deltas
+// MetricAggregate sums metricDerivedFormula's per-series derivation (deltas
 // already resolved per attribute-series — counter resets included, see
-// metricDerivedCTE's doc comment) into one bucketed, per-facet-group series.
+// metricDerivedFormula's doc comment) into one bucketed, per-facet-group
+// series. Gauge samples are averaged over time per underlying series before
+// those series are summed, so a wider bucket does not inflate an
+// instantaneous value merely because it contains more samples.
 // This is the fix for the chart's facet view concatenating raw points from
 // every underlying series instead of summing them: summing must happen AFTER
 // the per-series delta derivation, never before, or a counter reset in one
@@ -106,19 +110,33 @@ func (s *Storage) MetricAggregate(ctx context.Context, serviceName, metricName s
 		selectGroupCols[i] = fmt.Sprintf("COALESCE(attrs_json::JSON->>?, '') AS %s", groupCols[i])
 	}
 
-	query := metricDerivedCTE + `,
-aggregated AS (
+	query := metricPointsWithPredecessorsCTE + `,
+per_series_bucket AS (
 	SELECT
 		time_bucket(?::BIGINT * INTERVAL '1 second', ts) AS bucket,
 		` + strings.Join(selectGroupCols, ",\n\t\t") + `,
+		series_key,
 		max(metric_type) AS metric_type,
-		sum(scalar_value) AS scalar_value_sum,
+		CASE WHEN max(metric_type) = 'Gauge' THEN avg(scalar_value) ELSE sum(scalar_value) END AS scalar_value,
 		sum(count_delta) AS count_sum,
 		sum(sum_delta) AS sum_sum,
 		min(min) AS min_min,
 		max(max) AS max_max
 	FROM derived
-	GROUP BY 1, ` + strings.Join(groupOrdinals, ", ") + `
+	WHERE ts >= ?
+	GROUP BY 1, ` + strings.Join(groupOrdinals, ", ") + `, series_key
+),
+aggregated AS (
+	SELECT
+		bucket, ` + groupColList + `,
+		max(metric_type) AS metric_type,
+		sum(scalar_value) AS scalar_value_sum,
+		sum(count_sum) AS count_sum,
+		sum(sum_sum) AS sum_sum,
+		min(min_min) AS min_min,
+		max(max_max) AS max_max
+	FROM per_series_bucket
+	GROUP BY bucket, ` + groupColList + `
 	HAVING NOT (scalar_value_sum IS NULL AND count_sum IS NULL AND sum_sum IS NULL)
 )
 SELECT
@@ -135,11 +153,12 @@ FROM aggregated
 ORDER BY ` + groupColList + `, bucket
 `
 
-	args := make([]any, 0, 5+len(groupBy))
-	args = append(args, serviceName, metricName, from, to, int64(bucket/time.Second))
+	args := make([]any, 0, 7+len(groupBy))
+	args = append(args, serviceName, metricName, from, to, from, int64(bucket/time.Second))
 	for _, k := range groupBy {
 		args = append(args, k)
 	}
+	args = append(args, from)
 
 	rows, err := s.DB().QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/storage/query_metric_aggregate_test.go
+++ b/internal/storage/query_metric_aggregate_test.go
@@ -193,12 +193,12 @@ func TestMetricAggregate_SeriesMissingFromOneBucket(t *testing.T) {
 	}
 }
 
-func TestMetricAggregate_GaugeSum(t *testing.T) {
+func TestMetricAggregate_GaugeAveragesOverTimeThenSumsSeries(t *testing.T) {
 	s := openTestStorage(t, Options{})
 	ctx := context.Background()
 	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	build := func(v float64, region string) pmetric.Metrics {
+	build := func(v float64, ts time.Time, region, worker string) pmetric.Metrics {
 		md := pmetric.NewMetrics()
 		rm := md.ResourceMetrics().AppendEmpty()
 		rm.Resource().Attributes().PutStr("service.name", "svc")
@@ -207,12 +207,19 @@ func TestMetricAggregate_GaugeSum(t *testing.T) {
 		m.SetName("cpu.usage")
 		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
 		dp.SetDoubleValue(v)
-		dp.SetTimestamp(pcommon.NewTimestampFromTime(t0))
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 		dp.Attributes().PutStr("region", region)
+		dp.Attributes().PutStr("worker", worker)
 		return md
 	}
-	s.AddMetrics(ctx, build(0.3, "A"))
-	s.AddMetrics(ctx, build(0.5, "A"))
+	// Each worker is one underlying Gauge series. Temporal samples must be
+	// averaged per worker before workers in the shared region are summed:
+	// avg(2,4) + avg(6,8) = 10. Summing all samples would incorrectly yield 20
+	// and make the displayed value depend on the selected bucket width.
+	s.AddMetrics(ctx, build(2, t0, "A", "1"))
+	s.AddMetrics(ctx, build(4, t0.Add(10*time.Second), "A", "1"))
+	s.AddMetrics(ctx, build(6, t0, "A", "2"))
+	s.AddMetrics(ctx, build(8, t0.Add(10*time.Second), "A", "2"))
 	s.Sync()
 
 	out, err := s.MetricAggregate(ctx, "svc", "cpu.usage", []string{"region"}, time.Minute, t0.Add(-time.Minute), t0.Add(time.Minute))
@@ -222,8 +229,8 @@ func TestMetricAggregate_GaugeSum(t *testing.T) {
 	if len(out) != 1 || len(out[0].Points) != 1 {
 		t.Fatalf("unexpected shape: %+v", out)
 	}
-	if out[0].Points[0].Value == nil || *out[0].Points[0].Value != 0.8 {
-		t.Errorf("Value = %v, want 0.8 (0.3+0.5)", out[0].Points[0].Value)
+	if out[0].Points[0].Value == nil || *out[0].Points[0].Value != 10 {
+		t.Errorf("Value = %v, want 10 (avg(2,4) + avg(6,8))", out[0].Points[0].Value)
 	}
 }
 
@@ -406,15 +413,10 @@ func TestMetricAggregate_BucketBoundaryAlignment(t *testing.T) {
 	}
 }
 
-// TestMetricAggregate_TimeRangeFiltering verifies out-of-range points never
-// contribute to a bucket. The very first point (t0) sits before the queried
-// range and must be fully excluded — not just from the output but from the
-// window function's lag() predecessor lookup, since metricDerivedCTE filters
-// `points` before computing deltas (the same window-truncation behavior
-// TestMetricPoints_TimeRangeFiltering documents for the per-point query).
-// Two more points landing INSIDE the range give the in-window delta
-// something real to compute, sidestepping that quirk rather than exercising
-// it here.
+// TestMetricAggregate_TimeRangeFiltering verifies the point immediately
+// before the window contributes only as the cumulative counter baseline. It
+// must produce the first in-window delta without surfacing an out-of-window
+// bucket of its own.
 func TestMetricAggregate_TimeRangeFiltering(t *testing.T) {
 	s := openTestStorage(t, Options{})
 	ctx := context.Background()
@@ -429,13 +431,13 @@ func TestMetricAggregate_TimeRangeFiltering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MetricAggregate: %v", err)
 	}
-	if len(out) != 1 || len(out[0].Points) != 1 {
-		t.Fatalf("expected 1 group with 1 point in range (the in-window baseline at t0+40m is dropped), got %+v", out)
+	if len(out) != 1 || len(out[0].Points) != 2 {
+		t.Fatalf("expected 1 group with 2 derived points in range, got %+v", out)
 	}
-	if !out[0].Points[0].TS.Equal(t0.Add(50 * time.Minute)) {
-		t.Errorf("TS = %v, want %v", out[0].Points[0].TS, t0.Add(50*time.Minute))
+	if !out[0].Points[0].TS.Equal(t0.Add(40*time.Minute)) || out[0].Points[0].Value == nil || *out[0].Points[0].Value != 2 {
+		t.Errorf("first point = %+v, want t0+40m with value 2 (3-1)", out[0].Points[0])
 	}
-	if out[0].Points[0].Value == nil || *out[0].Points[0].Value != 4 {
-		t.Errorf("Value = %v, want 4 (7-3, the t0 baseline outside the range never contributes)", out[0].Points[0].Value)
+	if !out[0].Points[1].TS.Equal(t0.Add(50*time.Minute)) || out[0].Points[1].Value == nil || *out[0].Points[1].Value != 4 {
+		t.Errorf("second point = %+v, want t0+50m with value 4 (7-3)", out[0].Points[1])
 	}
 }


### PR DESCRIPTION
## Summary

- average Gauge samples within each underlying series before summing facet groups, so wider chart buckets do not inflate instantaneous values
- derive the first in-window cumulative metric point using its predecessor without returning the out-of-window point
- document the aggregation semantics and add storage/GraphQL regression coverage

## Testing

- mise run check
- mise run test
- manually verified 1h/24h metric charts in the isolated E2E environment in light and dark modes