### PR TITLE
chore(deps): enable Go directive updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A local OpenTelemetry viewer for traces, metrics, and logs.
 Single binary, persistent local storage, browser UI.
 
-[![Go](https://img.shields.io/badge/go-1.26-00ADD8?logo=go&logoColor=white)](go.mod)
+[![Go](https://img.shields.io/badge/go-1.27-00ADD8?logo=go&logoColor=white)](go.mod)
 [![React](https://img.shields.io/badge/react-19-61DAFB?logo=react&logoColor=white)](frontend/package.json)
 [![License](https://img.shields.io/badge/license-MIT-black)](LICENSE)
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -37,6 +37,14 @@
       "matchUpdateTypes": ["pinDigest", "digest"],
       "minimumReleaseAge": null,
     },
+    // The go directive is a minimum supported version, so Renovate leaves it
+    // unchanged by default. Keep it current along with the project toolchain.
+    {
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchDepTypes": ["golang"],
+      "rangeStrategy": "bump",
+    },
     // Split GitHub Actions out of the catch-all group so workflow bumps land
     // independently and aren't blocked by an unrelated failing dependency.
     {


### PR DESCRIPTION
## Summary

- Enable Renovate to update the `go` directive when a newer Go release is available.
- Update the README Go badge from 1.26 to 1.27 to match the development toolchain.

The Renovate rule is scoped to the `gomod` manager's `golang` dependency type and uses `rangeStrategy: bump`. A Renovate 44.49.0 dry run detected the expected 1.26.2 to 1.27.0 update.

## Validation

- Renovate configuration validation
- `mise run check`
- `mise run test` (35 frontend test files, 498 tests; all backend packages passed)
