### PR TITLE
fix(deps): preserve monorepo grouping precedence

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,9 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    // Preset order is significant: keep the catch-all before best-practices so
+    // its known-monorepo groups override the generic non-major group.
+    "group:allNonMajor",
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver",
-    "group:allNonMajor",
     ":pinAllExceptPeerDependencies",
     ":separateMultipleMajorReleases",
     ":disableRateLimiting",


### PR DESCRIPTION
## Summary

- apply the generic non-major grouping before config:best-practices
- let the best-practices monorepo rules override the catch-all group
- keep the explicit OpenTelemetry Collector grouping from #239

This prevents OpenTelemetry Go monorepo updates from falling into the all non-major PR, as happened in #240.

## Verification

- Renovate config validator
- mise run check
- mise run test