### PR TITLE
fix(deps): restore non-major grouping precedence

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,11 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    // Preset order is significant: keep the catch-all before best-practices so
-    // its known-monorepo groups override the generic non-major group.
-    "group:allNonMajor",
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver",
+    // Keep this after best-practices so its monorepo rules collapse into one
+    // non-major PR. Repository-specific packageRules below override this group.
+    "group:allNonMajor",
     ":pinAllExceptPeerDependencies",
     ":separateMultipleMajorReleases",
     ":disableRateLimiting",


### PR DESCRIPTION
## Summary

- restore `group:allNonMajor` to its original position after `config:best-practices`
- keep standard monorepo updates collapsed into the catch-all non-major PR
- preserve repository-specific groups such as OpenTelemetry, Collector, vite-plus, and GitHub Actions through the later `packageRules`

## Verification

- `renovate-config-validator --strict renovate.json5`
- `mise run check`
- `mise run test` (35 files, 498 frontend tests; backend tests passed)