### PR TITLE
fix(deps): update OpenTelemetry compatibility set

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -43,10 +43,6 @@
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",
     },
-    // Renovate disables indirect Go module updates by default. Re-enable only
-    // the OpenTelemetry modules whose APIs must stay compatible with the direct
-    // SDK dependencies. Keep this separate from the grouping rule below: adding
-    // matchDepTypes there would exclude direct dependencies from the group.
     {
       "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],
@@ -55,11 +51,10 @@
         "go.opentelemetry.io/otel/**",
         "go.opentelemetry.io/contrib/**",
       ],
+      // Renovate disables indirect Go module updates by default. Re-enable only
+      // the OpenTelemetry modules that must remain compatible with the direct SDK.
       "enabled": true,
     },
-    // This rule matches both direct and indirect OpenTelemetry Go modules. For
-    // indirect modules it merges with the rule above, so they are both enabled
-    // and placed in the same PR as the direct SDK and contrib updates.
     {
       "matchManagers": ["gomod"],
       "matchPackageNames": [
@@ -67,6 +62,8 @@
         "go.opentelemetry.io/otel/**",
         "go.opentelemetry.io/contrib/**",
       ],
+      // Keep matchDepTypes out of this rule so direct and indirect modules share
+      // one PR. Indirect matches also merge with enabled: true from the rule above.
       "groupName": "opentelemetry-go",
     },
     // Collector's paired 1.x/0.x modules aren't covered by Renovate's known

--- a/renovate.json5
+++ b/renovate.json5
@@ -43,6 +43,29 @@
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",
     },
+    // The Go SDK and contrib release trains share the same logging API. Include
+    // their indirect modules so packages such as otelconf and otlploghttp don't
+    // remain on the previous API version, then update the compatibility set in
+    // one PR instead of the two default monorepo groups.
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "matchPackageNames": [
+        "go.opentelemetry.io/otel",
+        "go.opentelemetry.io/otel/**",
+        "go.opentelemetry.io/contrib/**",
+      ],
+      "enabled": true,
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "go.opentelemetry.io/otel",
+        "go.opentelemetry.io/otel/**",
+        "go.opentelemetry.io/contrib/**",
+      ],
+      "groupName": "opentelemetry-go",
+    },
     // Collector's paired 1.x/0.x modules aren't covered by Renovate's known
     // monorepos, so keep them together without coupling them to the Go SDK and
     // contrib release trains.

--- a/renovate.json5
+++ b/renovate.json5
@@ -43,10 +43,10 @@
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",
     },
-    // The Go SDK and contrib release trains share the same logging API. Include
-    // their indirect modules so packages such as otelconf and otlploghttp don't
-    // remain on the previous API version, then update the compatibility set in
-    // one PR instead of the two default monorepo groups.
+    // Renovate disables indirect Go module updates by default. Re-enable only
+    // the OpenTelemetry modules whose APIs must stay compatible with the direct
+    // SDK dependencies. Keep this separate from the grouping rule below: adding
+    // matchDepTypes there would exclude direct dependencies from the group.
     {
       "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],
@@ -57,6 +57,9 @@
       ],
       "enabled": true,
     },
+    // This rule matches both direct and indirect OpenTelemetry Go modules. For
+    // indirect modules it merges with the rule above, so they are both enabled
+    // and placed in the same PR as the direct SDK and contrib updates.
     {
       "matchManagers": ["gomod"],
       "matchPackageNames": [


### PR DESCRIPTION
## Summary

- enable Renovate updates for indirect OpenTelemetry Go SDK and contrib modules
- group the Go SDK and contrib modules into one compatibility update
- keep the OpenTelemetry Collector release train in its separate lockstep group

Renovate disables indirect Go module updates by default. This left modules such as otelconf, otlploghttp, and sdk/log/logtest on the previous experimental Logs API and caused #240, #243, and #244 to fail.

## Verification

- Renovate config validator
- mise run check
- mise run test
- updated all matching direct and indirect modules in a temporary copy and ran go test ./... successfully with the current Collector version