### PR TITLE
chore(deps): migrate Vite+ pnpm overrides

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -6,12 +6,15 @@ settings:
 
 catalogs:
   default:
+    vite:
+      specifier: npm:@voidzero-dev/vite-plus-core@0.3.0
+      version: 0.3.0
     vite-plus:
       specifier: 0.3.0
       version: 0.3.0
 
 overrides:
-  vite: npm:@voidzero-dev/vite-plus-core@0.3.0
+  vite@*: npm:@voidzero-dev/vite-plus-core@0.3.0
 
 importers:
 
@@ -139,7 +142,7 @@ importers:
         specifier: 7.0.2
         version: 7.0.2
       vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@0.3.0
+        specifier: 'catalog:'
         version: '@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)'
       vite-plus:
         specifier: 'catalog:'

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@0.3.0
   vite-plus: 0.3.0
 overrides:
-  vite: "catalog:"
+  vite@*: "catalog:"
 peerDependencyRules:
   allowAny:
     - vite


### PR DESCRIPTION
## Summary
- migrate the pnpm Vite override to the explicit `vite@*` selector
- preserve the Vite core alias through the workspace catalog
- refresh the lockfile with Vite+ 0.3.0 migration output

## Verification
- `mise run check`
- `mise run test`
- `mise run build`