### PR TITLE
fix(metrics): correct query window semantics

### DIFF
--- a/docs/design/duckdb-storage.md
+++ b/docs/design/duckdb-storage.md
@@ -265,9 +265,11 @@ A single writer goroutine owns the write connection. Per OTLP batch:
 
 WebSocket payloads still carry per-point deltas for live charts. After a
 metric batch commits, the broadcast adapter queries the committed points plus
-the immediately preceding observation for each represented series and applies
-the same SQL derivation used by GraphQL. Duplicate spans from OTLP re-sends are
-filtered by the indexed candidate lookup, so a restart or a resend cannot
+the immediately preceding observation only for represented cumulative source
+series whose delta derivation needs `lag`. Gauge, delta, and cumulative
+non-monotonic Sum series remain window-only. The adapter then applies the same
+SQL derivation used by GraphQL. Duplicate spans from OTLP re-sends are filtered
+by the indexed candidate lookup, so a restart or a resend cannot
 inflate stored spans or summaries.
 
 A trace that crosses 10,000 retained spans is not useful as an interactive

--- a/internal/graphql/schema.graphql
+++ b/internal/graphql/schema.graphql
@@ -240,12 +240,10 @@ One point in a metric's series. The primary fields describe per-interval
 activity: for cumulative OTLP inputs (monotonic Sum, Histogram, Summary,
 ExponentialHistogram) the server delta-izes against the previous observation
 before returning; delta inputs are already per-interval. The `cumulative`
-family carries the running total "since otelop started observing this series"
-so clients can show retained-history totals without re-summing the delta column — for
-cumulative-temporality input it's the exporter's raw cumulative, for
-delta-temporality input otelop accumulates the retained deltas itself. Retention
-or max-size cleanup can therefore change that derived total; cumulative input
-continues to expose the exporter's raw cumulative value.
+family carries the exporter's raw running total for cumulative-temporality
+inputs. For delta-temporality inputs it accumulates from the start of the
+selected query window, so it is window-dependent and is not a retained-lifetime
+total.
 """
 type DataPoint {
   "Stable, globally unique identity (UUIDv7) assigned at ingestion. Persists with the retained database row, so clients can use it as a key across reconnects."
@@ -258,27 +256,27 @@ type DataPoint {
   """
   value: Float!
   """
-  Running total for this series since otelop started observing it. For
-  cumulative temporality it's the exporter's raw cumulative; for delta
-  temporality otelop sums the deltas itself. Populated for monotonic Sum;
-  null for Gauge, non-monotonic Sum, and distribution metrics.
+  Running total for a monotonic Sum. For cumulative temporality this is the
+  exporter's raw cumulative. For delta temporality this sums observations from
+  the start of the selected query window.
+  Null for Gauge, non-monotonic Sum, and distribution metrics.
   """
   cumulative: Float
   "Delta observation count for distribution metrics. Null for Gauge/Sum."
   count: Float
   """
-  Running total observation count since otelop started observing this series.
-  For cumulative Histogram / Summary / ExponentialHistogram it's the
-  exporter's raw cumulative; for delta temporality otelop sums the deltas
-  itself. Null for Gauge and Sum.
+  Running observation count. For cumulative Histogram / Summary /
+  ExponentialHistogram this is the exporter's raw cumulative; for delta
+  temporality this sums observations from the start of the selected query
+  window. Null for Gauge and Sum.
   """
   countCumulative: Float
   "Delta of observation sums for distribution metrics. Null for Gauge/Sum."
   sum: Float
   """
-  Running total of observation sums since otelop started observing this
-  series, for distributions that report a sum. Raw cumulative for cumulative
-  temporality; accumulated by otelop for delta temporality. Null otherwise.
+  Running total of observation sums for distributions that report a sum. Raw
+  cumulative for cumulative temporality. For delta temporality this sums
+  observations from the start of the selected query window. Null otherwise.
   """
   sumCumulative: Float
   "Minimum observation in this window, as reported by the SDK. Null when unavailable."

--- a/internal/graphql/schema_test.go
+++ b/internal/graphql/schema_test.go
@@ -405,6 +405,18 @@ func buildCumulativeSumMetric(name, service string, v float64, ts time.Time) pme
 	return md
 }
 
+func buildDeltaSumMetric(name, service string, v float64, ts time.Time) pmetric.Metrics {
+	md := buildCumulativeSumMetric(name, service, v, ts)
+	md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	return md
+}
+
+func buildCumulativeSumMetricWithAttribute(name, service, key, value string, v float64, ts time.Time) pmetric.Metrics {
+	md := buildCumulativeSumMetric(name, service, v, ts)
+	md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().PutStr(key, value)
+	return md
+}
+
 // TestMetric_LatestValueWithoutFetchingPoints is the GraphQL-level companion
 // to TestMetrics_PointCountWithoutFetchingPoints: latestValue must resolve
 // without the query selecting dataPoints (issue #162's whole point).
@@ -489,6 +501,156 @@ func TestMetricPoints_RespectsFromTo(t *testing.T) {
 	}
 	if value := points[0].(map[string]any)["value"].(float64); value != 1 {
 		t.Fatalf("metricPoints value = %v, want 1 (2-1 from predecessor)", value)
+	}
+}
+
+func TestMetricPointCountMatchesDataPointsInHistoricalWindow(t *testing.T) {
+	s := newTestStorage(t)
+	ctx := context.Background()
+	t0 := time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)
+
+	s.AddMetrics(ctx, buildCumulativeSumMetric("m", "svc-count", 100, t0))
+	s.AddMetrics(ctx, buildCumulativeSumMetric("m", "svc-count", 150, t0.Add(time.Hour)))
+	s.Sync()
+	if _, err := s.DB().ExecContext(ctx,
+		`UPDATE metric_series SET first_seen = ?, last_seen = ? WHERE service_name = 'svc-count' AND metric_name = 'm'`,
+		t0, t0.Add(time.Hour),
+	); err != nil {
+		t.Fatalf("set metric series lifetime: %v", err)
+	}
+
+	data := exec(t, s, `
+		query($from: Time!, $to: Time!) {
+			metrics(from: $from, to: $to) {
+				items { name pointCount dataPoints { value } }
+			}
+		}
+	`, map[string]any{
+		"from": t0.Add(30 * time.Minute).Format(time.RFC3339),
+		"to":   t0.Add(90 * time.Minute).Format(time.RFC3339),
+	})
+
+	items := data["metrics"].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("metrics len = %d, want 1", len(items))
+	}
+	metric := items[0].(map[string]any)
+	points := metric["dataPoints"].([]any)
+	if metric["pointCount"].(float64) != float64(len(points)) || len(points) != 1 {
+		t.Fatalf("pointCount = %v, dataPoints len = %d, want both 1", metric["pointCount"], len(points))
+	}
+	if value := points[0].(map[string]any)["value"].(float64); value != 50 {
+		t.Fatalf("dataPoints[0].value = %v, want 50", value)
+	}
+}
+
+func TestMetricPointCountMatchesDataPointsWhenOnlyOneSeriesHasPredecessor(t *testing.T) {
+	s := newTestStorage(t)
+	ctx := context.Background()
+	t0 := time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)
+
+	s.AddMetrics(ctx, buildCumulativeSumMetricWithAttribute("m", "svc-count-series", "instance", "a", 100, t0))
+	s.AddMetrics(ctx, buildCumulativeSumMetricWithAttribute("m", "svc-count-series", "instance", "a", 150, t0.Add(time.Hour)))
+	s.AddMetrics(ctx, buildCumulativeSumMetricWithAttribute("m", "svc-count-series", "instance", "b", 200, t0.Add(time.Hour)))
+	s.Sync()
+	if _, err := s.DB().ExecContext(ctx,
+		`UPDATE metric_series SET first_seen = ?, last_seen = ? WHERE service_name = 'svc-count-series' AND metric_name = 'm'`,
+		t0, t0.Add(time.Hour),
+	); err != nil {
+		t.Fatalf("set metric series lifetime: %v", err)
+	}
+
+	data := exec(t, s, `
+		query($from: Time!, $to: Time!) {
+			metrics(from: $from, to: $to) {
+				items { pointCount dataPoints { value attributes } }
+			}
+		}
+	`, map[string]any{
+		"from": t0.Add(30 * time.Minute).Format(time.RFC3339),
+		"to":   t0.Add(90 * time.Minute).Format(time.RFC3339),
+	})
+
+	items := data["metrics"].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("metrics len = %d, want 1", len(items))
+	}
+	metric := items[0].(map[string]any)
+	points := metric["dataPoints"].([]any)
+	if metric["pointCount"].(float64) != float64(len(points)) || len(points) != 1 {
+		t.Fatalf("pointCount = %v, dataPoints len = %d, want both 1", metric["pointCount"], len(points))
+	}
+	point := points[0].(map[string]any)
+	if point["value"].(float64) != 50 || point["attributes"].(map[string]any)["instance"] != "a" {
+		t.Fatalf("dataPoints[0] = %+v, want instance a with value 50", point)
+	}
+}
+
+func TestMetricPointsDeltaCumulativeStartsAtQueryWindow(t *testing.T) {
+	s := newTestStorage(t)
+	ctx := context.Background()
+	t0 := time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)
+
+	s.AddMetrics(ctx, buildDeltaSumMetric("m", "svc-delta-window", 5, t0))
+	s.AddMetrics(ctx, buildDeltaSumMetric("m", "svc-delta-window", 3, t0.Add(time.Hour)))
+	s.AddMetrics(ctx, buildDeltaSumMetric("m", "svc-delta-window", 2, t0.Add(2*time.Hour)))
+	s.Sync()
+
+	data := exec(t, s, `
+		query($from: Time!, $to: Time!) {
+			metricPoints(serviceName: "svc-delta-window", name: "m", from: $from, to: $to) {
+				value cumulative
+			}
+		}
+	`, map[string]any{
+		"from": t0.Add(30 * time.Minute).Format(time.RFC3339),
+		"to":   t0.Add(3 * time.Hour).Format(time.RFC3339),
+	})
+
+	points := data["metricPoints"].([]any)
+	if len(points) != 2 {
+		t.Fatalf("metricPoints len = %d, want 2", len(points))
+	}
+	for i, want := range []struct {
+		value      float64
+		cumulative float64
+	}{{3, 3}, {2, 5}} {
+		point := points[i].(map[string]any)
+		if point["value"].(float64) != want.value || point["cumulative"].(float64) != want.cumulative {
+			t.Errorf("point %d = value %v cumulative %v, want value %v cumulative %v",
+				i, point["value"], point["cumulative"], want.value, want.cumulative)
+		}
+	}
+}
+
+func TestMetricPointsWindowIsFromInclusiveToExclusive(t *testing.T) {
+	s := newTestStorage(t)
+	ctx := context.Background()
+	t0 := time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)
+
+	s.AddMetrics(ctx, buildCumulativeSumMetric("m", "svc-boundary", 100, t0))
+	s.AddMetrics(ctx, buildCumulativeSumMetric("m", "svc-boundary", 150, t0.Add(time.Hour)))
+	s.AddMetrics(ctx, buildCumulativeSumMetric("m", "svc-boundary", 225, t0.Add(2*time.Hour)))
+	s.Sync()
+
+	data := exec(t, s, `
+		query($from: Time!, $to: Time!) {
+			metricPoints(serviceName: "svc-boundary", name: "m", from: $from, to: $to) {
+				timestamp value
+			}
+		}
+	`, map[string]any{
+		"from": t0.Add(time.Hour).Format(time.RFC3339),
+		"to":   t0.Add(2 * time.Hour).Format(time.RFC3339),
+	})
+
+	points := data["metricPoints"].([]any)
+	if len(points) != 1 {
+		t.Fatalf("metricPoints len = %d, want only the point exactly at from", len(points))
+	}
+	point := points[0].(map[string]any)
+	if point["timestamp"] != t0.Add(time.Hour).Format(time.RFC3339Nano) || point["value"].(float64) != 50 {
+		t.Fatalf("metricPoints[0] = %+v, want from-boundary point with derived value 50", point)
 	}
 }
 

--- a/internal/storage/query_metric.go
+++ b/internal/storage/query_metric.go
@@ -79,6 +79,12 @@ type DerivedPoint struct {
 // OTLP metric type names, is what keeps them from drifting apart.
 const distributionTypesSQL = `('Histogram', 'ExponentialHistogram', 'Summary')`
 
+// predecessorRequiredSQL identifies source series whose first selected point
+// needs an older observation for lag-based delta derivation. Delta sources,
+// Gauges, and non-monotonic Sums derive entirely from the selected window.
+const predecessorRequiredSQL = `(temporality = 'cumulative' AND (` +
+	`(metric_type = 'Sum' AND is_monotonic) OR metric_type IN ` + distributionTypesSQL + `))`
+
 // IsDistributionType reports whether metricType names one of the
 // distribution shapes (Histogram/ExponentialHistogram/Summary), which carry
 // Count/Sum instead of a plain Value — see DataPoint's schema doc comment
@@ -226,7 +232,7 @@ func (s *Storage) populateMetricSummaryStats(ctx context.Context, items []Metric
 		return nil
 	}
 	values := make([]string, len(items))
-	args := make([]any, 0, len(items)*2+2)
+	args := make([]any, 0, len(items)*2+3)
 	for i := range items {
 		values[i] = "(?, ?)"
 		args = append(args, items[i].ServiceName, items[i].MetricName)
@@ -235,15 +241,32 @@ func (s *Storage) populateMetricSummaryStats(ctx context.Context, items []Metric
 
 	countQuery := `
 WITH selected(service_name, metric_name) AS (VALUES ` + selected + `),
-points AS (
+target_series AS (
+	SELECT s.service_name, s.metric_name, s.series_key, s.metric_type,
+		s.temporality, s.is_monotonic
+	FROM selected x
+	JOIN metric_series s USING (service_name, metric_name)
+), window_points AS (
 	SELECT s.service_name, s.metric_name, s.series_key, s.metric_type,
 		s.temporality, s.is_monotonic, p.ts,
 		coalesce(p.value_double, cast(p.value_int AS DOUBLE)) AS value,
 		cast(p.count AS DOUBLE) AS count
-	FROM selected x
-	JOIN metric_series s USING (service_name, metric_name)
+	FROM target_series s
 	JOIN metric_points p USING (series_key)
 	WHERE p.ts >= make_timestamp_ns(?) AND p.ts < make_timestamp_ns(?)
+), represented_series AS (
+	SELECT DISTINCT series_key FROM window_points
+	WHERE ` + predecessorRequiredSQL + `
+), predecessor_series AS (
+	SELECT DISTINCT p.series_key
+	FROM metric_points p
+	JOIN represented_series r USING (series_key)
+	WHERE p.ts < make_timestamp_ns(?)
+), points AS (
+	SELECT window_points.*,
+		predecessor_series.series_key IS NOT NULL AS has_predecessor
+	FROM window_points
+	LEFT JOIN predecessor_series USING (series_key)
 ), ranked AS (
 	SELECT *, row_number() OVER (PARTITION BY series_key ORDER BY ts) AS point_rank
 	FROM points
@@ -251,15 +274,17 @@ points AS (
 SELECT service_name, metric_name, sum(
 	CASE
 		WHEN metric_type IN ` + distributionTypesSQL + `
-			AND count IS NOT NULL AND (temporality <> 'cumulative' OR point_rank > 1) THEN 1
+			AND count IS NOT NULL
+			AND (temporality <> 'cumulative' OR point_rank > 1 OR has_predecessor) THEN 1
 		WHEN metric_type NOT IN ` + distributionTypesSQL + ` AND value IS NOT NULL
-			AND (metric_type <> 'Sum' OR temporality <> 'cumulative' OR NOT is_monotonic OR point_rank > 1) THEN 1
+			AND (metric_type <> 'Sum' OR temporality <> 'cumulative' OR NOT is_monotonic
+				OR point_rank > 1 OR has_predecessor) THEN 1
 		ELSE 0
 	END
 )
 FROM ranked
 GROUP BY service_name, metric_name`
-	countArgs := append(args, from.UnixNano(), to.UnixNano())
+	countArgs := append(args, from.UnixNano(), to.UnixNano(), from.UnixNano())
 	rows, err := s.DB().QueryContext(ctx, countQuery, countArgs...)
 	if err != nil {
 		return fmt.Errorf("storage: query metric summary point counts: %w", err)
@@ -482,9 +507,9 @@ ORDER BY ts
 
 const metricPointsQuery = metricDerivedCTE + metricPointsSelect
 
-// metricPointsWithPredecessorsQuery adds the immediately preceding point for
-// each series represented in the requested window. Broadcast derivation needs
-// those rows for lag() but must not assume any maximum collection interval.
+// metricPointsWithPredecessorsQuery adds the immediately preceding point only
+// for represented cumulative source series whose delta derivation uses lag().
+// Gauge, delta, and cumulative non-monotonic Sum series stay window-only.
 const metricPointsWithPredecessorsCTE = `
 WITH target_series AS (
 	SELECT series_key, metric_type, temporality, is_monotonic, attributes::VARCHAR AS attrs_json
@@ -504,6 +529,7 @@ window_points AS (
 ),
 represented_series AS (
 	SELECT DISTINCT series_key FROM window_points
+	WHERE ` + predecessorRequiredSQL + `
 ),
 points AS (
 	SELECT * FROM window_points
@@ -550,6 +576,7 @@ window_points AS (
 ),
 represented_series AS (
 	SELECT DISTINCT request_index, series_key FROM window_points
+	WHERE ` + predecessorRequiredSQL + `
 ),
 points AS (
 	SELECT * FROM window_points
@@ -612,7 +639,7 @@ func (s *Storage) MetricPoints(ctx context.Context, serviceName, metricName stri
 }
 
 // MetricPointsWithPredecessors returns the requested points plus at most one
-// older point per series so cumulative values in the window can be derived.
+// older point for each represented cumulative source series that needs lag().
 func (s *Storage) MetricPointsWithPredecessors(ctx context.Context, serviceName, metricName string, from, to time.Time) (points []DerivedPoint, err error) {
 	ctx, span := startStorageSpan(ctx, "storage.MetricPointsWithPredecessors")
 	defer func() { endStorageSpan(span, err) }()

--- a/internal/storage/query_metric_test.go
+++ b/internal/storage/query_metric_test.go
@@ -164,6 +164,54 @@ func TestMetricPoints_DeltaSumAccumulatesToCumulative(t *testing.T) {
 	}
 }
 
+func TestMetricPointsWithPredecessors_DeltaHistogramStartsAtWindow(t *testing.T) {
+	s := openTestStorage(t, Options{})
+	ctx := context.Background()
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	s.AddMetrics(ctx, explicitHistogram("latency", pmetric.AggregationTemporalityDelta, []uint64{1, 1, 0}, 10, 1, 9, t0))
+	s.AddMetrics(ctx, explicitHistogram("latency", pmetric.AggregationTemporalityDelta, []uint64{1, 1, 1}, 30, 1, 21, t0.Add(time.Hour)))
+	s.AddMetrics(ctx, explicitHistogram("latency", pmetric.AggregationTemporalityDelta, []uint64{2, 1, 1}, 50, 1, 25, t0.Add(2*time.Hour)))
+	s.Sync()
+
+	from, to := t0.Add(30*time.Minute), t0.Add(3*time.Hour)
+	assertWindow := func(t *testing.T, points []DerivedPoint) {
+		t.Helper()
+		if len(points) != 2 {
+			t.Fatalf("points len = %d, want 2 window points and no delta predecessor", len(points))
+		}
+		for i, want := range []struct {
+			count, sum float64
+		}{{3, 30}, {7, 80}} {
+			if points[i].CountCumulative == nil || *points[i].CountCumulative != want.count ||
+				points[i].SumCumulative == nil || *points[i].SumCumulative != want.sum {
+				t.Errorf("point %d cumulative = count %v sum %v, want count %v sum %v",
+					i, points[i].CountCumulative, points[i].SumCumulative, want.count, want.sum)
+			}
+		}
+	}
+
+	t.Run("single", func(t *testing.T) {
+		points, err := s.MetricPointsWithPredecessors(ctx, "svc", "latency", from, to)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertWindow(t, points)
+	})
+	t.Run("batch", func(t *testing.T) {
+		batches, err := s.MetricPointsWithPredecessorsBatch(ctx, []MetricPointWindow{{
+			ServiceName: "svc", MetricName: "latency", From: from, To: to,
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(batches) != 1 {
+			t.Fatalf("batches len = %d, want 1", len(batches))
+		}
+		assertWindow(t, batches[0])
+	})
+}
+
 func TestMetricPoints_GaugePassthrough(t *testing.T) {
 	s := openTestStorage(t, Options{})
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fix two metric query correctness issues:

1. Metric.pointCount could undercount a historical window when the first in-window cumulative point had a predecessor before from, causing it to disagree with dataPoints.
2. Cumulative fields derived from delta-temporality input included an unnecessary predecessor instead of starting at the selected GraphQL window.

## Implementation

- Make the page-wide point-count query track predecessor availability per represented cumulative source series while retaining constant page-wide query behavior.
- Load predecessors only for cumulative monotonic Sum and cumulative distribution series that require lag-based derivation.
- Keep Gauge, delta-temporality, and cumulative non-monotonic Sum series restricted to window_points, so delta cumulative values naturally start at from.
- Apply the same predecessor-selection rule to the single and batch query paths shared by GraphQL, aggregate queries, and broadcast derivation.
- Update the GraphQL schema and DuckDB storage design documentation to describe the corrected semantics.

## Regression coverage

- Historical cumulative pointCount matches dataPoints.
- Multiple attribute series where only one series has a predecessor.
- Delta Sum cumulative values start at the query window.
- Delta Histogram countCumulative and sumCumulative start at the query window in both single and batch paths.
- from is inclusive and to is exclusive.

## Validation

- mise run check
- mise run test