### PR TITLE
fix(cli): remove unsolicited docs promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,6 @@ otelop docs list       # list documentation bundled with this binary (--json for
 otelop docs show <name> # print one document as Markdown
 ```
 
-The bundled documentation always matches the installed otelop version. This is
-also the preferred entry point for coding agents: run `otelop docs list --json`,
-then `otelop docs show <name>` for the relevant topic.
-
 `start` flags:
 
 ```

--- a/cmd/otelop/docs.go
+++ b/cmd/otelop/docs.go
@@ -11,8 +11,6 @@ import (
 	otelopdocs "github.com/mashiro/otelop/docs"
 )
 
-const docsHint = "Run `otelop docs list` to list the bundled documentation and `otelop docs show <name>` to read a topic. Add `--json` to the list command for machine-readable output."
-
 func docsCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "docs",
@@ -54,21 +52,11 @@ func runDocsList(_ context.Context, cmd *cli.Command) error {
 				return err
 			}
 		}
-		if _, err := fmt.Fprintln(writer, "\nRun `otelop docs show <name>` to read a document."); err != nil {
-			return err
-		}
 		return writer.Flush()
-	}
-	output := struct {
-		Results []otelopdocs.Document `json:"results"`
-		Help    string                `json:"help"`
-	}{
-		Results: documents,
-		Help:    "Run `otelop docs show {name}` to read a document.",
 	}
 	encoder := json.NewEncoder(cmd.Writer)
 	encoder.SetIndent("", "  ")
-	return encoder.Encode(output)
+	return encoder.Encode(documents)
 }
 
 func runDocsShow(_ context.Context, cmd *cli.Command) error {

--- a/cmd/otelop/docs_test.go
+++ b/cmd/otelop/docs_test.go
@@ -17,10 +17,13 @@ func TestDocsListCommand(t *testing.T) {
 	if err := command.Run(context.Background(), []string{"list"}); err != nil {
 		t.Fatalf("run docs list: %v", err)
 	}
-	for _, want := range []string{"configuration", "getting-started", "docs show <name>"} {
+	for _, want := range []string{"configuration", "getting-started"} {
 		if !strings.Contains(output.String(), want) {
 			t.Errorf("plain-text output missing %q:\n%s", want, output.String())
 		}
+	}
+	if strings.Contains(output.String(), "docs show") {
+		t.Errorf("plain-text output contains redundant usage hint:\n%s", output.String())
 	}
 	if json.Valid(output.Bytes()) {
 		t.Fatalf("default output is JSON, want plain text:\n%s", output.String())
@@ -34,14 +37,11 @@ func TestDocsListCommandJSON(t *testing.T) {
 	if err := command.Run(context.Background(), []string{"list", "--json"}); err != nil {
 		t.Fatalf("run docs list --json: %v", err)
 	}
-	var result struct {
-		Results []otelopdocs.Document `json:"results"`
-		Help    string                `json:"help"`
-	}
+	var result []otelopdocs.Document
 	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
 		t.Fatalf("decode output: %v\n%s", err, output.String())
 	}
-	if len(result.Results) == 0 || !strings.Contains(result.Help, "docs show") {
+	if len(result) == 0 {
 		t.Fatalf("unexpected output: %#v", result)
 	}
 }

--- a/cmd/otelop/main.go
+++ b/cmd/otelop/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -12,20 +11,17 @@ import (
 var version = "dev"
 
 func main() {
-	cli.VersionPrinter = printVersionWithDocsHint
 	if err := newApp(version).Run(context.Background(), os.Args); err != nil {
 		slog.Error("fatal", "error", err)
-		slog.Info(docsHint)
 		os.Exit(1)
 	}
 }
 
 func newApp(version string) *cli.Command {
 	return &cli.Command{
-		Name:        "otelop",
-		Usage:       "Browser-based OpenTelemetry viewer",
-		Version:     version,
-		Description: docsHint,
+		Name:    "otelop",
+		Usage:   "Browser-based OpenTelemetry viewer",
+		Version: version,
 		Commands: []*cli.Command{
 			startCommand(version),
 			restartCommand(version),
@@ -37,9 +33,4 @@ func newApp(version string) *cli.Command {
 			docsCommand(),
 		},
 	}
-}
-
-func printVersionWithDocsHint(cmd *cli.Command) {
-	_, _ = fmt.Fprintf(cmd.Root().Writer, "%s version %s\n", cmd.Name, cmd.Version)
-	_, _ = fmt.Fprintln(cmd.Root().ErrWriter, docsHint)
 }

--- a/cmd/otelop/version.go
+++ b/cmd/otelop/version.go
@@ -12,10 +12,7 @@ func versionCommand(version string) *cli.Command {
 		Name:  "version",
 		Usage: "Print version",
 		Action: func(_ context.Context, cmd *cli.Command) error {
-			if _, err := fmt.Fprintln(cmd.Writer, version); err != nil {
-				return err
-			}
-			_, err := fmt.Fprintln(cmd.ErrWriter, docsHint)
+			_, err := fmt.Fprintln(cmd.Writer, version)
 			return err
 		},
 	}

--- a/cmd/otelop/version_test.go
+++ b/cmd/otelop/version_test.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"strings"
 	"testing"
-
-	"github.com/urfave/cli/v3"
 )
 
 func TestVersionCommandKeepsStdoutMachineReadable(t *testing.T) {
@@ -15,16 +12,12 @@ func TestVersionCommandKeepsStdoutMachineReadable(t *testing.T) {
 	if stdout != "test-version\n" {
 		t.Errorf("stdout = %q, want one version line", stdout)
 	}
-	if !strings.Contains(stderr, "docs list") {
-		t.Errorf("stderr missing docs hint: %q", stderr)
+	if stderr != "" {
+		t.Errorf("stderr = %q, want no output", stderr)
 	}
 }
 
 func TestVersionFlagKeepsStdoutMachineReadable(t *testing.T) {
-	oldPrinter := cli.VersionPrinter
-	cli.VersionPrinter = printVersionWithDocsHint
-	t.Cleanup(func() { cli.VersionPrinter = oldPrinter })
-
 	stdout, stderr, err := runTestApp("--version")
 	if err != nil {
 		t.Fatalf("run --version: %v", err)
@@ -32,7 +25,7 @@ func TestVersionFlagKeepsStdoutMachineReadable(t *testing.T) {
 	if stdout != "otelop version test-version\n" {
 		t.Errorf("stdout = %q, want one version line", stdout)
 	}
-	if !strings.Contains(stderr, "docs list") {
-		t.Errorf("stderr missing docs hint: %q", stderr)
+	if stderr != "" {
+		t.Errorf("stderr = %q, want no output", stderr)
 	}
 }


### PR DESCRIPTION
## Summary

- keep version and error output focused on the requested command result
- remove redundant usage hints from docs list output
- return a plain document array from docs list --json
- remove the promotional README paragraph

## Testing

- mise run check
- mise run test